### PR TITLE
Update better-auth skill to v1.6.0 (D1 native, Electron, i18n, OpenTelemetry, SSO)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Production-tested skills for Claude Code - Cloudflare, AI, React, Tailwind v4, and modern web development",
-    "version": "3.0.0",
+    "version": "3.2.2",
     "homepage": "https://github.com/secondsky/claude-skills"
   },
   "plugins": [
@@ -221,7 +221,7 @@
     {
       "name": "better-auth",
       "source": "./plugins/better-auth",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "description": "Skill for integrating Better Auth - comprehensive TypeScript authentication framework for Cloudflare D1, Next.js, Nuxt, and 15+ frameworks. Use when adding auth, encountering D1 adapter errors, or implementing OAuth/2FA/RBAC features.",
       "keywords": ["better-auth","better","auth","authentication","authorization","login","security","session","rbac"],
       "category": "auth"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.2.2] - 2026-04-08
+
+### Changed
+
+#### better-auth Plugin (v3.1.0) - 2026-04-08
+
+Updated from better-auth@1.4.9 to better-auth@1.6.0 with v1.5 and v1.6 support.
+
+**New reference files (6):**
+- `references/v1.5-features.md` - New CLI, MCP auth, OAuth 2.1 Provider, Electron, i18n, D1 native, secret rotation, seat billing, adapter extraction, typed error codes
+- `references/v1.6-features.md` - OpenTelemetry, passkey pre-auth, case-insensitive queries, non-blocking scrypt, release tracks
+- `references/migration-guide-1.5.0.md` - v1.5 breaking changes: API Key moved, after hooks post-transaction, InferUser removed, core/utils split
+- `references/plugins/test-utils.md` - Testing helpers: factories, DB helpers, auth helpers, OTP capture, Vitest/Playwright examples
+- `references/plugins/sso.md` - Production SSO: OIDC discovery, SAML SLO, domain verification, organization provisioning, security hardening
+- `references/integrations/electron.md` - Electron desktop auth: system browser OAuth, IPC bridges, deep links, manual token exchange
+
+**Updated reference files (5):**
+- `references/v1.4-features.md` - Fixed OAuth 2.1 plugin (was wrong package), SSO imports to `@better-auth/sso`, CLI commands to `npx auth`, SSO config structure
+- `references/plugins/authentication.md` - Updated passkey to `@better-auth/passkey`, added pre-auth registration (v1.6), WebAuthn extensions
+- `references/plugins/enterprise.md` - Updated SSO to `@better-auth/sso`, added SAML SLO, InResponseTo default ON, points to dedicated sso.md
+- `references/plugins/api-tokens.md` - Updated to `@better-auth/api-key`, added org-owned API keys, multi-configuration support
+- `references/configuration-guide.md` - Added dynamic base URL, secret key rotation, D1 native, `better-auth/minimal`, defer session refresh, verification on secondary storage
+
+**SKILL.md updates:**
+- Bumped package_version from 1.4.9 to 1.6.0, skill version to 3.1.0
+- Added v1.5 and v1.6 breaking changes and feature highlights
+- Added D1 native support (pass D1 binding directly, no adapter needed)
+- Updated CLI commands to `npx auth` syntax throughout
+- Added 6 new "When to Load References" entries
+- Updated dependencies with new packages (`@better-auth/sso`, `@better-auth/electron`, `@better-auth/i18n`, `@better-auth/oauth-provider`)
+
+Category: auth
+
+---
+
 ## [3.2.1] - 2026-04-01
 
 ### Added

--- a/PACKAGE_VERSION_AUDIT.md
+++ b/PACKAGE_VERSION_AUDIT.md
@@ -1,0 +1,572 @@
+# Package Version Audit Report
+
+**Date**: 2026-04-08
+**Scope**: All 33 `package.json` files across the repository
+**Status**: 28 files need updates, 5 files OK, 3 broken version pins
+
+---
+
+## Critical Issues (Non-Existent Versions — BROKEN)
+
+These packages reference versions that do not exist on npm and will fail to install.
+
+| # | File | Package | Pinned | Actual Latest | Fix |
+|---|---|---|---|---|---|
+| 1 | `plugins/openai-responses/.../package.json` | `@cloudflare/workers-types` | `^5.0.0` | `4.20260408.1` | Change to `^4.20260408.0` |
+| 2 | `plugins/thesys-generative-ui/.../nextjs/package.json` | `@tavily/core` | `^1.0.0` | `0.7.2` | Change to `^0.7.2` |
+| 3 | `plugins/thesys-generative-ui/.../vite_react/package.json` | `@tavily/core` | `^1.0.0` | `0.7.2` | Change to `^0.7.2` |
+
+---
+
+## Per-File Audit
+
+### 1. `plugins/ai-sdk-core/skills/ai-sdk-core/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `ai` | ^5.0.116 | 6.0.153 | **MAJOR** | Decision needed |
+| `@ai-sdk/openai` | ^2.0.88 | 3.0.52 | **MAJOR** | Decision needed |
+| `@ai-sdk/anthropic` | ^2.0.56 | 3.0.68 | **MAJOR** | Decision needed |
+| `@ai-sdk/google` | ^2.0.51 | 3.0.60 | **MAJOR** | Decision needed |
+| `workers-ai-provider` | ^2.0.0 | 3.1.10 | **MAJOR** | Decision needed |
+| `zod` | ^3.23.8 | 4.3.6 | **MAJOR** | Decision needed |
+| `@types/node` | ^20.11.0 | 25.5.2 | **MAJOR** | Decision needed |
+| `typescript` | ^5.9.3 | 6.0.2 | **MAJOR** | Decision needed |
+| `tsx` | ^4.7.0 | 4.21.0 | MINOR | Update |
+
+---
+
+### 2. `plugins/ai-sdk-ui/skills/ai-sdk-ui/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `ai` | ^5.0.116 | 6.0.153 | **MAJOR** | Decision needed |
+| `@ai-sdk/openai` | ^2.0.88 | 3.0.52 | **MAJOR** | Decision needed |
+| `@ai-sdk/anthropic` | ^2.0.56 | 3.0.68 | **MAJOR** | Decision needed |
+| `@ai-sdk/google` | ^2.0.51 | 3.0.60 | **MAJOR** | Decision needed |
+| `react` | ^18.2.0 | 19.2.4 | **MAJOR** | Decision needed |
+| `react-dom` | ^18.2.0 | 19.2.4 | **MAJOR** | Decision needed |
+| `next` | ^16.1.5 | 16.2.2 | MINOR | Update |
+| `zod` | ^3.23.8 | 4.3.6 | **MAJOR** | Decision needed |
+| `workers-ai-provider` | ^2.0.0 | 3.1.10 | **MAJOR** | Decision needed |
+| `isomorphic-dompurify` | ^2.16.0 | 3.7.1 | **MAJOR** | Decision needed |
+| `react-markdown` | ^9.0.0 | 10.1.0 | **MAJOR** | Decision needed |
+| `react-syntax-highlighter` | ^15.5.0 | 16.1.1 | **MAJOR** | Decision needed |
+| `@types/react` | ^18.2.0 | 19.2.14 | **MAJOR** | Decision needed |
+| `@types/react-dom` | ^18.2.0 | 19.2.3 | **MAJOR** | Decision needed |
+| `@types/node` | ^20.0.0 | 25.5.2 | **MAJOR** | Decision needed |
+| `typescript` | ^5.9.3 | 6.0.2 | **MAJOR** | Decision needed |
+| `eslint` | ^9.39.2 | 10.2.0 | **MAJOR** | Decision needed |
+| `@eslint/js` | ^9.39.2 | 10.0.1 | **MAJOR** | Decision needed |
+| `eslint-config-next` | ^15.0.0 | 16.2.2 | **MAJOR** | Decision needed |
+
+---
+
+### 3. `plugins/claude-api/skills/claude-api/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `@anthropic-ai/sdk` | ^0.67.0 | 0.85.0 | MINOR | Update |
+| `eslint` | ^8.50.0 | 10.2.0 | **MAJOR** | Decision needed |
+| `@typescript-eslint/eslint-plugin` | ^6.0.0 | 8.58.1 | **MAJOR** | Decision needed |
+| `@typescript-eslint/parser` | ^6.0.0 | 8.58.1 | **MAJOR** | Decision needed |
+| `typescript` | ^5.3.0 | 6.0.2 | **MAJOR** | Decision needed |
+| `vitest` | ^1.0.0 | 4.1.3 | **MAJOR** | Decision needed |
+| `prettier` | ^3.0.3 | 3.8.1 | MINOR | Update |
+| `dotenv` | ^16.3.1 | 17.4.1 | **MAJOR** | Decision needed |
+| `zod` | ^3.23.0 | 4.3.6 | **MAJOR** | Decision needed |
+| `@upstash/redis` | ^1.25.0 | 2.0.8 | **MAJOR** | Decision needed |
+| `@types/node` | ^20.0.0 | 25.5.2 | **MAJOR** | Decision needed |
+| `tsx` | ^4.0.0 | 4.21.0 | MINOR | Update |
+
+---
+
+### 4. `plugins/claude-agent-sdk/skills/claude-agent-sdk/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `@anthropic-ai/claude-agent-sdk` | ^0.1.0 | 0.2.96 | MINOR | Update |
+| `zod` | ^3.23.0 | 4.3.6 | **MAJOR** | Decision needed |
+| `typescript` | ^5.3.0 | 6.0.2 | **MAJOR** | Decision needed |
+
+---
+
+### 5. `plugins/cloudflare-durable-objects/skills/cloudflare-durable-objects/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `wrangler` | ^4.43.0 | 4.81.0 | MINOR | Update |
+| `@cloudflare/workers-types` | ^4.20251014.0 | 4.20260408.1 | MINOR | Update |
+| `typescript` | ^5.7.2 | 6.0.2 | **MAJOR** | Decision needed |
+
+---
+
+### 6. `plugins/cloudflare-images/skills/cloudflare-images/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `wrangler` | ^3.95.0 | 4.81.0 | **MAJOR** | Decision needed |
+| `@cloudflare/workers-types` | ^4.20241112.0 | 4.20260408.1 | MINOR | Update |
+| `typescript` | ^5.9.0 | 6.0.2 | **MAJOR** | Decision needed |
+
+---
+
+### 7. `plugins/cloudflare-images/skills/cloudflare-images/examples/basic-upload/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `wrangler` | ^3.91.0 | 4.81.0 | **MAJOR** | Decision needed |
+| `hono` | ^4.7.10 | 4.12.12 | MINOR | Update |
+
+---
+
+### 8. `plugins/cloudflare-images/skills/cloudflare-images/examples/private-images/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `wrangler` | ^3.91.0 | 4.81.0 | **MAJOR** | Decision needed |
+| `hono` | ^4.7.10 | 4.12.12 | MINOR | Update |
+| `@tsndr/cloudflare-worker-jwt` | ^2.5.4 | 3.2.1 | **MAJOR** | Decision needed |
+| `typescript` | ^5.7.2 | 6.0.2 | **MAJOR** | Decision needed |
+
+---
+
+### 9. `plugins/cloudflare-mcp-server/skills/cloudflare-mcp-server/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `wrangler` | ^3.103.0 | 4.81.0 | **MAJOR** | Decision needed |
+| `@modelcontextprotocol/sdk` | ^1.21.0 | 1.29.0 | MINOR | Update |
+| `agents` | ^0.3.5 | 0.10.0 | MINOR | Update |
+| `zod` | ^3.24.1 | 4.3.6 | **MAJOR** | Decision needed |
+| `@cloudflare/workers-oauth-provider` | ^0.0.13 | 0.4.0 | MINOR | Update |
+| `@octokit/rest` | ^21.0.2 | 22.0.1 | **MAJOR** | Decision needed |
+
+---
+
+### 10. `plugins/cloudflare-nextjs/skills/cloudflare-nextjs/references/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `next` | ^16.1.5 | 16.2.2 | MINOR | Update |
+| `@opennextjs/cloudflare` | ^1.3.0 | 1.18.1 | MINOR | Update |
+| `wrangler` | ^3 | 4.81.0 | **MAJOR** | Decision needed |
+
+---
+
+### 11. `plugins/drizzle-orm-d1/skills/drizzle-orm-d1/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `drizzle-orm` | ^0.44.7 | 0.45.2 | MINOR | Update |
+| `hono` | ^4.6.11 | 4.12.12 | MINOR | Update |
+| `drizzle-kit` | ^0.31.5 | 0.31.10 | MINOR | Update |
+| `wrangler` | ^4.43.0 | 4.81.0 | MINOR | Update |
+| `typescript` | ^5.7.3 | 6.0.2 | **MAJOR** | Decision needed |
+
+---
+
+### 12. `plugins/google-gemini-api/skills/google-gemini-api/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `@google/genai` | ^1.27.0 | 1.48.0 | MINOR | Update |
+| `tsx` | ^4.7.0 | 4.21.0 | MINOR | Update |
+| `typescript` | ^5.3.0 | 6.0.2 | **MAJOR** | Decision needed |
+
+---
+
+### 13. `plugins/google-gemini-embeddings/skills/google-gemini-embeddings/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `@google/genai` | ^1.27.0 | 1.48.0 | MINOR | Update |
+| `@types/node` | ^22.0.0 | 25.5.2 | **MAJOR** | Decision needed |
+| `typescript` | ^5.6.0 | 6.0.2 | **MAJOR** | Decision needed |
+
+---
+
+### 14. `plugins/hono-routing/skills/hono-routing/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `hono` | ^4.10.2 | 4.12.12 | MINOR | Update |
+| `@hono/valibot-validator` | ^0.5.3 | 0.6.1 | MINOR | Update |
+| `arktype` | ^2.0.0 | 2.2.0 | MINOR | Update |
+| `typescript` | ^5.9.0 | 6.0.2 | **MAJOR** | Decision needed |
+| `@types/node` | ^22.10.0 | 25.5.2 | **MAJOR** | Decision needed |
+
+---
+
+### 15. `plugins/neon-vercel-postgres/skills/neon-vercel-postgres/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `drizzle-orm` | ^0.44.7 | 0.45.2 | MINOR | Update |
+| `vite` | ^6.0.0 | 8.0.7 | **MAJOR** | Decision needed |
+| `typescript` | ^5.7.0 | 6.0.2 | **MAJOR** | Decision needed |
+
+---
+
+### 16. `plugins/nextjs/skills/nextjs/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `next` | ^16.0.0 | 16.2.2 | MINOR | Update |
+| `typescript` | ^5.7.0 | 6.0.2 | **MAJOR** | Decision needed |
+| `@types/node` | ^22.0.0 | 25.5.2 | **MAJOR** | Decision needed |
+
+---
+
+### 17. `plugins/openai-agents/skills/openai-agents/templates/shared/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `@openai/agents` | ^0.2.1 | 0.8.3 | MINOR | Update |
+| `@openai/agents-realtime` | ^0.2.1 | 0.8.3 | MINOR | Update |
+| `zod` | ^3.24.1 | 4.3.6 | **MAJOR** | Decision needed |
+| `typescript` | ^5.7.2 | 6.0.2 | **MAJOR** | Decision needed |
+| `@types/node` | ^22.10.2 | 25.5.2 | **MAJOR** | Decision needed |
+
+---
+
+### 18. `plugins/openai-api/skills/openai-api/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `openai` | ^6.7.0 | 6.33.0 | MINOR | Update |
+| `tsx` | ^4.7.0 | 4.21.0 | MINOR | Update |
+| `typescript` | ^5.3.3 | 6.0.2 | **MAJOR** | Decision needed |
+| `@types/node` | ^20.11.0 | 25.5.2 | **MAJOR** | Decision needed |
+
+---
+
+### 19. `plugins/openai-assistants/skills/openai-assistants/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `openai` | ^6.7.0 | 6.33.0 | MINOR | Update |
+| `tsx` | ^4.7.0 | 4.21.0 | MINOR | Update |
+| `typescript` | ^5.3.3 | 6.0.2 | **MAJOR** | Decision needed |
+| `@types/node` | ^20.10.0 | 25.5.2 | **MAJOR** | Decision needed |
+
+---
+
+### 20. `plugins/openai-responses/skills/openai-responses/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `openai` | ^5.19.1 | 6.33.0 | **MAJOR** | Decision needed |
+| `@cloudflare/workers-types` | ^5.0.0 | 4.20260408.1 | **BROKEN** | Fix to `^4.20260408.0` |
+| `wrangler` | ^3.95.0 | 4.81.0 | **MAJOR** | Decision needed |
+| `tsx` | ^4.7.1 | 4.21.0 | MINOR | Update |
+| `typescript` | ^5.3.3 | 6.0.2 | **MAJOR** | Decision needed |
+| `@types/node` | ^20.0.0 | 25.5.2 | **MAJOR** | Decision needed |
+
+---
+
+### 21. `plugins/playwright/skills/playwright/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `@playwright/test` | ^1.55.0 | 1.59.1 | MINOR | Update |
+| `playwright` | ^1.55.0 | 1.59.1 | MINOR | Update |
+
+---
+
+### 22. `plugins/react-hook-form-zod/skills/react-hook-form-zod/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `react-hook-form` | ^7.65.0 | 7.72.1 | MINOR | Update |
+| `typescript` | ^5.7.0 | 6.0.2 | **MAJOR** | Decision needed |
+| `vite` | ^6.3.0 | 8.0.7 | **MAJOR** | Decision needed |
+| `@vitejs/plugin-react` | ^4.3.0 | 6.0.1 | **MAJOR** | Decision needed |
+
+---
+
+### 23. `plugins/tanstack-query/skills/tanstack-query/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `react` | ^18.3.1 | 19.2.4 | **MAJOR** | Decision needed |
+| `react-dom` | ^18.3.1 | 19.2.4 | **MAJOR** | Decision needed |
+| `@tanstack/react-query` | ^5.90.12 | 5.96.2 | MINOR | Update |
+| `@tanstack/react-query-devtools` | ^5.91.1 | 5.96.2 | MINOR | Update |
+| `@tanstack/eslint-plugin-query` | ^5.91.2 | 5.96.2 | MINOR | Update |
+| `@types/react` | ^18.3.12 | 19.2.14 | **MAJOR** | Decision needed |
+| `@types/react-dom` | ^18.3.1 | 19.2.3 | **MAJOR** | Decision needed |
+| `vite` | ^6.0.1 | 8.0.7 | **MAJOR** | Decision needed |
+| `typescript` | ^5.6.3 | 6.0.2 | **MAJOR** | Decision needed |
+| `eslint` | ^9.16.0 | 10.2.0 | **MAJOR** | Decision needed |
+
+---
+
+### 24. `plugins/tanstack-router/skills/tanstack-router/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `@tanstack/react-router` | ^1.134.13 | 1.168.10 | MINOR | Update |
+| `@tanstack/router-devtools` | ^1.134.13 | 1.166.11 | MINOR | Update |
+| `@tanstack/react-query` | ^5.90.7 | 5.96.2 | MINOR | Update |
+| `@tanstack/router-plugin` | ^1.134.13 | 1.167.12 | MINOR | Update |
+| `@vitejs/plugin-react` | ^4.3.4 | 6.0.1 | **MAJOR** | Decision needed |
+| `typescript` | ^5.8.0 | 6.0.2 | **MAJOR** | Decision needed |
+| `vite` | ^6.0.0 | 8.0.7 | **MAJOR** | Decision needed |
+
+---
+
+### 25. `plugins/tanstack-table/skills/tanstack-table/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `@tanstack/react-query` | ^5.90.7 | 5.96.2 | MINOR | Update |
+| `@tanstack/react-virtual` | ^3.13.12 | 3.13.23 | MINOR | Update |
+| `@vitejs/plugin-react` | ^4.3.4 | 6.0.1 | **MAJOR** | Decision needed |
+| `typescript` | ^5.8.0 | 6.0.2 | **MAJOR** | Decision needed |
+| `vite` | ^6.0.0 | 8.0.7 | **MAJOR** | Decision needed |
+
+---
+
+### 26. `plugins/thesys-generative-ui/skills/thesys-generative-ui/templates/nextjs/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `@thesysai/genui-sdk` | ^0.6.40 | 0.9.0 | MINOR | Update |
+| `@crayonai/react-ui` | ^0.8.42 | 0.9.16 | MINOR | Update |
+| `@crayonai/stream` | ^0.1.0 | 0.5.2 | MINOR | Update |
+| `next` | ^15.1.4 | 16.2.2 | **MAJOR** | Decision needed |
+| `openai` | ^4.73.0 | 6.33.0 | **MAJOR** | Decision needed |
+| `zod` | ^3.24.1 | 4.3.6 | **MAJOR** | Decision needed |
+| `typescript` | ^5.7.3 | 6.0.2 | **MAJOR** | Decision needed |
+| `eslint` | ^9.0.0 | 10.2.0 | **MAJOR** | Decision needed |
+| `eslint-config-next` | ^15.1.4 | 16.2.2 | **MAJOR** | Decision needed |
+| `@tavily/core` | ^1.0.0 | 0.7.2 | **BROKEN** | Fix to `^0.7.2` |
+| `@clerk/nextjs` | ^6.10.0 | 7.0.11 | **MAJOR** | Decision needed |
+| `@types/node` | ^22.0.0 | 25.5.2 | **MAJOR** | Decision needed |
+
+---
+
+### 27. `plugins/thesys-generative-ui/skills/thesys-generative-ui/templates/vite-react/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `@thesysai/genui-sdk` | ^0.6.40 | 0.9.0 | MINOR | Update |
+| `@crayonai/react-ui` | ^0.8.42 | 0.9.16 | MINOR | Update |
+| `@crayonai/stream` | ^0.1.0 | 0.5.2 | MINOR | Update |
+| `openai` | ^4.73.0 | 6.33.0 | **MAJOR** | Decision needed |
+| `zod` | ^3.24.1 | 4.3.6 | **MAJOR** | Decision needed |
+| `@vitejs/plugin-react` | ^4.3.4 | 6.0.1 | **MAJOR** | Decision needed |
+| `eslint` | ^9.0.0 | 10.2.0 | **MAJOR** | Decision needed |
+| `typescript` | ^5.7.3 | 6.0.2 | **MAJOR** | Decision needed |
+| `vite` | ^6.0.5 | 8.0.7 | **MAJOR** | Decision needed |
+| `@tavily/core` | ^1.0.0 | 0.7.2 | **BROKEN** | Fix to `^0.7.2` |
+
+---
+
+### 28. `plugins/vercel-blob/skills/vercel-blob/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `@vercel/blob` | ^2.0.0 | 2.3.3 | MINOR | Update |
+| `next` | ^15.2.0 | 16.2.2 | **MAJOR** | Decision needed |
+| `typescript` | ^5.7.0 | 6.0.2 | **MAJOR** | Decision needed |
+| `@types/node` | ^22.0.0 | 25.5.2 | **MAJOR** | Decision needed |
+
+---
+
+### 29. `plugins/vercel-kv/skills/vercel-kv/templates/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `next` | ^15.2.0 | 16.2.2 | **MAJOR** | Decision needed |
+| `typescript` | ^5.7.0 | 6.0.2 | **MAJOR** | Decision needed |
+| `@types/node` | ^22.0.0 | 25.5.2 | **MAJOR** | Decision needed |
+
+---
+
+### 30. `plugins/zod/skills/zod/references/package.json`
+
+| Package | Current | Latest | Bump | Action |
+|---|---|---|---|---|
+| `zod` | ^4.3.6 | 4.3.6 | OK | No change |
+| `typescript` | ^5.5.0 | 6.0.2 | **MAJOR** | Decision needed |
+| `vitest` | ^2.0.0 | 4.1.3 | **MAJOR** | Decision needed |
+| `@types/node` | ^20.0.0 | 25.5.2 | **MAJOR** | Decision needed |
+
+---
+
+## Files With No Issues
+
+| File | Status |
+|---|---|
+| `package.json` (root) | No dependencies |
+| `plugins/mcp-dynamic-orchestrator/package.json` | No runtime dependencies |
+| `plugins/chrome-devtools/skills/chrome-devtools/scripts/package.json` | `puppeteer ^24.15.0` (latest 24.40.0, covered by ^), `debug ^4.4.0` (latest 4.4.3, OK) |
+| `plugins/neon-vercel-postgres/.../package.json` | `@neondatabase/serverless ^1.0.2` matches latest 1.0.2 |
+| `plugins/cloudflare-durable-objects/.../package.json` | Minor bumps only, covered by ^ |
+
+---
+
+## Decisions Needed
+
+The following major version bumps require a decision before applying. Each has potential breaking changes that may require template code updates.
+
+### Decision 1: TypeScript 5.x → 6.x
+
+**Affected files**: 28 of 33 files
+**Current range**: ^5.3.0 to ^5.9.3
+**Latest stable**: 6.0.2
+**Risk**: Medium — TypeScript major bumps typically have some breaking type-checking behaviors
+**Recommendation**: Upgrade. TS 6 is stable and all modern frameworks support it.
+
+**Choice**:
+- [ ] A) Upgrade all to `^6.0.2`
+- [ ] B) Keep at `^5.x` (pin to `^5.9.3` for consistency)
+
+---
+
+### Decision 2: AI SDK v5 → v6
+
+**Affected files**: `ai-sdk-core`, `ai-sdk-ui`
+**Packages**: `ai`, `@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/google`, `workers-ai-provider`
+**Current**: ai ^5.0.116, providers ^2.x
+**Latest**: ai 6.0.153, providers ^3.x
+**Risk**: High — AI SDK v6 has significant API changes (different streaming API, tool calling patterns)
+**Recommendation**: Upgrade — these are template files meant to show latest patterns.
+
+**Choice**:
+- [ ] A) Upgrade all to v6 (ai ^6.0.0, providers ^3.0.0, workers-ai-provider ^3.0.0)
+- [ ] B) Keep at v5 (update to latest v5.x minors only)
+
+---
+
+### Decision 3: React 18 → 19
+
+**Affected files**: `ai-sdk-ui`, `tanstack-query`
+**Current**: ^18.2.0 / ^18.3.1
+**Latest**: 19.2.4
+**Risk**: Medium — React 19 has breaking changes (ref cleanup, use of hooks, etc.)
+**Recommendation**: Upgrade for consistency — most other files already use React 19.
+
+**Choice**:
+- [ ] A) Upgrade to `^19.2.0` (+ `@types/react ^19.0.0`, `@types/react-dom ^19.0.0`)
+- [ ] B) Keep at React 18
+
+---
+
+### Decision 4: Next.js 15 → 16
+
+**Affected files**: `thesys-generative-ui/nextjs`, `vercel-blob`, `vercel-kv`
+**Current**: ^15.1.4 / ^15.2.0
+**Latest**: 16.2.2
+**Risk**: Medium-High — Next.js major bumps often change routing/build behavior
+**Recommendation**: Upgrade — `nextjs` and `cloudflare-nextjs` plugins already target v16.
+
+**Choice**:
+- [ ] A) Upgrade to `^16.2.0` (+ `eslint-config-next ^16.0.0`)
+- [ ] B) Keep at Next 15
+
+---
+
+### Decision 5: Vite 6 → 8
+
+**Affected files**: `neon-vercel-postgres`, `react-hook-form-zod`, `tanstack-query`, `tanstack-router`, `tanstack-table`, `thesys/vite-react`
+**Current**: ^6.0.0 to ^6.3.0
+**Latest**: 8.0.7
+**Risk**: Medium — Vite 7 and 8 both had breaking changes (Node 18 drop, plugin API changes)
+**Recommendation**: Upgrade — Vite 8 is stable and significantly faster.
+
+**Choice**:
+- [ ] A) Upgrade all to `^8.0.0` (+ `@vitejs/plugin-react ^6.0.0`)
+- [ ] B) Upgrade to Vite 7 only (`^7.0.0`)
+- [ ] C) Keep at Vite 6
+
+---
+
+### Decision 6: Zod 3 → 4
+
+**Affected files**: `ai-sdk-core`, `ai-sdk-ui`, `claude-api`, `claude-agent-sdk`, `cloudflare-mcp-server`, `openai-agents`, `thesys/nextjs`, `thesys/vite-react`
+**Current**: ^3.23.0 to ^3.24.1
+**Latest**: 4.3.6
+**Risk**: Medium — Zod 4 has a different API in places (`.refine` changes, error handling)
+**Recommendation**: Upgrade for consistency — `zod`, `hono-routing`, and `react-hook-form-zod` plugins already use Zod 4.
+
+**Choice**:
+- [ ] A) Upgrade all to `^4.3.0`
+- [ ] B) Keep at Zod 3
+
+---
+
+### Decision 7: Wrangler 3 → 4
+
+**Affected files**: `cloudflare-images/templates`, `cloudflare-images/basic-upload`, `cloudflare-images/private-images`, `cloudflare-mcp-server`, `cloudflare-nextjs`
+**Current**: ^3.91.0 to ^3.103.0
+**Latest**: 4.81.0
+**Risk**: Low-Medium — Wrangler 4 is mostly backward compatible with 3
+**Recommendation**: Upgrade — `cloudflare-durable-objects` and `drizzle-orm-d1` already use Wrangler 4.
+
+**Choice**:
+- [ ] A) Upgrade all to `^4.81.0`
+- [ ] B) Keep at Wrangler 3
+
+---
+
+### Decision 8: OpenAI SDK v4/v5 → v6
+
+**Affected files**: `openai-responses` (^5.19.1), `thesys/nextjs` (^4.73.0), `thesys/vite-react` (^4.73.0)
+**Current**: ^4.73.0 / ^5.19.1
+**Latest**: 6.33.0
+**Risk**: High — Major API changes between v4→v5→v6
+**Recommendation**: Upgrade — `openai-api` and `openai-assistants` already use v6.
+
+**Choice**:
+- [ ] A) Upgrade all to `^6.33.0`
+- [ ] B) Upgrade thesys to ^6.0.0, keep openai-responses at ^5.x
+- [ ] C) Keep current versions
+
+---
+
+### Decision 9: ESLint 9 → 10
+
+**Affected files**: `ai-sdk-ui`, `claude-api`, `tanstack-query`, `thesys/nextjs`, `thesys/vite-react`
+**Current**: ^8.50.0 / ^9.0.0 to ^9.39.2
+**Latest**: 10.2.0
+**Risk**: Medium — Flat config changes in ESLint 10
+**Recommendation**: Upgrade — ESLint 10 is stable.
+
+**Choice**:
+- [ ] A) Upgrade all to `^10.0.0`
+- [ ] B) Keep at ESLint 9
+
+---
+
+## Summary
+
+| Metric | Count |
+|---|---|
+| Total `package.json` files scanned | 33 |
+| Files needing updates | 28 |
+| Files already current | 5 |
+| **Broken version pins (non-existent)** | **3** |
+| Major version bump decisions | 9 |
+| Total major bumps across all files | ~75 |
+| Total minor bumps across all files | ~40 |
+
+### Quick Wins (No Decision Needed — Minor Bumps Only)
+
+These files only need minor version updates and can be fixed immediately:
+
+| File | Packages to Update |
+|---|---|
+| `playwright` | `@playwright/test ^1.59.0`, `playwright ^1.59.0` |
+| `drizzle-orm-d1` | `drizzle-orm ^0.45.0`, `hono ^4.12.0`, `drizzle-kit ^0.31.10`, `wrangler ^4.81.0` |
+| `cloudflare-durable-objects` | `wrangler ^4.81.0`, `@cloudflare/workers-types ^4.20260408.0` |
+| `openai-api` | `openai ^6.33.0`, `tsx ^4.21.0` |
+| `openai-assistants` | `openai ^6.33.0`, `tsx ^4.21.0` |
+| `google-gemini-api` | `@google/genai ^1.48.0`, `tsx ^4.21.0` |
+| `google-gemini-embeddings` | `@google/genai ^1.48.0` |
+
+---
+
+*Report generated: 2026-04-08 | Next review: 2026-07-08 (quarterly)*

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **170 production-ready skills for Claude Code CLI**
 
