### PR TITLE
chore: Add nuxt-studio plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -957,6 +957,15 @@
     }
 ,
     {
+      "name": "nuxt-studio",
+      "source": "./plugins/nuxt-studio",
+      "version": "1.0.0",
+      "description": "Visual CMS for Nuxt Content with Cloudflare deployment. Use when setting up Nuxt Studio, configuring OAuth authentication, deploying to Cloudflare Pages/Workers with subdomain routing, or troubleshooting Studio integration.",
+      "keywords": ["nuxt","nuxt-studio","nuxt-content","cms","visual-editor","cloudflare","cloudflare-pages","cloudflare-workers","oauth","github-auth","gitlab-auth","google-auth","subdomain","content-management","tiptap","monaco","deployment"],
+      "category": "frontend"
+    }
+,
+    {
       "name": "nuxt-ui-v4",
       "source": "./plugins/nuxt-ui-v4",
       "version": "3.0.0",


### PR DESCRIPTION
## Summary
- Adds nuxt-studio plugin to marketplace.json
- Plugin version: 1.0.0
- Category: frontend
- Total plugins in marketplace: 170

## Context
This PR adds the newly created nuxt-studio plugin to the official marketplace, making it available for installation via:
```
/plugin install nuxt-studio@claude-skills
```

## Testing
- ✅ Verified plugin exists in marketplace.json
- ✅ All 170 plugins successfully synced
- ✅ JSON validation passed

## Related
- Parent feature branch: feat/nuxt-studio-plugin (contains plugin implementation and fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New nuxt-studio plugin now available, providing a visual CMS for Nuxt Content projects with full Cloudflare deployment support (Pages and Workers), OAuth authentication options, and advanced content management features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->