### PR TITLE
Add Bun native runner support to mutation-testing skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1941,15 +1941,18 @@
     {
       "name": "mutation-testing",
       "source": "./plugins/mutation-testing",
-      "version": "3.0.0",
-      "description": "Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.",
+      "version": "3.0.1",
+      "description": "Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript with Vitest or bun test via @hughescr/stryker-bun-runner) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.",
       "keywords": [
         "mutation-testing",
         "mutation",
         "testing",
         "tests",
         "unit-tests",
-        "quality"
+        "quality",
+        "stryker-bun-runner",
+        "bun-test",
+        "bun-runner"
       ],
       "category": "testing"
     },

--- a/plugins/mutation-testing/.claude-plugin/plugin.json
+++ b/plugins/mutation-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mutation-testing",
   "description": "Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"
@@ -14,6 +14,9 @@
     "testing",
     "tests",
     "unit-tests",
-    "quality"
+    "quality",
+    "stryker-bun-runner",
+    "bun-test",
+    "bun-runner"
   ]
 }

--- a/plugins/mutation-testing/README.md
+++ b/plugins/mutation-testing/README.md
@@ -24,6 +24,8 @@ Expert guidance for mutation testing - finding weak tests by introducing deliber
 ## Tools Supported
 
 - **Stryker** (TypeScript/JavaScript)
+  - Vitest runner (`@stryker-mutator/vitest-runner`)
+  - Bun native runner (`@hughescr/stryker-bun-runner`) — for `bun test` projects
 - **mutmut** (Python)
 
 ## Quick Start
@@ -47,6 +49,8 @@ uv run mutmut results
 - mutmut
 - test validation
 - code mutations
+- stryker-bun-runner
+- bun test mutation
 
 ## Source
 

--- a/plugins/mutation-testing/skills/mutation-testing/SKILL.md
+++ b/plugins/mutation-testing/skills/mutation-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mutation-testing
-description: Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.
+description: Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript with Vitest or bun test via @hughescr/stryker-bun-runner) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TodoWrite
 ---
 
@@ -17,7 +17,9 @@ Expert knowledge for mutation testing - validating that your tests actually catc
 
 ## TypeScript/JavaScript (Stryker)
 
-### Installation
+### Vitest Runner
+
+#### Installation
 
 ```bash
 # Using Bun
@@ -27,7 +29,7 @@ bun add -d @stryker-mutator/core @stryker-mutator/vitest-runner
 npm install -D @stryker-mutator/core @stryker-mutator/vitest-runner
 ```
 
-### Configuration
+#### Configuration
 
 ```typescript
 // stryker.config.mjs
@@ -41,6 +43,47 @@ export default {
   incremental: true,
 }
 ```
+
+### Bun Native Runner (`bun test`)
+
+Use when projects use `bun test` directly (not Vitest).
+
+#### Requirements
+
+- Bun **>= 1.3.7** (needs TestReporter WebSocket events from Bun PR #25986)
+- `@stryker-mutator/core ^9.0.0`
+
+#### Installation
+
+```bash
+bun add -D @hughescr/stryker-bun-runner @stryker-mutator/core
+```
+
+#### Configuration
+
+```javascript
+// stryker.conf.mjs
+export default {
+  testRunner: 'bun',
+  coverageAnalysis: 'perTest',
+  mutate: ['src/**/*.ts', '!src/**/*.test.ts'],
+  thresholds: { high: 80, low: 60, break: 60 },
+  incremental: true,
+  bun: {
+    inspectorTimeout: 5000,  // WebSocket Inspector connection timeout (ms)
+    // bunPath: '/path/to/bun',  // only if custom Bun install
+    // timeout: 30000,           // test timeout (ms)
+    // env: { DEBUG: 'true' },
+    // bunArgs: ['--bail'],
+  },
+}
+```
+
+#### Key Behaviors
+
+- **Sequential execution**: Runs tests with `--concurrency=1` for accurate per-test coverage. Slower than parallel but required for correct test-to-mutant correlation.
+- **Concurrent test patching**: Automatically patches `describe.concurrent()`, `test.concurrent()`, `it.concurrent()` to run sequentially during mutation testing — no code changes needed.
+- **Inspector Protocol**: Uses Bun's WebSocket Inspector API to discover tests and correlate coverage.
 
 ### Running Stryker
 

--- a/plugins/mutation-testing/skills/mutation-testing/SKILL.md
+++ b/plugins/mutation-testing/skills/mutation-testing/SKILL.md
@@ -2,6 +2,7 @@
 name: mutation-testing
 description: Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript with Vitest or bun test via @hughescr/stryker-bun-runner) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TodoWrite
+license: MIT
 ---
 
 # Mutation Testing


### PR DESCRIPTION
## Summary

- Adds **Bun Native Runner** subsection to the mutation-testing skill for projects using `bun test` directly (not Vitest)
- Documents `@hughescr/stryker-bun-runner` with requirements (Bun >=1.3.7), installation, config options, and key behaviors (sequential execution, concurrent test patching, Inspector Protocol)
- Renames existing Stryker section to "Vitest Runner" for clarity
- Updates description, keywords (`stryker-bun-runner`, `bun-test`, `bun-runner`), and version bump 3.0.0 → 3.0.1 in `plugin.json` and `marketplace.json`

## Test plan

- [ ] Install skill and verify both Vitest Runner and Bun Native Runner sections are visible
- [ ] Confirm `marketplace.json` entry reflects new version, description, and keywords
- [ ] Verify `plugin.json` is valid (JSON schema passes — confirmed by pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Vitest runner and Bun native runner support for TypeScript/JavaScript mutation testing projects; package version bumped.

* **Documentation**
  * Expanded docs with Vitest and Bun-specific setup, installation, configuration examples, auto-trigger keywords, and notes on Bun behavior (execution and configuration guidance).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->