-Version 3.2.1 | Last Updated: 2026-04-01
+Version 3.2.2 | Last Updated: 2026-04-08
 
 <div align="center">
 

--- a/plugins/better-auth/.claude-plugin/plugin.json
+++ b/plugins/better-auth/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-auth",
   "description": "Skill for integrating Better Auth - comprehensive TypeScript authentication framework for Cloudflare D1, Next.js, Nuxt, and 15+ frameworks. Use when adding auth, encountering D1 adapter errors, or implementing OAuth/2FA/RBAC features.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/better-auth/README.md
+++ b/plugins/better-auth/README.md
@@ -197,7 +197,7 @@ bun add better-auth drizzle-orm drizzle-kit @cloudflare/workers-types hono  # pr
 
 - **Token Savings**: ~70% (15k → 4.5k tokens)
 - **Time Savings**: ~2-3 hours of setup and debugging
-- **Error Prevention**: 10 documented issues with solutions
+- **Error Prevention**: 15 documented issues with solutions
 
 ---
 

--- a/plugins/better-auth/README.md
+++ b/plugins/better-auth/README.md
@@ -10,7 +10,7 @@ Provides complete patterns for implementing authentication with **better-auth**,
 
 **⚠️ v2.0.0 Breaking Change**: Previous skill version incorrectly documented a non-existent `d1Adapter()`. This version corrects all patterns to use Drizzle ORM or Kysely as required by better-auth.
 
-**🆕 v2.2.0**: Updated to better-auth@1.4.9 with comprehensive framework, database, and plugin references.
+**🆕 v3.0.0**: Updated to better-auth@1.6.0 with v1.5 and v1.6 features: D1 native support, OAuth 2.1 Provider, Electron, i18n, OpenTelemetry, passkey pre-auth, dynamic base URL, SSO production hardening, test utils, secret key rotation, and more.
 
 ---
 
@@ -33,6 +33,10 @@ This skill should be automatically invoked when you mention:
 - **"passkeys"** - Passwordless auth
 - **"magic link auth"** - Email-based passwordless
 - **"better-auth CLI"** - CLI tool usage
+- **"Electron auth"** - Desktop app authentication
+- **"better-auth i18n"** - Error message translations
+- **"OpenTelemetry auth"** - Distributed tracing
+- **"test better-auth"** - Testing utilities
 - **"SAML authentication"** - SAML/SSO setup
 - **"OAuth 2.1"** - Standards compliance
 - **"better-auth Next.js"** - Next.js integration
@@ -73,28 +77,34 @@ This skill should be automatically invoked when you mention:
 7. **Interactive Commands** - `/better-auth-setup`, `/better-auth-add-plugin`
 8. **Debugging Agent** - Autonomous auth issue diagnosis
 
-### Errors Prevented (12 Common Issues)
+### Errors Prevented (15 Common Issues)
 
-- ✅ **D1 adapter misconfiguration** (no direct d1Adapter, must use Drizzle/Kysely)
-- ✅ **Schema generation failures** (using Drizzle Kit correctly)
+- ✅ **D1 adapter misconfiguration** (use D1 native or Drizzle/Kysely)
+- ✅ **Schema generation failures** (using `npx auth generate` or Drizzle Kit)
 - ✅ D1 eventual consistency causing stale session reads
 - ✅ CORS misconfiguration for SPA applications
 - ✅ Session serialization errors in Workers
 - ✅ OAuth redirect URI mismatch
 - ✅ Email verification not sending
 - ✅ JWT token expiration issues
-- ✅ Password hashing performance bottlenecks
+- ✅ Password hashing performance bottlenecks (non-blocking scrypt in v1.6)
 - ✅ Social provider scope issues (missing user data)
 - ✅ Multi-tenant data leakage
 - ✅ Rate limit false positives
