### PR TITLE
fix(plan-interview): Prevent hook from blocking non-plan file writes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1094,7 +1094,7 @@
     {
       "name": "plan-interview",
       "source": "./plugins/plan-interview",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "description": "Adaptive interview-driven spec generation with quality review. Automatically adjusts depth based on plan complexity.",
       "keywords": ["plan-interview","specification","planning","interview","requirements","spec-generation","spec-review","quality","project-planning","adaptive","stakeholder-analysis","risk-assessment"],
       "category": "tooling"

--- a/plugins/plan-interview/.claude-plugin/plugin.json
+++ b/plugins/plan-interview/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-interview",
   "description": "Adaptive interview-driven spec generation with quality review. Automatically adjusts depth based on plan complexity.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/plan-interview/hooks/hooks.json
+++ b/plugins/plan-interview/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Check if the file just written matches *plan*.md or *-plan.md pattern (but NOT *-spec.md). If it appears to be a project/feature plan document, suggest: 'This looks like a plan file. Would you like me to run `/plan-interview:interview [filepath]` to generate a detailed specification through an interview process?' Be contextually aware - only suggest once per file, and don't suggest if user is clearly doing something else.",
+            "prompt": "After a Write operation, silently check if the written file matches the pattern *plan*.md or *-plan.md (excluding *-spec.md). ONLY if the file matches this pattern AND appears to be a project/feature plan document, offer this suggestion: 'This looks like a plan file. Would you like me to run `/plan-interview:interview [filepath]` to generate a detailed specification through an interview process?' IMPORTANT: If the file does NOT match the pattern, or if the user is clearly doing something else, do nothing and allow normal execution to continue. This hook should NEVER block file writes. Only suggest once per plan file.",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
Fixed the plan-interview plugin's PostToolUse:Write hook that was incorrectly blocking writes to non-plan markdown files like README.md.

The hook now silently ignores non-matching files and only suggests the interview command for actual plan files (*plan*.md or *-plan.md).

Changes:
- Updated hook prompt with explicit non-blocking language
- Bumped plugin version to v2.0.1
- Regenerated marketplace.json

Fixes blocking error: 'File does not match *plan*.md or *-plan.md pattern'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - plan-interview v2.0.1

* **New Features**
  * Enhanced plan file recognition with more intelligent pattern matching capabilities

* **Bug Fixes**
  * Improved accuracy and reliability of automated plan file suggestions
  * Ensured non-blocking file write operations
  * Optimized suggestion frequency for a smoother user experience

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->