### PR TITLE
fix: Update bun plugin hooks.json to match current schema

### DIFF
--- a/plugins/bun/hooks/hooks.json
+++ b/plugins/bun/hooks/hooks.json
@@ -1,26 +1,29 @@
 {
-  "PreToolUse": [
-    {
-      "matcher": "Bash",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-bun-command.sh",
-          "timeout": 5
-        }
-      ]
-    }
-  ],
-  "PostToolUse": [
-    {
-      "matcher": "Bash",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/bun-suggestions.sh",
-          "timeout": 5
-        }
-      ]
-    }
-  ]
+  "description": "Validates bun command usage and provides suggestions",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-bun-command.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/bun-suggestions.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Fixed hooks.json schema validation error in bun plugin
- Wrapped PreToolUse and PostToolUse events in top-level 'hooks' object
- Added description field for better documentation

## Problem
The bun plugin's hooks.json was using an outdated schema format that caused validation errors:
```
Failed to load hooks from .../bun/1.0.0/hooks/hooks.json
Expected: object at path ["hooks"]
Received: undefined
```

## Solution
Updated hooks.json to match the current schema standard used by other plugins (e.g., nuxt-seo):
- Added top-level `"hooks"` wrapper object (required by schema)
- Added `"description"` field for documentation
- Moved hook events (PreToolUse, PostToolUse) inside the `hooks` object

## Validation
✅ JSON syntax valid (jq validation passed)
✅ Schema structure correct (top-level `hooks` object present)
✅ Hook events present (PreToolUse and PostToolUse inside `hooks`)
✅ Matches working pattern (identical structure to nuxt-seo plugin)

## Test plan
- [x] Validate JSON syntax with jq
- [x] Verify hooks.json structure matches schema
- [x] Compare with working nuxt-seo plugin structure
- [ ] Load plugin in Claude Code and verify no validation errors
- [ ] Test PreToolUse hook executes before bash commands
- [ ] Test PostToolUse hook executes after bash commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured internal plugin configuration to improve organization and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->