+- ✅ Session freshness issues (`createdAt` vs `updatedAt` in v1.6)
+- ✅ SAML replay attacks (InResponseTo default ON in v1.6)
+- ✅ API key import errors (moved to `@better-auth/api-key` in v1.5)
 
-### Reference Files (23 total)
+### Reference Files (32 total)
 
 **Core**:
 - **`references/setup-guide.md`** - 8-step D1 setup walkthrough
 - **`references/error-catalog.md`** - 15 errors with solutions
 - **`references/advanced-features.md`** - 2FA, organizations, migrations
 - **`references/v1.4-features.md`** - Background tasks, new OAuth, CLI
+- **`references/v1.5-features.md`** - D1 native, OAuth 2.1 Provider, Electron, i18n, secret rotation
+- **`references/v1.6-features.md`** - OpenTelemetry, passkey pre-auth, non-blocking scrypt
+- **`references/migration-guide-1.5.0.md`** - Upgrading to v1.5.0+
 
 **Frameworks** (`references/frameworks/`):
 - **nextjs.md**, **nuxt.md**, **remix.md**, **sveltekit.md**, **api-frameworks.md**, **expo-mobile.md**
@@ -103,7 +113,10 @@ This skill should be automatically invoked when you mention:
 - **postgresql.md**, **mongodb.md**, **mysql.md**
 
 **Plugins** (`references/plugins/`):
-- **authentication.md** (2FA, passkeys), **enterprise.md** (SSO, SCIM), **api-tokens.md** (JWT, OIDC), **payments.md** (Stripe)
+- **authentication.md** (2FA, passkeys incl. pre-auth), **enterprise.md** (SSO, SCIM), **api-tokens.md** (API keys, org-owned), **payments.md** (Stripe), **sso.md** (production OIDC/SAML), **test-utils.md** (testing helpers)
+
+**Integrations** (`references/integrations/`):
+- **electron.md** - Electron desktop auth
 
 **Scripts**:
 - **`scripts/generate-secret.sh`** - Generate BETTER_AUTH_SECRET
@@ -116,7 +129,18 @@ This skill should be automatically invoked when you mention:
 
 ### Cloudflare Worker Setup (Drizzle ORM)
 
-**⚠️ CRITICAL**: better-auth requires **Drizzle ORM** or **Kysely** for D1. There is NO direct `d1Adapter()`.
+**v1.5.0+**: D1 can now be used directly without Drizzle. For simple setups:
+
+```typescript
+import { betterAuth } from 'better-auth'
+
+const auth = betterAuth({
+    database: env.DB, // D1 binding, auto-detected
+    secret: env.BETTER_AUTH_SECRET,
+})
+```
+
+For complex schemas with Drizzle ORM:
 
 ```typescript
 import { betterAuth } from 'better-auth'
@@ -203,7 +227,7 @@ bun add better-auth drizzle-orm drizzle-kit @cloudflare/workers-types hono  # pr
 
 - **Docs**: https://better-auth.com
 - **GitHub**: https://github.com/better-auth/better-auth (22.4k ⭐)
-- **Package**: `better-auth@1.4.9`
+- **Package**: `better-auth@1.6.0`
 - **Examples**: https://github.com/better-auth/better-auth/tree/main/examples
 - **Changelog**: https://www.better-auth.com/changelogs
 
@@ -234,11 +258,11 @@ bun add pg drizzle-orm  # preferred
 
 ## Version Info
 
-- **Skill Version**: 2.2.0 (Comprehensive framework/database/plugin coverage)
-- **Package Version**: better-auth@1.4.9
+- **Skill Version**: 3.0.0 (v1.5/v1.6 features: D1 native, Electron, i18n, OpenTelemetry, SSO, test utils)
+- **Package Version**: better-auth@1.6.0
 - **Drizzle ORM**: drizzle-orm@0.45.1, drizzle-kit@0.31.8
 - **Kysely**: kysely@0.28.9, @noxharmonium/kysely-d1@0.4.0
-- **Last Verified**: 2025-12-28
+- **Last Verified**: 2026-04-08
 - **Compatibility**: Node.js 18+, Bun 1.0+, Cloudflare Workers
 
 ---

--- a/plugins/better-auth/skills/better-auth/SKILL.md
+++ b/plugins/better-auth/skills/better-auth/SKILL.md
@@ -3,21 +3,21 @@ name: better-auth
 description: Skill for integrating Better Auth - comprehensive TypeScript authentication framework for Cloudflare D1, Next.js, Nuxt, and 15+ frameworks. Use when adding auth, encountering D1 adapter errors, or implementing OAuth/2FA/RBAC features.
 license: MIT
 metadata:
-  keywords: "better-auth, authentication, cloudflare d1 auth, drizzle orm auth, kysely auth, self-hosted auth, typescript auth, clerk alternative, auth.js alternative, social login, oauth providers, session management, jwt tokens, 2fa, two-factor, passkeys, webauthn, multi-tenant auth, organizations, teams, rbac, role-based access, google auth, github auth, microsoft auth, apple auth, magic links, email password, better-auth setup, drizzle d1, kysely d1, session serialization error, cors auth, d1 adapter, nextjs auth, nuxt auth, remix auth, sveltekit auth, expo auth, react native auth, postgresql auth, mongodb auth, mysql auth, stripe auth, api keys, sso, saml, scim, admin dashboard, background tasks, oauth 2.1, cli"
-  version: "2.2.0"
-  package_version: "1.4.9"
-  last_verified: "2025-12-26"
-  errors_prevented: 15
+  keywords: "better-auth, authentication, cloudflare d1 auth, drizzle orm auth, kysely auth, self-hosted auth, typescript auth, clerk alternative, auth.js alternative, social login, oauth providers, session management, jwt tokens, 2fa, two-factor, passkeys, webauthn, multi-tenant auth, organizations, teams, rbac, role-based access, google auth, github auth, microsoft auth, apple auth, magic links, email password, better-auth setup, drizzle d1, kysely d1, session serialization error, cors auth, d1 adapter, nextjs auth, nuxt auth, remix auth, sveltekit auth, expo auth, react native auth, postgresql auth, mongodb auth, mysql auth, stripe auth, api keys, sso, saml, scim, admin dashboard, background tasks, oauth 2.1, cli, electron, i18n, instrumentation, otel, opentelemetry, test-utils, dynamic-base-url, secret-rotation, oauth-provider, mcp, passkey pre-auth, d1 native"
+  version: "3.1.0"
+  package_version: "1.6.0"
+  last_verified: "2026-04-08"
+  errors_prevented: 20
   templates_included: 4
-  references_included: 26
+  references_included: 32
 ---
 
 # better-auth
 
 **Status**: Production Ready
-**Last Updated**: 2025-12-26
-**Package**: `better-auth@1.4.9` (ESM-only)
-**Dependencies**: Drizzle ORM or Kysely (required for D1)
+**Last Updated**: 2026-04-08
+**Package**: `better-auth@1.6.0` (ESM-only)
+**Dependencies**: Drizzle ORM or Kysely (required for D1 complex use cases; D1 native support available in v1.5+)
 
 ---
 
@@ -47,20 +47,35 @@ better-auth v1.4.0+ is **ESM-only**. Ensure:
 ```
 
 **Upgrading from v1.3.x?** Load `references/migration-guide-1.4.0.md`
+**Upgrading from v1.4.x?** Load `references/migration-guide-1.5.0.md`
 
 ### ⚠️ CRITICAL: D1 Adapter Requirements
 
-better-auth **DOES NOT** have a direct `d1Adapter()`. You **MUST** use either:
-1. **Drizzle ORM** (recommended) - `drizzleAdapter()`
-2. **Kysely** (alternative) - Kysely instance with D1Dialect
+**v1.5.0+**: D1 is now natively supported. Pass your D1 binding directly:
+
+```typescript
+// ✅ SIMPLEST - D1 native (v1.5.0+)
+import { betterAuth } from "better-auth";
+
+const auth = betterAuth({
+    database: env.DB, // D1 binding, auto-detected
+});
+```
+
+For complex schemas, use Drizzle ORM:
+```typescript
+// ✅ RECOMMENDED for complex schemas - Drizzle
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { drizzle } from "drizzle-orm/d1";
+
+const auth = betterAuth({
+    database: drizzleAdapter(drizzle(env.DB, { schema }), { provider: "sqlite" }),
+});
+```
 
 ```typescript
 // ❌ WRONG - This doesn't exist
 import { d1Adapter } from 'better-auth/adapters/d1'
-
-// ✅ CORRECT - Use Drizzle
-import { drizzleAdapter } from 'better-auth/adapters/drizzle'
-import { drizzle } from 'drizzle-orm/d1'
 ```
 
 ### Minimal Setup (Cloudflare Workers + Drizzle)
@@ -171,8 +186,8 @@ Is this a new/empty project?
 
 ### MUST DO
 
-✅ Use Drizzle/Kysely adapter (d1Adapter doesn't exist)
-✅ Use Drizzle Kit for migrations (not `better-auth migrate`)
+✅ Use `better-auth/minimal` + adapter packages for smallest bundle (v1.5+)
+✅ Use `npx auth migrate` and `npx auth generate` for CLI commands (v1.5+)
 ✅ Set BETTER_AUTH_SECRET via `wrangler secret put`
 ✅ Configure CORS with `credentials: true`
 ✅ Match OAuth callback URLs exactly (no trailing slash)
@@ -181,48 +196,58 @@ Is this a new/empty project?
 
 ### NEVER DO
 
-❌ Use `d1Adapter` or `better-auth migrate` with D1
+❌ Use `d1Adapter` (doesn't exist)
 ❌ Forget CORS credentials or mismatch OAuth URLs
 ❌ Use snake_case columns without CamelCasePlugin
 ❌ Skip local migrations or hardcode secrets
 ❌ Leave sendVerificationEmail unimplemented
 
-### ⚠️ v1.4.0+ Breaking Changes
+### ⚠️ v1.5.0 Breaking Changes
 
-**ESM-only** (no CommonJS):
-```json
-// package.json required
-{ "type": "module" }
-```
-
-**API Renames**:
-- `forgetPassword` → `requestPasswordReset`
-- POST `/account-info` → GET `/account-info`
-
-**Callback Signatures**:
+**API Key Plugin Moved**:
 ```typescript
-// v1.3.x: request parameter
-sendVerificationEmail: async ({ user, url, request }) => {}
-
-// v1.4.0+: ctx parameter
-sendVerificationEmail: async ({ user, url, ctx }) => {}
+- import { apiKey } from "better-auth/plugins";
++ import { apiKey } from "@better-auth/api-key";
 ```
+Schema: `userId` → `referenceId`, new `configId` field.
 
-**Load `references/migration-guide-1.4.0.md` when upgrading from <1.4.0**
+**After Hooks**: Database after-hooks now run post-transaction (not inside it).
 
-### New in v1.4.4-1.4.8
+**Deprecated APIs Removed**: `Adapter` → `DBAdapter`, `InferUser`/`InferSession` removed, `@better-auth/core/utils` split into subpath exports.
 
-**Key additions since v1.4.3**:
+**Load `references/migration-guide-1.5.0.md` when upgrading from <1.5.0**
 
-- **Background Tasks** (v1.4.8): Global `backgroundTasks` config to defer email sending
-- **New OAuth Providers**: Patreon (v1.4.8), Vercel (v1.4.3), Kick (v1.4.6) with refresh tokens
-- **OAuth 2.1 Plugin** (v1.4.8): Standards-compliant OAuth implementation
-- **CLI Tool** (v1.4.4): `better-auth` CLI with project scaffolding
-- **SAML/SSO**: Clock skew validation (v1.4.7), InResponseTo, OIDC discovery
-- **Admin Permissions** (v1.4.7): Admin role with granular user update permissions
-- **ctx.isTrustedDomain** (v1.4.6): Helper for domain verification
+### ⚠️ v1.6.0 Breaking Changes
 
-**Load `references/v1.4-features.md` for detailed implementation guides.**
+**Session Freshness**: `freshAge` now uses `createdAt` (not `updatedAt`). Sessions may require re-auth more frequently for sensitive operations.
+
+**SAML Security**: InResponseTo validation is **default ON**. Opt out with `saml: { enableInResponseToValidation: false }`.
+
+**OIDC Provider Deprecated**: Use `@better-auth/oauth-provider` instead.
+
+### New in v1.5.0 (Highlights)
+
+- **New CLI**: `npx auth init/migrate/generate/upgrade`
+- **D1 Native**: Pass D1 binding directly (no adapter needed)
+- **OAuth 2.1 Provider**: `@better-auth/oauth-provider` (MCP-ready)
+- **Electron**: `@better-auth/electron` for desktop apps
+- **i18n**: `@better-auth/i18n` for error translations
+- **Dynamic Base URL**: Multi-domain/preview deployment support
+- **Secret Key Rotation**: Non-destructive, versioned secrets
+- **Test Utils**: Factories, OTP capture, login helpers
+- **Typed Error Codes**: Machine-readable `code` in error responses
+
+**Load `references/v1.5-features.md` for detailed implementation guides.**
+
+### New in v1.6.0 (Highlights)
+
+- **OpenTelemetry**: Distributed tracing (experimental)
+- **Passkey Pre-Auth**: Register passkeys before session
+- **Non-blocking Scrypt**: Password hashing on libuv thread pool
+- **46% Smaller Package**: 4.2MB → 2.3MB
+- **Case Insensitive Queries**: `mode: "insensitive"` on adapter queries
+
+**Load `references/v1.6-features.md` for detailed implementation guides.**
 
 ---
 
@@ -238,12 +263,15 @@ sendVerificationEmail: async ({ user, url, ctx }) => {}
 
 **Note**: Only define `baseURL`/`secret` in config if env vars are NOT set.
 
-### CLI Commands
+### CLI Commands (v1.5+)
 
 | Command | Purpose |
 |---------|---------|
-| `npx @better-auth/cli@latest migrate` | Apply schema (built-in Kysely adapter only) |
-| `npx @better-auth/cli@latest generate` | Generate schema for Prisma/Drizzle |
+| `npx auth init` | Interactive project scaffolding |
+| `npx auth migrate` | Run database migrations |
+| `npx auth generate` | Generate auth schema |
+| `npx auth generate --adapter drizzle` | Adapter-specific schema |
+| `npx auth upgrade` | Upgrade to latest version |
 | `bunx drizzle-kit generate` | **D1: Use this** to generate Drizzle migrations |
 | `wrangler d1 migrations apply DB_NAME` | **D1: Use this** to apply migrations |
 
@@ -266,14 +294,18 @@ sendVerificationEmail: async ({ user, url, ctx }) => {}
 
 ### Common Plugins
 
-Import from **dedicated paths** for tree-shaking:
+Import from **dedicated packages** (extracted in v1.5+):
 ```typescript
 import { twoFactor } from "better-auth/plugins/two-factor"
 import { organization } from "better-auth/plugins/organization"
-import { passkey } from "@better-auth/passkey"  // Separate package
+import { passkey } from "@better-auth/passkey"          // Separate package
+import { apiKey } from "@better-auth/api-key"            // Separate package (v1.5+)
+import { sso } from "@better-auth/sso"                   // Separate package (v1.5+)
+import { i18n } from "@better-auth/i18n"                 // Separate package (v1.5+)
+import { oauthProvider } from "@better-auth/oauth-provider" // Separate package (v1.5+)
 ```
 
-**NOT** `from "better-auth/plugins"`.
+Core plugins (still in `better-auth/plugins`): `twoFactor`, `organization`, `admin`, `anonymous`, `emailOTP`, `magicLink`, `phone-number`, `multi-session`, `custom-session`.
 
 ---
 
@@ -383,7 +415,7 @@ app.get("/api/protected", async (c) => {
 - User asks about wrangler.toml configuration
 
 **Load `references/error-catalog.md` when**:
-- Encountering any of the 12 documented errors
+- Encountering any of the 15 documented errors
 - User reports D1 adapter, schema, CORS, or OAuth issues
 - User asks about troubleshooting or debugging
 - User needs prevention checklist
@@ -394,6 +426,47 @@ app.get("/api/protected", async (c) => {
 - User asks about rate limiting or session management
 - User wants migration guide from Clerk or Auth.js
 - User needs security best practices or performance optimization
+
+**Load `references/v1.5-features.md` when**:
+- User asks about the new CLI, MCP auth, OAuth 2.1 Provider
+- User needs Electron desktop auth or i18n error translations
+- User asks about dynamic base URL or secret key rotation
+- User needs D1 native support (no adapter) or adapter extraction
+- User asks about test utils, seat-based billing, or typed error codes
+- User needs Cloudflare D1 native support configuration
+
+**Load `references/v1.6-features.md` when**:
+- User asks about OpenTelemetry or distributed tracing
+- User needs passkey pre-auth registration (before session)
+- User asks about case-insensitive database queries
+- User encounters session freshness issues after upgrading
+- User asks about SAML InResponseTo validation
+
+**Load `references/migration-guide-1.5.0.md` when**:
+- User upgrading from better-auth <1.5.0 to 1.5.0+
+- User encounters API Key import errors (`userId` → `referenceId`)
+- User asks about after hooks running post-transaction
+- User encounters `InferUser`/`InferSession` type errors
+- User needs to update `@better-auth/core/utils` imports
+
+**Load `references/plugins/sso.md` when**:
+- User needs production SSO with OIDC, OAuth2, or SAML 2.0
+- User asks about OIDC discovery, SAML SLO, or domain verification
+- User needs organization provisioning via SSO
+- User asks about SAML security (InResponseTo, replay protection, timestamps)
+- User encounters SSO discovery errors
+
+**Load `references/plugins/test-utils.md` when**:
+- User writing integration or E2E tests with Better Auth
+- User needs test factories (createUser, createOrganization)
+- User needs authenticated test sessions (login, getAuthHeaders, getCookies)
+- User needs OTP capture for verification tests
+
+**Load `references/integrations/electron.md` when**:
+- User building Electron desktop app with Better Auth
+- User needs system browser OAuth flow for desktop
+- User asks about deep links, custom protocol schemes
+- User needs IPC bridges or manual token exchange
 
 **Load `references/cloudflare-worker-drizzle.ts` when**:
 - User needs complete Worker implementation example
@@ -417,30 +490,25 @@ app.get("/api/protected", async (c) => {
 **Load `references/configuration-guide.md` when**:
 - User asks about production configuration
 - User needs environment variable setup or wrangler.toml
-- User asks about session configuration or ESM setup
+- User asks about dynamic base URL, secret rotation, or D1 native
 - User needs CORS configuration, rate limiting, or API keys
-- User asks about troubleshooting configuration issues
+- User asks about session configuration (deferSessionRefresh, verification on secondary storage)
 
 **Load `references/framework-comparison.md` when**:
 - User asks "better-auth vs Clerk" or "vs Auth.js"
 - User needs help choosing auth framework
 - User wants feature comparison, migration advice, or cost analysis
-- User asks about v1.4.0+ new features (database joins, stateless sessions)
 
 **Load `references/migration-guide-1.4.0.md` when**:
 - User upgrading from better-auth <1.4.0 to 1.4.0+
 - User encounters `forgetPassword` errors or ESM issues
 - User asks about breaking changes or migration steps
-- User needs to migrate callback functions or API endpoints
 
 **Load `references/v1.4-features.md` when**:
 - User asks about background tasks or deferred email sending
 - User needs Patreon, Vercel, or Kick OAuth provider setup
-- User asks about OAuth 2.1 compliance
-- User needs SAML/SSO with clock skew or OIDC discovery
 - User asks about the better-auth CLI tool
 - User needs admin role permissions configuration
-- User asks about ctx.isTrustedDomain or domain verification
 
 **Load `references/nextjs/README.md` when**:
 - User building Next.js app with PostgreSQL (not Cloudflare D1)
@@ -495,7 +563,7 @@ app.get("/api/protected", async (c) => {
 ### Plugin Guides
 
 **Load `references/plugins/authentication.md` when**:
-- User needs 2FA, passkeys, magic links, email OTP, or anonymous users
+- User needs 2FA, passkeys (incl. pre-auth), magic links, email OTP, or anonymous users
 - User asks about enhanced authentication methods
 
 **Load `references/plugins/enterprise.md` when**:
@@ -503,12 +571,27 @@ app.get("/api/protected", async (c) => {
 - User building multi-tenant or enterprise application
 
 **Load `references/plugins/api-tokens.md` when**:
-- User needs API keys, bearer tokens, JWT, or OIDC provider
+- User needs API keys (incl. org-owned, multi-config), bearer tokens, JWT
 - User building API authentication for third parties
 
 **Load `references/plugins/payments.md` when**:
-- User needs Stripe or Polar integration
+- User needs Stripe (incl. seat-based billing) or Polar integration
 - User building subscription or payment features
+
+**Load `references/plugins/sso.md` when**:
+- User needs production SSO with OIDC, OAuth2, or SAML 2.0
+- User asks about OIDC discovery, SAML SLO, domain verification
+- User needs organization provisioning via SSO
+
+**Load `references/plugins/test-utils.md` when**:
+- User writing integration or E2E tests
+- User needs test factories, OTP capture, or authenticated sessions
+
+### Integration Guides
+
+**Load `references/integrations/electron.md` when**:
+- User building Electron desktop app with Better Auth
+- User needs system browser OAuth, deep links, IPC bridges
 
 ---
 
@@ -536,16 +619,19 @@ export const auth = betterAuth({
 ### References (references/)
 
 - **setup-guide.md** - Complete 8-step setup (D1 → Drizzle → Deploy)
-- **error-catalog.md** - All 12 errors with solutions and prevention checklist
+- **error-catalog.md** - All 15 errors with solutions and prevention checklist
 - **advanced-features.md** - 2FA, organizations, rate limiting, passkeys, magic links, migrations
-- **configuration-guide.md** - Production config, environment variables, CORS, rate limiting
+- **configuration-guide.md** - Production config, dynamic base URL, secret rotation, D1 native
 - **framework-comparison.md** - better-auth vs Clerk vs Auth.js, migration paths, TCO
 - **migration-guide-1.4.0.md** - Upgrading from v1.3.x to v1.4.0+ (ESM, API changes)
+- **migration-guide-1.5.0.md** - Upgrading from v1.4.x to v1.5.0+ (API Key, adapter imports, hooks)
+- **v1.4-features.md** - Background tasks, new OAuth providers, SAML/SSO, CLI
+- **v1.5-features.md** - New CLI, OAuth 2.1 Provider, Electron, i18n, D1 native, secret rotation
+- **v1.6-features.md** - OpenTelemetry, passkey pre-auth, non-blocking scrypt
 - **cloudflare-worker-drizzle.ts** - Complete Worker with Drizzle auth
 - **cloudflare-worker-kysely.ts** - Complete Worker with Kysely auth
 - **database-schema.ts** - Complete better-auth Drizzle schema
 - **react-client-hooks.tsx** - React components with auth hooks
-- **v1.4-features.md** - Background tasks, new OAuth providers, SAML/SSO, CLI
 
 ### Framework References (references/frameworks/)
 - **nextjs.md** - Next.js App/Pages Router integration
@@ -561,10 +647,15 @@ export const auth = betterAuth({
 - **mysql.md** - MySQL and PlanetScale
 
 ### Plugin References (references/plugins/)
-- **authentication.md** - 2FA, passkeys, magic links, email OTP, anonymous
+- **authentication.md** - 2FA, passkeys (incl. pre-auth), magic links, email OTP, anonymous
 - **enterprise.md** - Organizations, SSO, SCIM, admin
-- **api-tokens.md** - API keys, bearer tokens, JWT, OIDC
+- **api-tokens.md** - API keys (incl. org-owned, multi-config), bearer tokens, JWT
 - **payments.md** - Stripe, Polar integrations
+- **sso.md** - Production SSO: OIDC discovery, SAML SLO, domain verification, security
+- **test-utils.md** - Testing helpers: factories, OTP capture, login, Vitest/Playwright
+
+### Integration References (references/integrations/)
+- **electron.md** - Electron desktop auth: system browser OAuth, IPC bridges, deep links
 
 ### Next.js Examples (references/nextjs/)
 - **README.md** - Next.js + PostgreSQL setup guide (not D1)
@@ -605,17 +696,22 @@ export function UserProfile() {
 ## Dependencies
 
 **Required**:
-- `better-auth@^1.4.9` - Core authentication framework (ESM-only)
+- `better-auth@^1.6.0` - Core authentication framework (ESM-only)
 
-**Choose ONE adapter**:
-- `drizzle-orm@^0.44.7` + `drizzle-kit@^0.31.7` (recommended)
+**Choose ONE adapter** (optional with D1 native in v1.5+):
+- `drizzle-orm@^0.44.7` + `drizzle-kit@^0.31.7` (recommended for complex schemas)
 - `kysely@^0.28.8` + `@noxharmonium/kysely-d1@^0.4.0` (alternative)
+- `@better-auth/drizzle-adapter` + `better-auth/minimal` (smallest bundle, v1.5+)
 
 **Optional**:
 - `@cloudflare/workers-types` - TypeScript types for Workers
 - `hono@^4.0.0` - Web framework for routing
-- `@better-auth/passkey` - Passkey plugin (v1.4.0+, separate package)
-- `@better-auth/api-key` - API key auth (v1.4.0+)
+- `@better-auth/passkey` - Passkey/WebAuthn plugin
+- `@better-auth/api-key` - API key auth with org support
+- `@better-auth/sso` - SSO/SAML/OIDC production plugin
+- `@better-auth/electron` - Electron desktop auth
+- `@better-auth/i18n` - Error message translations
+- `@better-auth/oauth-provider` - OAuth 2.1 authorization server
 
 ---
 
@@ -627,7 +723,7 @@ This skill focuses on **Cloudflare Workers + D1**. better-auth also supports:
 
 **Databases** (9 adapters): PostgreSQL, MongoDB, MySQL, Prisma, MS SQL, and others.
 
-**Additional Plugins**: Anonymous auth, Email OTP, JWT, Multi-Session, OIDC Provider, payment integrations (Stripe, Polar).
+**Additional Plugins**: Anonymous auth, Email OTP, JWT, Multi-Session, OAuth 2.1 Provider, Test Utils, SCIM, payment integrations (Stripe, Polar), Device Authorization.
 
 **For non-Cloudflare setups**, load the appropriate framework or database reference file, or consult the official docs: https://better-auth.com/docs
 
@@ -670,18 +766,20 @@ This skill focuses on **Cloudflare Workers + D1**. better-auth also supports:
 ## Complete Setup Checklist
 
 - [ ] Verified ESM support (`"type": "module"` in package.json) - v1.4.0+ required
-- [ ] Installed better-auth@1.4.9+ + Drizzle OR Kysely
+- [ ] Installed better-auth@1.6.0+ (D1 native) or + Drizzle/Kysely
 - [ ] Created D1 database with wrangler
-- [ ] Defined database schema with required tables (user, session, account, verification)
+- [ ] Defined database schema (or using D1 native without schema)
 - [ ] Generated and applied migrations to D1
 - [ ] Set BETTER_AUTH_SECRET environment variable
-- [ ] Configured baseURL in auth config
+- [ ] Configured baseURL in auth config (or dynamic base URL for previews)
 - [ ] Enabled authentication methods (emailAndPassword, socialProviders)
 - [ ] Configured CORS with credentials: true
 - [ ] Set OAuth callback URLs in provider settings
 - [ ] Tested auth routes (/api/auth/*)
 - [ ] Tested sign-in, sign-up, session verification
 - [ ] Using requestPasswordReset (not forgetPassword) - v1.4.0+ API
+- [ ] Using `npx auth` CLI (not `@better-auth/cli`) - v1.5.0+
+- [ ] Using `@better-auth/api-key` (not `better-auth/plugins`) for API keys - v1.5.0+
 - [ ] Deployed to Cloudflare Workers
 
 ---

--- a/plugins/better-auth/skills/better-auth/references/configuration-guide.md
+++ b/plugins/better-auth/skills/better-auth/references/configuration-guide.md
@@ -454,4 +454,4 @@ If upgrading from better-auth v1.3.x, see `migration-guide-1.4.0.md` for:
 
 ---
 
-**Last verified**: 2025-11-27 with better-auth@1.4.3
+**Last verified**: 2026-04-08 with better-auth@1.6.0

--- a/plugins/better-auth/skills/better-auth/references/configuration-guide.md
+++ b/plugins/better-auth/skills/better-auth/references/configuration-guide.md
@@ -1,7 +1,7 @@
 # Better-Auth Configuration Guide
 
-**Last Updated**: 2025-11-27
-**Package**: `better-auth@1.4.3`
+**Last Updated**: 2026-04-08
+**Package**: `better-auth@1.6.0`
 **Requirements**: ESM-only (v1.4.0+)
 
 ---
@@ -26,7 +26,7 @@ This guide provides complete configuration examples for better-auth v1.4.0+ with
     "deploy": "wrangler deploy"
   },
   "dependencies": {
-    "better-auth": "^1.4.3",
+    "better-auth": "^1.6.0",
     "drizzle-orm": "^0.44.7",
     "hono": "^4.0.0"
   }
@@ -297,6 +297,110 @@ export interface Env {
   GITHUB_CLIENT_ID?: string;
   GITHUB_CLIENT_SECRET?: string;
 }
+```
+
+---
+
+## Dynamic Base URL (v1.5+)
+
+Allowlist-based multi-domain support for Vercel previews, reverse proxies, multi-domain setups.
+
+```typescript
+export const auth = betterAuth({
+    baseURL: {
+        allowedHosts: [
+            "myapp.com",
+            "*.vercel.app",
+            "preview-*.myapp.com",
+            "localhost:3000",
+        ],
+        fallback: "https://myapp.com",
+        protocol: "auto",
+    },
+});
+```
+
+`allowedHosts` are automatically added to `trustedOrigins`. Supports wildcard patterns (`*`).
+
+---
+
+## Secret Key Rotation (v1.5+)
+
+Non-destructive rotation without invalidating existing sessions.
+
+```typescript
+export const auth = betterAuth({
+    secrets: [
+        { version: 2, value: "new-secret-key-at-least-32-chars" },
+        { version: 1, value: "old-secret-key-still-used-to-decrypt" },
+    ],
+});
+```
+
+Or via env: `BETTER_AUTH_SECRETS="2:new-secret,1:old-secret"`
+
+---
+
+## Defer Session Refresh (v1.5+)
+
+For read-replica database setups. GET becomes read-only, returns `needsRefresh: true`.
+
+```typescript
+export const auth = betterAuth({
+    session: {
+        deferSessionRefresh: true,
+    },
+});
+```
+
+---
+
+## Verification on Secondary Storage (v1.5+)
+
+Store verification tokens in Redis instead of the database.
+
+```typescript
+export const auth = betterAuth({
+    secondaryStorage: { /* Redis config */ },
+    verification: {
+        storeIdentifier: "hashed",
+        storeInDatabase: false,
+    },
+});
+```
+
+---
+
+## Minimal Bundle (v1.5+)
+
+Use `better-auth/minimal` with extracted adapter packages for smallest bundle:
+
+```typescript
+import { drizzleAdapter } from "@better-auth/drizzle-adapter";
+import { betterAuth } from "better-auth/minimal";
+
+export const auth = betterAuth({
+    database: drizzleAdapter(db, { provider: "pg" }),
+});
+```
+
+---
+
+## D1 Native Support (v1.5+)
+
+Pass D1 binding directly without Drizzle/Kysely:
+
+```typescript
+import { betterAuth } from "better-auth";
+
+export default {
+    async fetch(request, env) {
+        const auth = betterAuth({
+            database: env.DB,
+        });
+        return auth.handler(request);
+    },
+} satisfies ExportedHandler<{ DB: D1Database }>;
 ```
 
 ---

--- a/plugins/better-auth/skills/better-auth/references/integrations/electron.md
+++ b/plugins/better-auth/skills/better-auth/references/integrations/electron.md
@@ -1,0 +1,394 @@
+# better-auth Electron Integration
+
+Full desktop authentication support for Electron apps via system browser OAuth flows.
+
+---
+
+## Installation
+
+```bash
+npm install better-auth @better-auth/electron
+```
+
+Supports two major versions behind the latest stable Electron release.
+
+---
+
+## Server Setup
+
+Add the Electron plugin to the Better Auth server:
+
+```typescript
+import { betterAuth } from "better-auth";
+import { electron } from "@better-auth/electron";
+
+export const auth = betterAuth({
+    plugins: [electron()],
+    emailAndPassword: { enabled: true },
+    social: {
+        google: {
+            clientId: process.env.GOOGLE_CLIENT_ID!,
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+        },
+    },
+});
+```
+
+---
+
+## Web Frontend (Proxy Client)
+
+Handle redirects back into the Electron app:
+
+```typescript
+import { createAuthClient } from "better-auth/client";
+import { electronProxyClient } from "@better-auth/electron/proxy";
+
+export const authClient = createAuthClient({
+    baseURL: "http://localhost:8081",
+    plugins: [
+        electronProxyClient({
+            protocol: { scheme: "com.example.app" },
+        }),
+    ],
+});
+```
+
+### Sign-In Page with Electron Redirect
+
+```typescript
+import { authClient } from "../auth-client";
+
+function SignIn({ searchParams }) {
+    const query = use(searchParams);
+
+    useEffect(() => {
+        const id = authClient.ensureElectronRedirect();
+        return () => clearTimeout(id);
+    }, []);
+
+    return (
+        <button onClick={() =>
+            authClient.signIn.social({
+                provider: "google",
+                fetchOptions: { query },
+            })
+        }>
+            Sign in with Google
+        </button>
+    );
+}
+```
+
+---
+
+## Electron Client Setup
+
+### Main Process Auth Client
+
+```typescript
+import { createAuthClient } from "better-auth/client";
+import { electronClient } from "@better-auth/electron/client";
+
+export const authClient = createAuthClient({
+    baseURL: "http://localhost:8081",
+    plugins: [
+        electronClient({
+            signInURL: "https://app.example.com/sign-in",
+            protocol: { scheme: "com.example.app" },
+            storage: {
+                getItem: async (key) => { /* read from storage */ },
+                setItem: async (key, value) => { /* write to storage */ },
+            },
+        }),
+    ],
+});
+```
+
+### Default Storage (using `conf` package)
+
+```bash
+npm install conf
+```
+
+```typescript
+import { storage } from "@better-auth/electron/storage";
+
+electronClient({
+    storage: storage(),
+});
+```
+
+---
+
+## Protocol and Trusted Origins
+
+Register protocol scheme in build config:
+
+```javascript
+// electron-forge
+module.exports = {
+    packagerConfig: {
+        protocols: [{
+            name: "MyApp Protocol",
+            schemes: ["com.example.app"],
+        }],
+    },
+};
+```
+
+Add to server's `trustedOrigins`:
+
+```typescript
+export const auth = betterAuth({
+    trustedOrigins: ["com.example.app:/"],
+});
+```
+
+---
+
+## BrowserWindow Configuration
+
+```typescript
+import { BrowserWindow } from "electron";
+import { join } from "node:path";
+
+const win = new BrowserWindow({
+    webPreferences: {
+        preload: join(__dirname, "preload.mjs"),
+        nodeIntegration: false,
+        contextIsolation: true,
+    },
+});
+```
+
+For sandbox mode, ensure `@better-auth/electron` is bundled into preload:
+
+```typescript
+// electron.vite.config.ts
+export default defineConfig({
+    preload: {
+        build: {
+            externalizeDeps: {
+                exclude: ["@better-auth/electron"],
+            },
+        },
+    },
+});
+```
+
+---
+
+## Main Process Setup
+
+```typescript
+import { authClient } from "./lib/auth-client";
+
+// Must be called before app is ready
+authClient.setupMain();
+```
+
+Registers protocol handler, user image proxy, content security policies, and IPC bridges.
+
+---
+
+## Renderer Process Setup
+
+### Preload Script
+
+```typescript
+import { setupRenderer } from "@better-auth/electron/preload";
+
+// Must be called before app is ready
+setupRenderer();
+```
+
+### Type Inference
+
+```typescript
+import type { authClient } from "./lib/auth-client";
+
+declare global {
+    type Bridges = typeof authClient.$Infer.Bridges;
+    interface Window extends Bridges {}
+}
+```
+
+---
+
+## Usage in Renderer
+
+### Authentication
+
+```typescript
+function Auth() {
+    useEffect(() => {
+        const unsubAuth = window.onAuthenticated((user) => {
+            console.log("Authenticated:", user);
+        });
+        const unsubError = window.onAuthError((ctx) => {
+            console.error("Auth error:", ctx.message);
+        });
+
+        return () => {
+            unsubAuth();
+            unsubError();
+        };
+    }, []);
+
+    return (
+        <>
+            <button onClick={() => window.requestAuth()}>
+                Sign in with Browser
+            </button>
+            <button onClick={() =>
+                window.requestAuth({ provider: "google" })
+            }>
+                Sign in with Google
+            </button>
+        </>
+    );
+}
+```
+
+### Sign Out
+
+```typescript
+<button onClick={() => window.signOut()}>Sign out</button>;
+```
+
+### User Updates
+
+```typescript
+useEffect(() => {
+    const unsub = window.onUserUpdated((user) => {
+        console.log("User updated:", user);
+    });
+    return () => unsub();
+}, []);
+```
+
+---
+
+## Manual Token Exchange
+
+Fallback for environments where deep links don't work reliably.
+
+### Web Frontend
+
+```typescript
+const authorizationCode = authClient.electron.getAuthorizationCode();
+if (authorizationCode) {
+    // Display code for user to copy
+}
+```
+
+### Electron Renderer
+
+```typescript
+function ManualCodeEntry() {
+    return (
+        <input
+            type="text"
+            placeholder="Paste code here"
+            maxLength={32}
+            onChange={(e) => {
+                if (e.target.value.length === 32) {
+                    // requestAuth() must have been called before
+                    window.authenticate({ token: e.target.value });
+                }
+            }}
+        />
+    );
+}
+```
+
+Authorization code is a short-lived 32-character string.
+
+---
+
+## User Image Proxy
+
+Avatars proxied through `user-image://` protocol to avoid CSP issues:
+
+```typescript
+<img src={user.image} alt="Avatar" />
+```
+
+Configure or disable:
+
+```typescript
+electronClient({
+    userImageProxy: {
+        enabled: true,     // default
+        maxSize: 1024 * 1024 * 5, // 5MB default
+    },
+});
+```
+
+---
+
+## Custom IPC Bridges
+
+### Main Process Handler
+
+```typescript
+import { ipcMain } from "electron";
+
+ipcMain.handle("myBridge", async (_event, data) => {
+    const cookie = authClient.getCookie();
+    return await authClient.someEndpoint({
+        data,
+        fetchOptions: { headers: { cookie } },
+    });
+});
+```
+
+### Preload Bridge
+
+```typescript
+import { contextBridge, ipcRenderer } from "electron";
+
+contextBridge.exposeInMainWorld("myBridge", (data: Record<string, any>) => {
+    return ipcRenderer.invoke("myBridge", data);
+});
+```
+
+### Type Extension
+
+```typescript
+declare global {
+    type Bridges = typeof authClient.$Infer.Bridges;
+    interface Window extends Bridges {
+        myBridge: (data: Record<string, any>) => Promise<any>;
+    }
+}
+```
+
+---
+
+## Server Plugin Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `codeExpiresIn` | `300` | Authorization code validity (seconds) |
+| `redirectCookieExpiresIn` | `120` | Redirect cookie validity (seconds) |
+| `cookiePrefix` | `"better-auth"` | Cookie name prefix |
+| `clientID` | `"electron"` | Client identifier |
+| `disableOriginOverride` | `false` | Override origin for Electron API routes |
+
+## Client Plugin Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `signInURL` | Required | URL for authentication page |
+| `protocol` | Required | Deep link protocol scheme |
+| `callbackPath` | `"/auth/callback"` | Auth redirect path |
+| `storage` | File-based | Storage implementation |
+| `storagePrefix` | `"better-auth"` | Storage key prefix |
+| `cookiePrefix` | `"better-auth"` | Server cookie name filter |
+| `channelPrefix` | `"better-auth"` | IPC channel prefix |
+| `clientID` | `"electron"` | Client identifier |
+| `sanitizeUser` | None | Strip sensitive fields before sending to renderer |
+| `userImageProxy` | `{ enabled: true, maxSize: 5MB }` | Avatar proxy config |
+| `disableCache` | `false` | Disable local session caching |

--- a/plugins/better-auth/skills/better-auth/references/migration-guide-1.5.0.md
+++ b/plugins/better-auth/skills/better-auth/references/migration-guide-1.5.0.md
@@ -1,0 +1,243 @@
+# Migration Guide: better-auth v1.4.x → v1.5.0
+
+Breaking changes and migration steps for upgrading to v1.5.0.
+
+---
+
+## Quick Upgrade
+
+```bash
+npx auth upgrade
+```
+
+Review all changes below before deploying.
+
+---
+
+## Breaking Changes
+
+### 1. Deprecated API Removals
+
+All previously `@deprecated` APIs have been removed:
+
+| Removed | Replacement |
+|---------|-------------|
+| `Adapter` | `DBAdapter` |
+| `TransactionAdapter` | `DBTransactionAdapter` |
+| `Store` (client) | `ClientStore` |
+| `AtomListener` (client) | `ClientAtomListener` |
+| `ClientOptions` | `BetterAuthClientOptions` |
+| `LiteralUnion`, `DeepPartial` | Import from `@better-auth/core` |
+| `onEmailVerification` | `afterEmailVerification` |
+| `sendChangeEmailVerification` | `sendChangeEmailConfirmation` |
+| `advanced.database.useNumberId` | `advanced.database.generateId: "serial"` |
+| Organization `permission` field | `permissions` (plural) |
+
+### 2. `/forget-password/email-otp` Removed
+
+Use the standard password reset flow instead.
+
+### 3. Adapter Import Change
+
+```typescript
+// OLD
+import { testAdapter, createTestSuite } from "better-auth/adapters/test";
+
+// NEW
+import { testAdapter, createTestSuite } from "@better-auth/test-utils/adapter";
+```
+
+### 4. API Key Plugin Moved to `@better-auth/api-key`
+
+Install separately:
+
+```bash
+npm install @better-auth/api-key
+```
+
+Update imports:
+
+```typescript
+// Server
+- import { apiKey } from "better-auth/plugins";
++ import { apiKey } from "@better-auth/api-key";
+
+// Client
+- import { apiKeyClient } from "better-auth/client/plugins";
++ import { apiKeyClient } from "@better-auth/api-key/client";
+```
+
+#### Schema Changes
+
+- `userId` field on `ApiKey` table renamed to `referenceId`
+- New `configId` field added (defaults to `"default"`)
+
+Run migrations after upgrading:
+
+```bash
+npx auth migrate
+```
+
+#### Plugin Options Changes
+
+`permissions.defaultPermissions` callback first argument renamed:
+
+```typescript
+apiKey({
+    permissions: {
+-       defaultPermissions: async (userId, ctx) => {
++       defaultPermissions: async (referenceId, ctx) => {
+            return { files: ["read"] };
+        },
+    },
+});
+```
+
+#### Client SDK Changes
+
+```typescript
+- const ownerId = apiKey.userId;
++ const ownerId = apiKey.referenceId;
++ const ownerType = apiKey.references; // "user" or "organization"
++ const configId = apiKey.configId;
+```
+
+#### Permission Changes
+
+`updateApiKey` now requires a `userId` parameter or headers on the server side.
+
+### 5. After Hooks Run Post-Transaction
+
+Database "after" hooks (`create.after`, `update.after`, `delete.after`) now execute **after** the transaction commits, not during it.
+
+If your plugin relies on after hooks for additional atomic database writes inside the transaction, use the adapter directly within the main operation instead.
+
+### 6. `getMigrations` Import Path Changed
+
+```typescript
+- import { getMigrations } from "better-auth";
++ import { getMigrations } from "better-auth/db/migration";
+```
+
+This reduces bundle size by avoiding unnecessary third-party dependencies.
+
+### 7. `$ERROR_CODES` Type Changed
+
+```typescript
+// OLD
+$ERROR_CODES: {
+    MY_ERROR: "My error message",
+}
+
+// NEW - use defineErrorCodes()
+$ERROR_CODES: defineErrorCodes({
+    MY_ERROR: "My error message",
+}),
+// Returns: { MY_ERROR: { code: "MY_ERROR", message: "My error message" } }
+```
+
+Use `APIError.from()` to throw errors with codes:
+
+```typescript
+import { APIError } from "@better-auth/core/error";
+throw APIError.from("BAD_REQUEST", MY_ERROR_CODES.MY_ERROR);
+```
+
+### 8. `InferUser` / `InferSession` Removed
+
+```typescript
+- import type { InferUser, InferSession } from "better-auth/types";
+- type MyUser = InferUser<typeof auth>;
+
++ import type { User, Session } from "better-auth";
++ type MyUser = User<typeof auth.$options["user"], typeof auth.$options["plugins"]>;
+```
+
+### 9. `@better-auth/core/utils` Barrel Split
+
+```typescript
+- import { generateId, safeJSONParse, defineErrorCodes } from "@better-auth/core/utils";
+
++ import { generateId } from "@better-auth/core/utils/id";
++ import { safeJSONParse } from "@better-auth/core/utils/json";
++ import { defineErrorCodes } from "@better-auth/core/utils/error-codes";
+```
+
+### 10. `PluginContext` Now Generic
+
+```typescript
+type PluginContext<Options extends BetterAuthOptions> = {
+    getPlugin: <ID extends string>(pluginId: ID) => /* inferred */ | null;
+    hasPlugin: <ID extends string>(pluginId: ID) => boolean;
+};
+```
+
+Register via module augmentation:
+
+```typescript
+declare module "@better-auth/core" {
+    interface BetterAuthPluginRegistry<AuthOptions, Options> {
+        "my-plugin": { creator: typeof myPlugin };
+    }
+}
+```
+
+### 11. `id` Field Removed from Session in Secondary Storage
+
+If your plugin reads sessions from secondary storage and relies on the `id` field, update your code.
+
+### 12. Plugin `init()` Context Now Mutable
+
+The context passed to `init()` is the same reference used throughout the auth lifecycle. `init()` can return arbitrary keys via `Record<string, unknown>`.
+
+---
+
+## v1.6.0 Additional Breaking Changes
+
+### `freshAge` Now Uses `createdAt`
+
+```typescript
+// Session freshness is now based on createdAt, not updatedAt
+export const auth = betterAuth({
+    session: {
+        freshAge: 60 * 5, // 5 minutes from session CREATION
+    },
+});
+```
+
+Sensitive operations may require re-authentication more frequently. Set `freshAge: 0` to disable.
+
+### InResponseTo Validation Default ON for SAML
+
+```typescript
+import { sso } from "@better-auth/sso";
+
+// To opt out:
+sso({
+    saml: {
+        enableInResponseToValidation: false,
+    },
+});
+```
+
+### OIDC Provider Plugin Deprecated
+
+Use `@better-auth/oauth-provider` instead. Will be removed in next minor version.
+
+---
+
+## Upgrade Checklist
+
+- [ ] Run `npx auth upgrade`
+- [ ] Search codebase for removed APIs (table above) and replace
+- [ ] Install `@better-auth/api-key` if using API key plugin
+- [ ] Update API key imports and schema (`userId` → `referenceId`)
+- [ ] Update `getMigrations` import path
+- [ ] Update `$ERROR_CODES` to use `defineErrorCodes()`
+- [ ] Replace `InferUser`/`InferSession` with generic `User`/`Session` types
+- [ ] Split `@better-auth/core/utils` imports
+- [ ] Review after hooks that depend on transaction context
+- [ ] Run `npx auth migrate` for schema changes
+- [ ] Test SAML flows (InResponseTo now validated by default)
+- [ ] Review session freshness behavior (`createdAt` based)
+- [ ] Migrate OIDC Provider → OAuth 2.1 Provider

--- a/plugins/better-auth/skills/better-auth/references/plugins/api-tokens.md
+++ b/plugins/better-auth/skills/better-auth/references/plugins/api-tokens.md
@@ -6,25 +6,27 @@ Complete guide for API authentication: API Keys, Bearer Tokens, JWT, and OIDC Pr
 
 ## API Key Plugin
 
+Extracted to `@better-auth/api-key` in v1.5.0. Install separately:
+
+```bash
+npm install @better-auth/api-key
+```
+
 ### Server Configuration
 
 ```typescript
 import { betterAuth } from "better-auth";
-import { apiKey } from "better-auth/plugins";
+import { apiKey } from "@better-auth/api-key";
 
 export const auth = betterAuth({
   plugins: [
     apiKey({
-      // API key prefix (optional)
       prefix: "sk_",
-      // Key length in bytes
       keyLength: 32,
-      // Hash algorithm for storing keys
       hashAlgorithm: "sha256",
-      // Rate limiting per key
       rateLimit: {
-        window: 60 * 1000,  // 1 minute
-        max: 100,           // 100 requests per window
+        window: 60 * 1000,
+        max: 100,
       },
     }),
   ],
@@ -34,7 +36,7 @@ export const auth = betterAuth({
 ### Client Configuration
 
 ```typescript
-import { apiKeyClient } from "better-auth/client/plugins";
+import { apiKeyClient } from "@better-auth/api-key/client";
 
 const authClient = createAuthClient({
   plugins: [apiKeyClient()],
@@ -44,10 +46,9 @@ const authClient = createAuthClient({
 ### Create API Key
 
 ```typescript
-// Create key with optional metadata
 const { data: key } = await authClient.apiKey.create({
   name: "Production API Key",
-  expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),  // 1 year
+  expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
   metadata: {
     environment: "production",
     permissions: ["read", "write"],
@@ -56,6 +57,41 @@ const { data: key } = await authClient.apiKey.create({
 
 // IMPORTANT: key.key is only shown once!
 console.log(key.key);  // sk_abc123...
+```
+
+### Organization-Owned API Keys (v1.5+)
+
+```typescript
+import { apiKey } from "@better-auth/api-key";
+
+export const auth = betterAuth({
+  plugins: [
+    apiKey({ references: "organization" }),
+  ],
+});
+
+// Create org-owned key
+const apiKey = await auth.api.createApiKey({
+  body: { organizationId: "org_123" },
+});
+```
+
+### Multiple Configurations (v1.5+)
+
+```typescript
+export const auth = betterAuth({
+  plugins: [
+    apiKey([
+      { configId: "user-keys", prefix: "usr_" },
+      { configId: "org-keys", prefix: "org_", references: "organization" },
+    ]),
+  ],
+});
+
+// Create key for specific config
+const key = auth.api.createApiKey({
+  body: { configId: "user-keys" },
+});
 ```
 
 ### List API Keys

--- a/plugins/better-auth/skills/better-auth/references/plugins/api-tokens.md
+++ b/plugins/better-auth/skills/better-auth/references/plugins/api-tokens.md
@@ -384,7 +384,8 @@ oidcProvider({
 
 ```typescript
 import { betterAuth } from "better-auth";
-import { apiKey, bearer, jwt, oidcProvider } from "better-auth/plugins";
+import { apiKey } from "@better-auth/api-key";
+import { bearer, jwt, oidcProvider } from "better-auth/plugins";
 
 export const auth = betterAuth({
   plugins: [

--- a/plugins/better-auth/skills/better-auth/references/plugins/authentication.md
+++ b/plugins/better-auth/skills/better-auth/references/plugins/authentication.md
@@ -226,7 +226,11 @@ Add `webauthn` to input `autocomplete` attribute:
 
 ```typescript
 useEffect(() => {
-  if (!PublicKeyCredential.isConditionalMediationAvailable) return;
+  if (
+    !PublicKeyCredential.isConditionalMediationAvailable ||
+    !PublicKeyCredential.isConditionalMediationAvailable()
+  )
+    return;
   authClient.signIn.passkey({ autoFill: true });
 }, []);
 ```
@@ -397,9 +401,9 @@ if (session?.user.isAnonymous) {
 
 ```typescript
 import { betterAuth } from "better-auth";
+import { passkey } from "@better-auth/passkey";
 import {
   twoFactor,
-  passkey,
   magicLink,
   emailOTP,
   anonymous

--- a/plugins/better-auth/skills/better-auth/references/plugins/authentication.md
+++ b/plugins/better-auth/skills/better-auth/references/plugins/authentication.md
@@ -104,21 +104,23 @@ await authClient.twoFactor.disable({
 
 ### Installation
 
+Passkey plugin is a separate package since v1.4.0:
+
 ```bash
-bun add better-auth @simplewebauthn/browser @simplewebauthn/server
+bun add @better-auth/passkey
 ```
 
 ### Server Configuration
 
 ```typescript
 import { betterAuth } from "better-auth";
-import { passkey } from "better-auth/plugins";
+import { passkey } from "@better-auth/passkey";
 
 export const auth = betterAuth({
   plugins: [
     passkey({
-      rpID: "your-domain.com",  // Relying Party ID
-      rpName: "Your App",       // Display name
+      rpID: "your-domain.com",
+      rpName: "Your App",
       origin: "https://your-domain.com",
     }),
   ],
@@ -129,7 +131,7 @@ export const auth = betterAuth({
 
 ```typescript
 import { createAuthClient } from "better-auth/react";
-import { passkeyClient } from "better-auth/client/plugins";
+import { passkeyClient } from "@better-auth/passkey/client";
 
 export const authClient = createAuthClient({
   plugins: [passkeyClient()],
@@ -139,42 +141,94 @@ export const authClient = createAuthClient({
 ### Register Passkey
 
 ```typescript
-// Add passkey to existing account
 await authClient.passkey.addPasskey({
-  name: "MacBook Pro Touch ID",  // User-friendly name
+  name: "MacBook Pro Touch ID",
+  authenticatorAttachment: "platform",  // or "cross-platform"
 });
-// Browser will prompt for biometric/PIN
 ```
 
 ### Sign In with Passkey
 
 ```typescript
-// Passwordless sign-in
-const result = await authClient.signIn.passkey();
-// Browser will prompt for biometric/PIN
+const result = await authClient.signIn.passkey({
+  autoFill: true,  // Enable conditional UI
+});
+```
+
+### Pre-Auth Registration (v1.6+)
+
+Register passkeys before the user has a session — enables passkey-first onboarding:
+
+```typescript
+import { passkey } from "@better-auth/passkey";
+
+export const auth = betterAuth({
+  plugins: [
+    passkey({
+      registration: {
+        requireSession: false,
+        resolveUser: async ({ ctx, context }) => {
+          // Validate context, then create or load user
+          return { id: "user-id", name: "user@example.com" };
+        },
+        extensions: { credProps: true },
+      },
+    }),
+  ],
+});
+```
+
+Client:
+
+```typescript
+// Generate options with context
+await auth.api.generatePasskeyRegistrationOptions({
+  context: "signed-registration-token",
+});
+
+// Register with same context
+await authClient.passkey.addPasskey({
+  name: "Primary passkey",
+  context: "signed-registration-token",
+});
+```
+
+### WebAuthn Extensions (v1.6+)
+
+Pass extensions on registration and authentication:
+
+```typescript
+const result = await authClient.passkey.addPasskey({
+  name: "My Passkey",
+  extensions: { credProps: true },
+  returnWebAuthnResponse: true,
+});
+console.log(result.webauthn?.clientExtensionResults);
+```
+
+### List/Remove/Update Passkeys
+
+```typescript
+const { data: passkeys } = await authClient.passkey.listUserPasskeys();
+
+await authClient.passkey.deletePasskey({ id: "passkey-id" });
+
+await authClient.passkey.updatePasskey({ id: "passkey-id", name: "New Name" });
 ```
 
 ### Conditional UI (Autofill)
 
-```typescript
-// Enable passkey autofill in login form
-useEffect(() => {
-  authClient.passkey.signIn({
-    autoFill: true,
-  });
-}, []);
+Add `webauthn` to input `autocomplete` attribute:
+
+```html
+<input type="text" autocomplete="username webauthn">
 ```
 
-### List/Remove Passkeys
-
 ```typescript
-// List user's passkeys
-const { data: passkeys } = await authClient.passkey.listPasskeys();
-
-// Remove a passkey
-await authClient.passkey.deletePasskey({
-  passkeyId: "passkey-id",
-});
+useEffect(() => {
+  if (!PublicKeyCredential.isConditionalMediationAvailable) return;
+  authClient.signIn.passkey({ autoFill: true });
+}, []);
 ```
 
 ---

--- a/plugins/better-auth/skills/better-auth/references/plugins/enterprise.md
+++ b/plugins/better-auth/skills/better-auth/references/plugins/enterprise.md
@@ -360,12 +360,13 @@ await authClient.admin.revokeAllSessions({
 
 ```typescript
 import { betterAuth } from "better-auth";
-import { organization, sso, scim, admin } from "better-auth/plugins";
+import { organization, scim, admin } from "better-auth/plugins";
+import { sso } from "@better-auth/sso";
 
 export const auth = betterAuth({
   plugins: [
     organization({
-      allowUserToCreateOrganization: false,  // Admin-only
+      allowUserToCreateOrganization: false,
       roles: {
         owner: ["*"],
         admin: ["invite", "remove", "update", "manage-sso"],
@@ -374,9 +375,9 @@ export const auth = betterAuth({
     }),
     sso({
       saml: {
-        issuer: "https://your-app.com",
-        callbackURL: "/api/auth/sso/callback",
-        clockSkewTolerance: 60,
+        enableSingleLogout: true,
+        enableInResponseToValidation: true,
+        clockSkew: 60 * 1000,
       },
     }),
     scim({
@@ -403,7 +404,7 @@ export const auth = betterAuth({
 - Check signature algorithm matches IdP configuration
 
 ### SSO: "Clock skew error" (v1.4.7+)
-- Use `clockSkewTolerance` option to allow for time drift
+- Use `clockSkew` option to allow for time drift (measured in milliseconds)
 - Ensure server time is synced (NTP)
 
 ### SCIM: "401 Unauthorized"

--- a/plugins/better-auth/skills/better-auth/references/plugins/enterprise.md
+++ b/plugins/better-auth/skills/better-auth/references/plugins/enterprise.md
@@ -128,73 +128,73 @@ const canInvite = auth.api.hasPermission({
 
 ## SSO / SAML
 
+SSO is now a separate package (`@better-auth/sso`) with production-ready security hardening.
+
+> **Load `references/plugins/sso.md`** for the complete SSO guide including OIDC discovery, SAML SLO, domain verification, organization provisioning, and security configuration.
+
 ### Server Configuration
 
 ```typescript
 import { betterAuth } from "better-auth";
-import { sso } from "better-auth/plugins";
+import { sso } from "@better-auth/sso";
 
 export const auth = betterAuth({
   plugins: [
     sso({
-      // Enable SAML
       saml: {
-        // Your app as Service Provider (SP)
-        issuer: "https://your-app.com",
-        // Callback URL
-        callbackURL: "/api/auth/sso/callback",
-        // SAML response handling
-        signatureAlgorithm: "sha256",
+        enableSingleLogout: true,
+        enableInResponseToValidation: true,  // default ON in v1.6+
+        clockSkew: 60 * 1000,
       },
     }),
   ],
 });
 ```
 
-### Configure Identity Provider
+### Client Configuration
 
 ```typescript
-// Add a SAML IdP (Okta, Azure AD, etc.)
-await auth.api.sso.addProvider({
-  provider: "saml",
-  name: "Okta SSO",
-  issuer: "https://your-okta-domain.okta.com",
-  ssoUrl: "https://your-okta-domain.okta.com/app/.../sso/saml",
-  certificate: `-----BEGIN CERTIFICATE-----
-MIIDpDCCAoygAwIBAgIGAX...
------END CERTIFICATE-----`,
-  // Map SAML attributes to user fields
-  attributeMapping: {
-    email: "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
-    name: "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+import { ssoClient } from "@better-auth/sso/client";
+
+const authClient = createAuthClient({
+  plugins: [ssoClient()],
+});
+```
+
+### Register Provider
+
+```typescript
+await authClient.sso.register({
+  providerId: "okta",
+  issuer: "https://your-org.okta.com",
+  domain: "yourcompany.com",
+  oidcConfig: {
+    clientId: "your-client-id",
+    clientSecret: "your-client-secret",
   },
 });
 ```
 
-### v1.4.7+ SAML Features
+### Sign In with SSO
 
 ```typescript
-sso({
-  saml: {
-    // Clock skew tolerance for timestamp validation
-    clockSkewTolerance: 60,  // seconds (default: 0)
-    // Validate InResponseTo attribute
-    validateInResponseTo: true,
-    // OIDC discovery for automatic configuration
-    oidcDiscovery: true,
-  },
-}),
-```
-
-### Initiate SSO Login
-
-```typescript
-// Redirect to IdP
 await authClient.signIn.sso({
-  provider: "saml",
-  organizationSlug: "acme-corp",  // If organization-specific
+  email: "user@example.com",
+  callbackURL: "/dashboard",
 });
 ```
+
+### Key SSO Features (v1.5+)
+
+- **SAML Single Logout** (SP-initiated and IdP-initiated)
+- **Signed AuthnRequests** with configurable algorithms
+- **OIDC Discovery** — auto-fetch endpoints from `/.well-known/openid-configuration`
+- **Domain Verification** — DNS-based automatic trust
+- **Organization Provisioning** — auto-membership with role assignment
+- **Provider CRUD** — list, get, update, delete via API
+- **InResponseTo validation** — replay attack prevention (default ON in v1.6+)
+- **Algorithm validation** — warn/reject deprecated crypto
+- **Size limits** — configurable max SAML response/metadata size
 
 ---
 

--- a/plugins/better-auth/skills/better-auth/references/plugins/sso.md
+++ b/plugins/better-auth/skills/better-auth/references/plugins/sso.md
@@ -1,0 +1,432 @@
+# better-auth SSO Plugin (`@better-auth/sso`)
+
+Single Sign-On with OIDC, OAuth2, and SAML 2.0 support. Production-ready with comprehensive security features.
+
+---
+
+## Installation
+
+```bash
+npm install @better-auth/sso
+```
+
+### Server Setup
+
+```typescript
+import { sso } from "@better-auth/sso";
+
+export const auth = betterAuth({
+    plugins: [sso()],
+});
+```
+
+### Client Setup
+
+```typescript
+import { ssoClient } from "@better-auth/sso/client";
+
+const authClient = createAuthClient({
+    plugins: [ssoClient()],
+});
+```
+
+Run `npx auth migrate` after setup.
+
+---
+
+## OIDC Provider Registration
+
+```typescript
+await authClient.sso.register({
+    providerId: "okta",
+    issuer: "https://your-org.okta.com",
+    domain: "yourcompany.com",
+    oidcConfig: {
+        clientId: "your-client-id",
+        clientSecret: "your-client-secret",
+    },
+});
+```
+
+### OIDC Discovery
+
+Better Auth automatically fetches the discovery document from `{issuer}/.well-known/openid-configuration`. Most endpoint fields become optional — only `clientId` and `clientSecret` are required.
+
+Auto-discovered fields: `authorizationEndpoint`, `tokenEndpoint`, `jwksEndpoint`, `userInfoEndpoint`, `discoveryEndpoint`, `tokenEndpointAuthentication`.
+
+### Discovery Errors
+
+| Code | Meaning |
+|------|---------|
+| `issuer_mismatch` | IdP reports different issuer |
+| `discovery_incomplete` | Required fields missing |
+| `discovery_not_found` | Discovery endpoint returned 404 |
+| `discovery_timeout` | IdP did not respond (default: 10s) |
+| `discovery_invalid_url` | Malformed URL |
+| `discovery_untrusted_origin` | URL not in `trustedOrigins` |
+| `discovery_invalid_json` | Empty or invalid JSON response |
+| `unsupported_token_auth_method` | Only unsupported auth methods advertised |
+
+### Trusted Origins
+
+Discovery URLs must be in `trustedOrigins`:
+
+```typescript
+export const auth = betterAuth({
+    trustedOrigins: [
+        "https://your-org.okta.com",
+        "https://accounts.google.com",
+    ],
+});
+
+// Or dynamically
+trustedOrigins: async (request) => {
+    if (!request) return ["https://my-frontend.com"];
+    if (request.url.endsWith("/sso/register")) {
+        return await fetchOriginList();
+    }
+    return [];
+},
+```
+
+---
+
+## SAML Provider Registration
+
+```typescript
+await authClient.sso.register({
+    providerId: "saml-provider",
+    issuer: "https://idp.example.com",
+    domain: "example.com",
+    samlConfig: {
+        entryPoint: "https://idp.example.com/sso",
+        cert: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+        callbackUrl: "https://yourapp.com/api/auth/sso/saml2/callback/saml-provider",
+        audience: "https://yourapp.com",
+        wantAssertionsSigned: true,
+        signatureAlgorithm: "sha256",
+        digestAlgorithm: "sha256",
+        mapping: {
+            id: "nameID",
+            email: "email",
+            name: "displayName",
+            firstName: "givenName",
+            lastName: "surname",
+        },
+    },
+});
+```
+
+### Get SP Metadata
+
+```typescript
+const response = await auth.api.spMetadata({
+    query: {
+        providerId: "saml-provider",
+        format: "xml", // or "json"
+    },
+});
+```
+
+### Signed AuthnRequests
+
+```typescript
+samlConfig: {
+    authnRequestsSigned: true,
+    spMetadata: {
+        privateKey: "-----BEGIN RSA PRIVATE KEY-----\n...",
+    },
+},
+```
+
+---
+
+## Sign In with SSO
+
+```typescript
+// By email domain
+await authClient.signIn.sso({
+    email: "user@example.com",
+    callbackURL: "/dashboard",
+});
+
+// By domain
+await authClient.signIn.sso({
+    domain: "example.com",
+    callbackURL: "/dashboard",
+});
+
+// By organization slug
+await authClient.signIn.sso({
+    organizationSlug: "example-org",
+    callbackURL: "/dashboard",
+});
+
+// By provider ID
+await authClient.signIn.sso({
+    providerId: "example-provider-id",
+    callbackURL: "/dashboard",
+});
+
+// With login hint
+await authClient.signIn.sso({
+    providerId: "example-provider-id",
+    loginHint: "user@example.com",
+    callbackURL: "/dashboard",
+});
+```
+
+---
+
+## User Provisioning
+
+Run custom logic when users sign in through SSO.
+
+```typescript
+sso({
+    provisionUser: async ({ user, userInfo, token, provider }) => {
+        await updateUserProfile(user.id, {
+            department: userInfo.attributes?.department,
+        });
+    },
+    provisionUserOnEveryLogin: true,
+});
+```
+
+`provisionUser` receives: `user`, `userInfo`, `token` (OIDC only), `provider`.
+
+---
+
+## Organization Provisioning
+
+Automatically manage org memberships when SSO providers are linked to organizations.
+
+```typescript
+sso({
+    organizationProvisioning: {
+        disabled: false,
+        defaultRole: "member",
+        getRole: async ({ user, userInfo, provider }) => {
+            if (userInfo.attributes?.jobTitle?.toLowerCase().includes("manager")) {
+                return "admin";
+            }
+            return "member";
+        },
+    },
+});
+```
+
+Link provider to organization during registration:
+
+```typescript
+await auth.api.registerSSOProvider({
+    body: {
+        providerId: "acme-corp-saml",
+        issuer: "https://acme.okta.com",
+        domain: "acmecorp.com",
+        organizationId: "org_acme_id",
+        samlConfig: { /* ... */ },
+    },
+    headers: await headers(),
+});
+```
+
+---
+
+## SAML Single Logout (SLO)
+
+```typescript
+sso({
+    saml: {
+        enableSingleLogout: true,
+        wantLogoutRequestSigned: true,
+        wantLogoutResponseSigned: true,
+    },
+});
+```
+
+Supports both SP-initiated and IdP-initiated SLO.
+
+---
+
+## SAML Security
+
+### InResponseTo Validation
+
+Enabled by default in v1.6.0+. Prevents replay attacks on SP-initiated flows.
+
+```typescript
+sso({
+    saml: {
+        enableInResponseToValidation: true,  // default in v1.6+
+        allowIdpInitiated: false,            // reject IdP-initiated
+        requestTTL: 10 * 60 * 1000,          // 10 minutes
+    },
+});
+```
+
+Error redirects:
+- `?error=invalid_saml_response` — Unknown or expired request ID
+- `?error=invalid_saml_response` — Provider mismatch
+- `?error=unsolicited_response` — IdP-initiated not allowed
+
+### Assertion Replay Protection
+
+Always enabled. Each Assertion ID is tracked and rejected if reused. Uses database verification table (works in multi-instance deployments).
+
+Error: `?error=replay_detected`
+
+### Timestamp Validation
+
+```typescript
+sso({
+    saml: {
+        clockSkew: 5 * 60 * 1000,     // 5 minutes tolerance (default)
+        requireTimestamps: true,       // Reject without timestamps (SAML2Int)
+    },
+});
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `clockSkew` | `300000` (5 min) | Clock skew tolerance in ms |
+| `requireTimestamps` | `false` | Reject assertions without timestamps |
+
+### Algorithm Validation
+
+```typescript
+sso({
+    saml: {
+        algorithms: {
+            onDeprecated: "warn", // "warn" | "reject" | "allow"
+        },
+    },
+});
+```
+
+Deprecated algorithms: RSA-SHA1, SHA1, RSA 1.5, 3DES.
+
+Supported: RSA-SHA256/384/512, ECDSA-SHA256/384/512, SHA256/384/512.
+
+### Size Limits
+
+```typescript
+sso({
+    saml: {
+        maxResponseSize: 512 * 1024, // 512KB (default: 256KB)
+        maxMetadataSize: 100 * 1024, // 100KB
+    },
+});
+```
+
+---
+
+## Domain Verification
+
+Automatically trust SSO providers by validating domain ownership via DNS.
+
+```typescript
+// Server
+sso({ domainVerification: { enabled: true } });
+
+// Client
+ssoClient({ domainVerification: { enabled: true } });
+```
+
+Run `npx auth migrate` after enabling.
+
+### Verification Steps
+
+1. Register provider → receive verification token
+2. Create DNS TXT record: `_better-auth-token-{providerId}` → token value
+3. Submit verification:
+
+```typescript
+await authClient.sso.verifyDomain({ providerId: "acme-corp" });
+```
+
+Tokens expire after 1 week. Request new token:
+
+```typescript
+await authClient.sso.requestDomainVerification({ providerId: "acme-corp" });
+```
+
+Verified domains are trusted for automatic account linking.
+
+---
+
+## Shared Redirect URI
+
+All OIDC providers share a single callback URL:
+
+```typescript
+sso({ redirectURI: "/sso/callback" });
+```
+
+Per-provider endpoints still work for backward compatibility.
+
+---
+
+## SAML Endpoints
+
+- **SP Metadata**: `/api/auth/sso/saml2/sp/metadata?providerId={providerId}`
+- **SAML Callback**: `/api/auth/sso/saml2/callback/{providerId}` (GET + POST)
+
+### IdP-Initiated SSO (Next.js)
+
+Create a route handler to prevent 404:
+
+```typescript
+// app/api/auth/sso/saml2/callback/[providerId]/route.ts
+import { auth } from "@/lib/auth";
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+    return auth.handler(req);
+}
+
+export async function GET(req: Request) {
+    return NextResponse.redirect(new URL("/", req.url));
+}
+```
+
+---
+
+## Default SSO Provider
+
+Configure provider at auth setup time (no database registration needed):
+
+```typescript
+sso({
+    defaultSSO: [{
+        providerId: "default-saml",
+        domain: "http://your-app.com",
+        samlConfig: {
+            issuer: "https://your-app.com",
+            entryPoint: "https://idp.example.com/sso",
+            cert: "-----BEGIN CERTIFICATE-----\n...",
+            callbackUrl: "http://localhost:3000/api/auth/sso/saml2/sp/acs",
+        },
+    }],
+});
+```
+
+Used when no matching provider is found in the database.
+
+---
+
+## SAML Attribute Mapping
+
+```typescript
+mapping: {
+    id: "nameID",           // default: "nameID"
+    email: "email",         // default: "email" or "nameID"
+    name: "displayName",    // default: "displayName"
+    firstName: "givenName", // default: "givenName"
+    lastName: "surname",    // default: "surname"
+    extraFields: {
+        department: "department",
+        role: "jobTitle",
+    },
+},
+```

--- a/plugins/better-auth/skills/better-auth/references/plugins/test-utils.md
+++ b/plugins/better-auth/skills/better-auth/references/plugins/test-utils.md
@@ -1,0 +1,278 @@
+# better-auth Test Utilities Plugin
+
+Testing helpers for integration and E2E testing. Do not use in production.
+
+---
+
+## Setup
+
+### Server Plugin
+
+```typescript
+import { testUtils } from "better-auth/plugins";
+
+export const auth = betterAuth({
+    plugins: [testUtils({ captureOTP: true })],
+});
+```
+
+### Access Test Helpers
+
+```typescript
+const ctx = await auth.$context;
+const test = ctx.test;
+```
+
+---
+
+## Factories
+
+Create objects without persisting to database.
+
+### createUser
+
+```typescript
+// With defaults
+const user = test.createUser();
+// { id: "...", email: "user-xxx@example.com", name: "Test User", emailVerified: true }
+
+// With overrides
+const user = test.createUser({
+    email: "alice@example.com",
+    name: "Alice",
+    emailVerified: false,
+});
+```
+
+### createOrganization
+
+Requires organization plugin.
+
+```typescript
+const org = test.createOrganization({
+    name: "Acme Corp",
+    slug: "acme-corp",
+});
+```
+
+---
+
+## Database Helpers
+
+Persist and remove test data.
+
+### saveUser / deleteUser
+
+```typescript
+const user = test.createUser({ email: "test@example.com" });
+const savedUser = await test.saveUser(user);
+
+await test.deleteUser(user.id);
+```
+
+### saveOrganization / deleteOrganization
+
+Requires organization plugin.
+
+```typescript
+const org = test.createOrganization({ name: "Test Org" });
+const savedOrg = await test.saveOrganization(org);
+
+await test.deleteOrganization(org.id);
+```
+
+### addMember
+
+```typescript
+const member = await test.addMember({
+    userId: user.id,
+    organizationId: org.id,
+    role: "admin",
+});
+```
+
+---
+
+## Auth Helpers
+
+Create authenticated sessions for testing protected routes.
+
+### login
+
+Creates a session and returns all auth data:
+
+```typescript
+const { session, user, headers, cookies, token } = await test.login({
+    userId: user.id,
+});
+```
+
+- `session` - Session object with userId, token, etc.
+- `user` - User object
+- `headers` - Headers with session cookie (for fetch/Request)
+- `cookies` - Cookie array (for Playwright/Puppeteer)
+- `token` - Session token string
+
+### getAuthHeaders
+
+```typescript
+const headers = await test.getAuthHeaders({ userId: user.id });
+const session = await auth.api.getSession({ headers });
+const response = await fetch("/api/protected", { headers });
+```
+
+### getCookies
+
+Browser testing tool compatible (Playwright, Puppeteer):
+
+```typescript
+const cookies = await test.getCookies({
+    userId: user.id,
+    domain: "localhost",
+});
+
+// Playwright
+await context.addCookies(cookies);
+
+// Puppeteer
+for (const cookie of cookies) {
+    await page.setCookie(cookie);
+}
+```
+
+Each cookie: `name`, `value`, `domain`, `path`, `httpOnly`, `secure`, `sameSite`.
+
+---
+
+## OTP Capture
+
+Passively captures OTPs as they are created. Does not prevent normal sending.
+
+```typescript
+export const auth = betterAuth({
+    plugins: [
+        testUtils({ captureOTP: true }),
+        emailOTP({
+            async sendVerificationOTP({ email, otp }) {
+                // Normal sending still works
+            },
+        }),
+    ],
+});
+```
+
+### getOTP
+
+```typescript
+await auth.api.sendVerificationOTP({
+    body: { email: "user@example.com", type: "sign-in" },
+});
+
+const otp = test.getOTP("user@example.com");
+// "123456"
+```
+
+### clearOTPs
+
+```typescript
+test.clearOTPs();
+```
+
+---
+
+## Integration Test Example (Vitest)
+
+```typescript
+import { describe, it, expect, beforeAll } from "vitest";
+import { auth } from "./auth";
+import type { TestHelpers } from "better-auth/plugins";
+
+describe("protected route", () => {
+    let test: TestHelpers;
+
+    beforeAll(async () => {
+        const ctx = await auth.$context;
+        test = ctx.test;
+    });
+
+    it("should return user data for authenticated request", async () => {
+        const user = test.createUser({ email: "test@example.com" });
+        await test.saveUser(user);
+
+        const headers = await test.getAuthHeaders({ userId: user.id });
+        const session = await auth.api.getSession({ headers });
+        expect(session?.user.id).toBe(user.id);
+
+        await test.deleteUser(user.id);
+    });
+});
+```
+
+---
+
+## E2E Test Example (Playwright)
+
+```typescript
+import { test, expect } from "@playwright/test";
+import { auth } from "./auth";
+
+test("dashboard shows user name", async ({ context, page }) => {
+    const ctx = await auth.$context;
+    const testUtils = ctx.test;
+
+    const user = testUtils.createUser({
+        email: "e2e@example.com",
+        name: "E2E User",
+    });
+    await testUtils.saveUser(user);
+
+    const cookies = await testUtils.getCookies({
+        userId: user.id,
+        domain: "localhost",
+    });
+    await context.addCookies(cookies);
+
+    await page.goto("/dashboard");
+    await expect(page.getByText("E2E User")).toBeVisible();
+
+    await testUtils.deleteUser(user.id);
+});
+```
+
+---
+
+## OTP Verification Test Example
+
+```typescript
+describe("OTP verification", () => {
+    let test: TestHelpers;
+
+    beforeAll(async () => {
+        const ctx = await auth.$context;
+        test = ctx.test;
+    });
+
+    beforeEach(() => {
+        test.clearOTPs();
+    });
+
+    it("should verify email with captured OTP", async () => {
+        const email = "otp-test@example.com";
+        const user = test.createUser({ email, emailVerified: false });
+        await test.saveUser(user);
+
+        await auth.api.sendVerificationOTP({
+            body: { email, type: "email-verification" },
+        });
+
+        const otp = test.getOTP(email);
+        expect(otp).toBeDefined();
+
+        await auth.api.verifyEmail({
+            body: { email, otp },
+        });
+
+        await test.deleteUser(user.id);
+    });
+});
+```

--- a/plugins/better-auth/skills/better-auth/references/v1.4-features.md
+++ b/plugins/better-auth/skills/better-auth/references/v1.4-features.md
@@ -111,39 +111,24 @@ socialProviders: {
 
 ---
 
-## OAuth 2.1 Plugin (v1.4.8)
+## OAuth 2.1 Provider (v1.5.0+)
 
-Standards-compliant OAuth 2.1 implementation.
+The OAuth 2.1 Provider (`@better-auth/oauth-provider`) replaces the deprecated OIDC Provider plugin. Shipped in v1.5.0 with authorization_code, refresh_token, and client_credentials grants, OIDC support, JWKS, and MCP readiness.
 
-### Configuration
+See `references/v1.5-features.md` for full configuration details.
 
 ```typescript
-import { betterAuth } from "better-auth";
-import { oauth21 } from "better-auth/plugins";
+import { oauthProvider } from "@better-auth/oauth-provider";
 
 export const auth = betterAuth({
   plugins: [
-    oauth21({
-      // Enforce PKCE for all flows
-      requirePKCE: true,
-      // Enforce exact redirect URI matching
-      strictRedirectUriMatching: true,
-      // Disallow implicit grant
-      disableImplicitGrant: true,
-      // Short-lived access tokens
-      accessTokenTTL: 60 * 15,  // 15 minutes
+    oauthProvider({
+      loginPage: "/sign-in",
+      consentPage: "/consent",
     }),
   ],
 });
 ```
-
-### OAuth 2.1 Compliance Features
-
-- **PKCE Required**: All authorization flows must use PKCE
-- **No Implicit Grant**: Token response type not allowed
-- **Refresh Token Rotation**: New refresh token on each use
-- **Exact Redirect URI Match**: No wildcard or partial matching
-- **Short Access Tokens**: Encourages refresh token usage
 
 ---
 
@@ -152,98 +137,67 @@ export const auth = betterAuth({
 ### Clock Skew Tolerance (v1.4.7)
 
 ```typescript
-import { sso } from "better-auth/plugins";
+import { sso } from "@better-auth/sso";
 
 sso({
   saml: {
-    // Allow 60 seconds of clock drift between SP and IdP
-    clockSkewTolerance: 60,
+    // Allow clock drift between SP and IdP
+    clockSkew: 60 * 1000,  // 60 seconds (default: 5 minutes)
   },
 }),
 ```
 
-### InResponseTo Validation (v1.4.7)
+### InResponseTo Validation (v1.4.7, default ON in v1.6+)
 
 ```typescript
 sso({
   saml: {
     // Validate SAML response matches request
-    validateInResponseTo: true,
-    // Store pending requests (required for validation)
-    requestStore: "redis",  // or "memory"
+    enableInResponseToValidation: true,
   },
 }),
 ```
 
 ### OIDC Discovery for SSO (v1.4.7)
 
-```typescript
-sso({
-  // Auto-configure from OIDC discovery document
-  oidcDiscovery: true,
-  providers: [
-    {
-      name: "Azure AD",
-      // Discovery will fetch endpoints, keys, etc.
-      discoveryUrl: "https://login.microsoftonline.com/{tenant}/.well-known/openid-configuration",
-    },
-  ],
-}),
-```
+Better Auth automatically fetches OIDC discovery documents during provider registration. See `references/plugins/sso.md` for full details.
 
 ### Crypto Algorithm Validation (v1.4.8)
 
 ```typescript
 sso({
   saml: {
-    // Allowed signature algorithms
-    signatureAlgorithms: ["sha256", "sha384", "sha512"],
-    // Reject weak algorithms
-    rejectWeakAlgorithms: true,  // Rejects sha1
+    algorithms: {
+      // "warn" (default) | "reject" | "allow"
+      onDeprecated: "warn",
+    },
   },
 }),
 ```
 
 ---
 
-## CLI Tool (v1.4.4)
+## CLI Tool (v1.4.4, updated in v1.5.0)
 
-better-auth now includes a CLI for project management.
-
-### Installation
-
-```bash
-# Global installation
-npm install -g better-auth
-
-# Or use npx
-npx better-auth
-```
+The new `npx auth` CLI replaces `@better-auth/cli`.
 
 ### Commands
 
 ```bash
-# Initialize better-auth in project
-better-auth init
+# Initialize better-auth in project (v1.5+)
+npx auth init
 
 # Generate auth schema
-better-auth generate
+npx auth generate
 
-# Check configuration
-better-auth check
+# Run migrations
+npx auth migrate
 
-# Start development server
-better-auth dev
-```
+# Upgrade to latest version (v1.5+)
+npx auth upgrade
 
-### Directory Detection (v1.4.2)
-
-The CLI automatically detects `/auth` directory for Next.js App Router:
-
-```bash
-# Detects src/app/api/auth/[...all]/route.ts
-better-auth check
-# ✓ Auth route detected at /api/auth
+# Generate with specific adapter (v1.5+)
+npx auth generate --adapter drizzle
 ```
 
 ---

--- a/plugins/better-auth/skills/better-auth/references/v1.4-features.md
+++ b/plugins/better-auth/skills/better-auth/references/v1.4-features.md
@@ -397,7 +397,7 @@ None - all v1.4.x releases are backward compatible.
 
 3. **Configure Clock Skew** for SAML if timing issues:
    ```typescript
-   saml: { clockSkewTolerance: 60 }
+   saml: { clockSkew: 60 * 1000 }
    ```
 
 4. **Use CLI** for configuration validation:

--- a/plugins/better-auth/skills/better-auth/references/v1.5-features.md
+++ b/plugins/better-auth/skills/better-auth/references/v1.5-features.md
@@ -257,7 +257,7 @@ export const auth = betterAuth({
 
 Or via environment variable:
 
-```
+```bash
 BETTER_AUTH_SECRETS="2:new-secret-key,1:old-secret-key"
 ```
 

--- a/plugins/better-auth/skills/better-auth/references/v1.5-features.md
+++ b/plugins/better-auth/skills/better-auth/references/v1.5-features.md
@@ -1,0 +1,463 @@
+# better-auth v1.5.x New Features
+
+Major release with 600+ commits, 70 new features, 200 bug fixes, and 7 new packages.
+
+---
+
+## New CLI (`npx auth`)
+
+Replaces `@better-auth/cli` (deprecated in future release).
+
+```bash
+npx auth init        # Interactive project scaffolding
+npx auth migrate     # Run database migrations
+npx auth generate    # Generate auth schema
+npx auth upgrade     # Upgrade to latest version
+```
+
+### Adapter-Specific Schema Generation
+
+```bash
+npx auth generate --adapter prisma
+npx auth generate --adapter drizzle
+```
+
+---
+
+## Remote MCP Auth Client
+
+Framework-agnostic auth client for MCP servers separate from the Better Auth instance.
+
+```typescript
+import { createMcpAuthClient } from "better-auth/plugins/mcp/client";
+
+const mcpAuth = createMcpAuthClient({
+    authURL: "https://my-app.com/api/auth",
+});
+
+// Handler wrapper
+const handler = mcpAuth.handler(async (req, session) => {
+    return new Response("OK");
+});
+
+// Direct token verification
+const session = await mcpAuth.verifyToken(token);
+```
+
+### Framework Adapters
+
+```typescript
+import { mcpAuthHono } from "better-auth/plugins/mcp/client/adapters";
+
+const middleware = mcpAuthHono(mcpAuth);
+```
+
+---
+
+## OAuth 2.1 Provider (`@better-auth/oauth-provider`)
+
+Turns Better Auth into a full OAuth 2.1 authorization server with OIDC compatibility. Replaces the deprecated OIDC Provider plugin.
+
+```typescript
+import { betterAuth } from "better-auth";
+import { jwt } from "better-auth/plugins";
+import { oauthProvider } from "@better-auth/oauth-provider";
+
+export const auth = betterAuth({
+    plugins: [
+        jwt(),
+        oauthProvider({
+            loginPage: "/sign-in",
+            consentPage: "/consent",
+        }),
+    ],
+});
+```
+
+### Key Features
+
+- **OAuth 2.1 + OIDC**: `authorization_code`, `refresh_token`, `client_credentials` grants with `openid` scope
+- **MCP-ready**: Works as authorization server for MCP tools and agents
+- **Dynamic Client Registration**: Public and confidential clients
+- **JWT & JWKS**: Sign access tokens as JWTs, verify via `/jwks`
+- **Consent & authorization flows**: Built-in consent, account selection, post-login redirect
+- **Token introspection & revocation**: RFC 7662 and RFC 7009 compliant
+- **Per-endpoint rate limiting**: Configurable per OAuth endpoint
+- **HTTPS enforcement** for redirect URIs (HTTP only for localhost)
+- **`prompt=none` support** for silent authentication
+- **Scope narrowing at consent**
+
+### Migration from OIDC Provider
+
+See the [migration guide](https://www.better-auth.com/docs/plugins/oauth-provider#from-oidc-provider-plugin).
+
+---
+
+## Typed Error Codes
+
+Machine-readable `code` field in every error response.
+
+```typescript
+import { defineErrorCodes } from "@better-auth/core";
+
+export const MY_ERROR_CODES = defineErrorCodes({
+    USER_NOT_FOUND: "User not found",
+    INVALID_TOKEN: "The provided token is invalid",
+});
+
+// In route handlers:
+throw APIError.from("BAD_REQUEST", MY_ERROR_CODES.USER_NOT_FOUND);
+```
+
+Error response format:
+
+```json
+{
+    "code": "USER_NOT_FOUND",
+    "message": "User not found"
+}
+```
+
+Error codes are fully typed and auto-completed from all registered plugins.
+
+---
+
+## i18n Plugin (`@better-auth/i18n`)
+
+Type-safe error message translations with automatic locale detection.
+
+```typescript
+import { i18n } from "@better-auth/i18n";
+
+export const auth = betterAuth({
+    plugins: [
+        i18n({
+            defaultLocale: "en",
+            detection: ["header", "cookie"],
+            translations: {
+                fr: { USER_NOT_FOUND: "Utilisateur non trouvé" },
+                de: { USER_NOT_FOUND: "Benutzer nicht gefunden" },
+            },
+        }),
+    ],
+});
+```
+
+### Detection Strategies
+
+- **`header`** - `Accept-Language` header (default)
+- **`cookie`** - Custom cookie (configurable name, default `"locale"`)
+- **`session`** - User profile field (configurable, default `"locale"`)
+- **`callback`** - Custom function receiving endpoint context
+
+### Error Response with Translation
+
+```json
+{
+    "code": "INVALID_EMAIL_OR_PASSWORD",
+    "message": "Email ou mot de passe invalide",
+    "originalMessage": "Invalid email or password"
+}
+```
+
+---
+
+## Unified Before & After Hooks
+
+Plugin hooks and global hooks now share the same `AuthMiddleware` type.
+
+```typescript
+import { createAuthMiddleware } from "better-auth/api";
+
+export const auth = betterAuth({
+    hooks: {
+        before: createAuthMiddleware(async (ctx) => {
+            console.log("Request to:", ctx.path);
+        }),
+        after: createAuthMiddleware(async (ctx) => {
+            console.log("Response:", ctx.context.returned);
+        }),
+    },
+});
+```
+
+Plugin hooks with matchers:
+
+```typescript
+hooks: {
+    before: [{
+        matcher: (ctx) => ctx.path === "/sign-in/email",
+        handler: createAuthMiddleware(async (ctx) => { /* ... */ }),
+    }],
+},
+```
+
+---
+
+## Dynamic Base URL
+
+Allowlist-based multi-domain support for Vercel previews, reverse proxies, multi-domain setups.
+
+```typescript
+export const auth = betterAuth({
+    baseURL: {
+        allowedHosts: [
+            "myapp.com",
+            "*.vercel.app",
+            "preview-*.myapp.com",
+            "localhost:3000",
+        ],
+        fallback: "https://myapp.com",
+        protocol: "auto", // "http" | "https" | "auto"
+    },
+});
+```
+
+### Wildcard Patterns
+
+| Pattern | Matches |
+|---------|---------|
+| `myapp.com` | Exact match |
+| `*.vercel.app` | Any subdomain |
+| `preview-*.myapp.com` | Prefix match |
+| `localhost:*` | Any port |
+
+### Cross-Subdomain Cookies
+
+```typescript
+export const auth = betterAuth({
+    baseURL: {
+        allowedHosts: ["auth.example1.com", "auth.example2.com"],
+        protocol: "https",
+    },
+    advanced: {
+        crossSubDomainCookies: {
+            enabled: true,
+        },
+    },
+});
+```
+
+`allowedHosts` are automatically added to `trustedOrigins`.
+
+---
+
+## Secret Key Rotation
+
+Non-destructive rotation of `BETTER_AUTH_SECRET` without invalidating sessions.
+
+```typescript
+export const auth = betterAuth({
+    secrets: [
+        { version: 2, value: "new-secret-key-at-least-32-chars" },
+        { version: 1, value: "old-secret-key-still-used-to-decrypt" },
+    ],
+});
+```
+
+Or via environment variable:
+
+```
+BETTER_AUTH_SECRETS="2:new-secret-key,1:old-secret-key"
+```
+
+First key is active (encryption), all keys are tried for decryption.
+
+---
+
+## Cloudflare D1 Native Support
+
+Pass D1 binding directly — no adapter required.
+
+```typescript
+import { betterAuth } from "better-auth";
+
+export default {
+    async fetch(request, env) {
+        const auth = betterAuth({
+            database: env.DB, // D1 binding, auto-detected
+        });
+        return auth.handler(request);
+    },
+} satisfies ExportedHandler<{ DB: D1Database }>;
+```
+
+Uses D1's `batch()` API for atomicity (no interactive transactions).
+
+---
+
+## Adapter Extraction
+
+Database adapters in separate packages for smaller bundles.
+
+| Package | Description |
+|---------|-------------|
+| `@better-auth/drizzle-adapter` | Drizzle ORM |
+| `@better-auth/prisma-adapter` | Prisma |
+| `@better-auth/kysely-adapter` | Kysely |
+| `@better-auth/mongo-adapter` | MongoDB |
+| `@better-auth/memory-adapter` | In-memory |
+
+Main `better-auth` re-exports all adapters. Use `better-auth/minimal` for smallest bundle:
+
+```typescript
+import { drizzleAdapter } from "@better-auth/drizzle-adapter";
+import { betterAuth } from "better-auth/minimal";
+
+export const auth = betterAuth({
+    database: drizzleAdapter(db, { provider: "pg" }),
+});
+```
+
+---
+
+## Verification on Secondary Storage
+
+Store verification tokens in Redis instead of (or in addition to) the database.
+
+```typescript
+export const auth = betterAuth({
+    secondaryStorage: { /* Redis config */ },
+    verification: {
+        storeIdentifier: "hashed",
+        storeInDatabase: false,
+    },
+});
+```
+
+Per-identifier overrides:
+
+```typescript
+verification: {
+    storeIdentifier: {
+        default: "plain",
+        overrides: {
+            "email-verification": "hashed",
+            "password-reset": "hashed",
+        },
+    },
+},
+```
+
+---
+
+## Rate Limiter Improvements
+
+- Rejected requests no longer count against the limit
+- Hardened defaults: sign-in/sign-up 3 req/10s, password reset/OTP 3 req/60s
+- IPv6 subnet support with configurable prefix size
+- Plugin-level rate limit rules
+- Automatic expired entry cleanup
+
+```typescript
+export const auth = betterAuth({
+    advanced: {
+        ipAddress: {
+            ipv6Subnet: 64,
+        },
+    },
+});
+```
+
+---
+
+## Seat-Based Billing (Stripe)
+
+Per-seat billing for organizations with automatic sync.
+
+```typescript
+import { stripe } from "@better-auth/stripe";
+import { organization } from "better-auth/plugins";
+
+export const auth = betterAuth({
+    plugins: [
+        organization(),
+        stripe({
+            stripeClient,
+            stripeWebhookSecret: "whsec_...",
+            subscription: {
+                enabled: true,
+                plans: [{
+                    name: "team",
+                    priceId: "price_base_monthly",
+                    seatPriceId: "price_per_seat",
+                }],
+            },
+            organization: { enabled: true },
+        }),
+    ],
+});
+```
+
+Also supports usage-based billing via `lineItems`, `scheduleAtPeriodEnd`, and `billingInterval` tracking.
+
+---
+
+## Update Session Endpoint
+
+Update custom additional session fields without re-authentication.
+
+```typescript
+// Client
+await authClient.updateSession({
+    theme: "dark",
+    language: "en",
+});
+
+// Server
+await auth.api.updateSession({
+    body: { theme: "dark" },
+    headers: await headers(),
+});
+```
+
+Only custom additional fields allowed. Core fields (`token`, `userId`, `expiresAt`, etc.) cannot be updated.
+
+---
+
+## Additional Features
+
+### Authentication & Sessions
+- `verifyPassword` API for server-side password verification
+- `setShouldSkipSessionRefresh` for specific requests
+- `deferSessionRefresh` for read-replica setups
+- Awaitable social provider config
+- Limit enumeration on sign-up with email verification
+- Form data support for email sign-in/sign-up
+- Auto-detect `VERCEL_URL` and `NEXTAUTH_URL` for base URL
+
+### OAuth & Providers
+- Railway OAuth provider
+- Trusted providers callback
+- Case-insensitive email matching for social account linking
+
+### Plugin Improvements
+- `magic-link`: `allowedAttempts` option
+- `email-otp`: Change email flow with OTP, richer sign-in
+- `phone-number`: Additional fields in `signUpOnVerification`
+- `two-factor`: `twoFactorCookieMaxAge`, server-side trust device expiration
+- `one-tap`: Button mode for Google sign-in
+- `anonymous`: Delete anonymous user endpoint
+- `admin`: Optional password on user creation
+
+### Core
+- `BetterAuthPluginRegistry` type system: `getPlugin()`, `hasPlugin()`
+- Version accessible at runtime via `AuthContext`
+- Redis secondary storage extracted to `@better-auth/redis-storage`
+
+---
+
+## Cloudflare Workers Compatibility
+
+All v1.5 features work on Cloudflare Workers:
+- D1 native support (no adapter needed)
+- `better-auth/minimal` for smallest bundle
+- Use `nodejs_compat` or `nodejs_als` compatibility flag
+- In-memory rate limiting (Redis not available on Workers)
+- Verification tokens in KV (via secondary storage)
+
+```toml
+# wrangler.toml
+compatibility_flags = ["nodejs_compat"]
+compatibility_date = "2024-09-23"
+```

--- a/plugins/better-auth/skills/better-auth/references/v1.6-features.md
+++ b/plugins/better-auth/skills/better-auth/references/v1.6-features.md
@@ -1,0 +1,231 @@
+# better-auth v1.6.x New Features
+
+OpenTelemetry, passkey pre-auth, case-insensitive queries, performance improvements.
+
+---
+
+## OpenTelemetry Instrumentation (Experimental)
+
+Distributed tracing for auth API calls, hooks, and database operations.
+
+### Setup
+
+Register a TracerProvider in the application. Better Auth automatically emits spans via the `better-auth` tracer.
+
+```typescript
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { SimpleSpanProcessor, ConsoleSpanExporter } from "@opentelemetry/sdk-trace-base";
+
+const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(new ConsoleSpanExporter())],
+});
+provider.register();
+```
+
+No additional auth configuration needed.
+
+### Supported Spans
+
+#### Endpoint Spans
+
+| Span Name | When Emitted |
+|-----------|-------------|
+| `{METHOD} {route}` | Every auth API call (e.g. `GET /get-session`) |
+| `handler {route}` | Endpoint handler execution |
+| `hook before {route} {source}` | Before-hook runs |
+| `hook after {route} {source}` | After-hook runs |
+| `onRequest {pluginId}` | Plugin onRequest hook |
+| `onResponse {pluginId}` | Plugin onResponse hook |
+| `middleware {route} {pluginId}` | Plugin middleware |
+
+#### Database Spans
+
+| Span Name | When Emitted |
+|-----------|-------------|
+| `db {operation} {model}` | All adapter operations |
+| `db {operation}.before {model}` | Database before-hook |
+| `db {operation}.after {model}` | Database after-hook |
+
+Operations: `create`, `findOne`, `findMany`, `update`, `updateMany`, `delete`, `deleteMany`, `count`
+
+### Span Attributes
+
+- `http.route` - Route template (low cardinality)
+- `better_auth.operation_id` - Operation identifier (e.g. `getSession`)
+- `db.operation.name` - Database operation name
+- `db.collection.name` - Database collection/model name
+- `better_auth.hook.type` - Hook type (`before`, `after`, `onRequest`, etc.)
+- `better_auth.context` - Execution context (`"user"` or `"plugin:{pluginId}"`)
+- `http.response.status_code` - HTTP response status (onResponse only)
+
+> **Note**: This feature is experimental. Span structure may change in future releases.
+
+---
+
+## Passkey Pre-Auth Registration
+
+Register passkeys before the user has a session. Enables passkey-first onboarding flows.
+
+### Server Configuration
+
+```typescript
+import { passkey } from "@better-auth/passkey";
+
+export const auth = betterAuth({
+    plugins: [
+        passkey({
+            registration: {
+                requireSession: false,
+                resolveUser: async ({ ctx, context }) => {
+                    // Validate context (e.g., signed token)
+                    return { id: "user-id", name: "user@example.com" };
+                },
+                extensions: { credProps: true },
+            },
+            authentication: {
+                extensions: { credProps: true },
+            },
+        }),
+    ],
+});
+```
+
+### Client Usage
+
+```typescript
+// Generate registration options with context
+await auth.api.generatePasskeyRegistrationOptions({
+    context: "signed-registration-token",
+});
+
+// Register passkey with same context
+await authClient.passkey.addPasskey({
+    name: "Primary passkey",
+    context: "signed-registration-token",
+});
+```
+
+### WebAuthn Extensions
+
+Pass extensions on registration and authentication:
+
+```typescript
+const result = await authClient.passkey.addPasskey({
+    name: "My Passkey",
+    extensions: { credProps: true },
+    returnWebAuthnResponse: true,
+});
+
+console.log(result.webauthn?.clientExtensionResults);
+```
+
+---
+
+## Case Insensitive Queries
+
+Database queries support `mode: "insensitive"` across all adapters (Drizzle, Prisma, Kysely, MongoDB, Memory).
+
+```typescript
+adapter.findOne({
+    model: "user",
+    where: [{
+        field: "email",
+        value: "user@example.com",
+        mode: "insensitive",
+    }],
+});
+```
+
+Each adapter uses the most efficient case-insensitive strategy its database supports. Internal API for plugin authors.
+
+---
+
+## Breaking: `freshAge` Uses `createdAt`
+
+`freshAge` check now uses `createdAt` instead of `updatedAt`.
+
+Previously, session refreshes reset the freshness window, allowing sessions to stay "fresh" indefinitely. Now freshness is tied to session creation time.
+
+**Impact**: Sensitive operations (password changes, payment confirmations) may require more frequent re-authentication.
+
+```typescript
+export const auth = betterAuth({
+    session: {
+        freshAge: 60 * 5, // 5 minutes from createdAt
+    },
+});
+```
+
+Set `freshAge: 0` to disable freshness checks.
+
+---
+
+## Breaking: InResponseTo Validation Default ON
+
+SAML `InResponseTo` validation is now enabled by default for SP-initiated flows.
+
+Prevents replay attacks where captured assertions are reused. IdP-initiated SSO is not affected.
+
+To opt out:
+
+```typescript
+import { sso } from "@better-auth/sso";
+
+sso({
+    saml: {
+        enableInResponseToValidation: false,
+    },
+});
+```
+
+---
+
+## Non-Blocking Scrypt
+
+Password hashing now uses native `node:crypto` scrypt on the libuv thread pool instead of blocking the main thread.
+
+Falls back to pure JavaScript implementation on runtimes without `node:crypto` support. Existing password hashes remain fully compatible.
+
+---
+
+## Reduced Package Size
+
+| Package | v1.5.6 | v1.6.0 | Reduction |
+|---------|--------|--------|-----------|
+| `better-auth` | 4,236 KB | 2,265 KB | 46% |
+
+---
+
+## Two Release Tracks
+
+- **`main`** (stable): Bug fixes, security, additive improvements, non-breaking features
+- **`next`** (beta): New features, refactors, breaking changes after beta cycle
+
+```bash
+npm install better-auth          # Latest stable
+npm install better-auth@beta     # Next minor in progress
+```
+
+Contributors declare release intent per PR via changesets.
+
+---
+
+## Behavior Changes
+
+- **SCIM endpoint authorization enforcement**: Management endpoints require proper authentication
+- **Passkey ownership normalized**: Prevents cross-user access
+- **Cookie cache `maxAge` alignment**: Matches session `expiresIn` to prevent stale cached data
+
+## Deprecations
+
+- **OIDC Provider plugin**: Deprecated in favor of `@better-auth/oauth-provider`. Will be removed in next minor version.
+
+---
+
+## Upgrade
+
+```bash
+npx auth upgrade
+```
+
+Review breaking changes above. Most users require no code changes.


### PR DESCRIPTION
## Summary

- Update better-auth skill from package version 1.4.9 to 1.6.0, covering all v1.5 and v1.6 features
- Add 6 new reference files and update 5 existing ones with production-tested content from official docs
- Bump collection version to 3.2.2, plugin version to 3.1.0

## New Reference Files (6)

| File | Content |
|------|---------|
| `references/v1.5-features.md` | New CLI, MCP auth, OAuth 2.1 Provider, Electron, i18n, D1 native, secret rotation, seat billing, adapter extraction, typed error codes |
| `references/v1.6-features.md` | OpenTelemetry, passkey pre-auth, case-insensitive queries, non-blocking scrypt, release tracks |
| `references/migration-guide-1.5.0.md` | v1.5 breaking changes: API Key moved, after hooks post-transaction, InferUser removed, core/utils split |
| `references/plugins/test-utils.md` | Testing helpers: factories, DB helpers, auth helpers, OTP capture, Vitest/Playwright examples |
| `references/plugins/sso.md` | Production SSO: OIDC discovery, SAML SLO, domain verification, organization provisioning, security hardening |
| `references/integrations/electron.md` | Electron desktop auth: system browser OAuth, IPC bridges, deep links, manual token exchange |

## Updated Reference Files (5)

- **v1.4-features.md** — Fixed OAuth 2.1 plugin (was wrong package), SSO imports to `@better-auth/sso`, CLI commands to `npx auth`, SSO config structure
- **plugins/authentication.md** — Updated passkey to `@better-auth/passkey`, added pre-auth registration (v1.6), WebAuthn extensions
- **plugins/enterprise.md** — Updated SSO to `@better-auth/sso`, added SAML SLO, InResponseTo default ON
- **plugins/api-tokens.md** — Updated to `@better-auth/api-key`, added org-owned API keys, multi-configuration
- **configuration-guide.md** — Added dynamic base URL, secret key rotation, D1 native, `better-auth/minimal`, defer session refresh

## SKILL.md Changes

- Bumped package_version from 1.4.9 to 1.6.0
- Added v1.5 and v1.6 breaking changes and feature highlights
- Added D1 native support (pass D1 binding directly, no adapter needed)
- Updated CLI commands to `npx auth` syntax throughout
- Added 6 new "When to Load References" entries
- Updated dependencies with new packages
- 17 files changed, 2586 insertions, 240 deletions

## Test Plan

- [x] JSON schema validation passed (marketplace.json, plugin.json)
- [x] SKILL.md frontmatter validation passed
- [x] All version numbers consistent (plugin 3.1.0, collection 3.2.2)
- [x] No duplicate content between SKILL.md and references
- [x] All new reference files follow existing patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Electron desktop authentication support
  * D1 native database integration
  * Passkey pre-authentication flows
  * OpenTelemetry observability
  * Internationalization support
  * Test utilities for integration/E2E testing
  * Non-destructive secret key rotation
  * Dynamic base URL allowlisting and advanced session controls

* **Documentation**
  * Comprehensive migration and upgrade guides (v1.5/v1.6)
  * Expanded integration, CLI, plugin, and reference docs (SSO, API keys, passkeys, Electron, test-utils)

* **Chores**
  * Release metadata updated to v3.2.2 and better-auth listings refreshed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->