### PR TITLE
refactor: extract Keywords from description into metadata.keywords in 67 SKILL.md files

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Production-tested skills for Claude Code - Cloudflare, AI, React, Tailwind v4, and modern web development",
-    "version": "3.0.0",
+    "version": "3.3.0",
     "homepage": "https://github.com/secondsky/claude-skills"
   },
   "plugins": [
     {
       "name": "access-control-rbac",
       "source": "./plugins/access-control-rbac",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Role-based access control (RBAC) with permissions and policies. Use for admin dashboards, enterprise access, multi-tenant apps, fine-grained authorization, or encountering permission hierarchies, role inheritance, policy conflicts.",
       "keywords": ["access-control-rbac","access","control","rbac","security","vulnerability","protection","authorization"],
       "category": "security"
@@ -23,7 +23,7 @@
     {
       "name": "aceternity-ui",
       "source": "./plugins/aceternity-ui",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "100+ animated React components (Aceternity UI) for Next.js with Tailwind. Use for hero sections, parallax, 3D effects, or encountering animation, shadcn CLI integration errors.",
       "keywords": ["aceternity-ui","aceternity","frontend","components","cli"],
       "category": "frontend"
@@ -32,7 +32,7 @@
     {
       "name": "ai-elements-chatbot",
       "source": "./plugins/ai-elements-chatbot",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "shadcn/ui AI chat components for conversational interfaces. Use for streaming chat, tool/function displays, reasoning visualization, or encountering Next.js App Router setup, Tailwind v4 integration, AI SDK v5 migration errors.",
       "keywords": ["ai-elements-chatbot","elements","chatbot","machine-learning","llm","artificial-intelligence","migration"],
       "category": "ai"
@@ -41,7 +41,7 @@
     {
       "name": "ai-sdk-core",
       "source": "./plugins/ai-sdk-core",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Vercel AI SDK v5 for backend AI (text generation, structured output, tools, agents). Multi-provider. Use for server-side AI or encountering AI_APICallError, AI_NoObjectGeneratedError, streaming failures.",
       "keywords": ["ai-sdk-core","sdk","core","machine-learning","llm","artificial-intelligence"],
       "category": "ai"
@@ -50,7 +50,7 @@
     {
       "name": "ai-sdk-ui",
       "source": "./plugins/ai-sdk-ui",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Vercel AI SDK v5 React hooks (useChat, useCompletion, useObject) for AI chat interfaces. Use for React/Next.js AI apps or encountering parse stream errors, no response, streaming issues.",
       "keywords": ["ai-sdk-ui","sdk","machine-learning","llm","artificial-intelligence"],
       "category": "ai"
@@ -59,7 +59,7 @@
     {
       "name": "api-authentication",
       "source": "./plugins/api-authentication",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Secure API authentication with JWT, OAuth 2.0, API keys. Use for authentication systems, third-party integrations, service-to-service communication, or encountering token management, security headers, auth flow errors.",
       "keywords": ["api-authentication","api","authentication","authorization","login","security","session","jwt"],
       "category": "auth"
@@ -68,7 +68,7 @@
     {
       "name": "api-changelog-versioning",
       "source": "./plugins/api-changelog-versioning",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Creates comprehensive API changelogs documenting breaking changes, deprecations, and migration strategies for API consumers. Use when managing API versions, communicating breaking changes, or creating upgrade guides.",
       "keywords": ["api-changelog-versioning","api","changelog","versioning","rest","graphql","endpoints","http","migration"],
       "category": "api"
@@ -77,7 +77,7 @@
     {
       "name": "api-contract-testing",
       "source": "./plugins/api-contract-testing",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Verifies API contracts between services using consumer-driven contracts, schema validation, and tools like Pact. Use when testing microservices communication, preventing breaking changes, or validating OpenAPI specifications.",
       "keywords": ["api-contract-testing","api","contract","testing","rest","graphql","endpoints","http","openapi","validation"],
       "category": "api"
@@ -86,7 +86,7 @@
     {
       "name": "api-design-principles",
       "source": "./plugins/api-design-principles",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewing API specifications, or establishing API design standards.",
       "keywords": ["api-design-principles","api","design","principles","rest","graphql","endpoints","http","scalable","maintainable"],
       "category": "api"
@@ -95,7 +95,7 @@
     {
       "name": "api-error-handling",
       "source": "./plugins/api-error-handling",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Implements standardized API error responses with proper status codes, logging, and user-friendly messages. Use when building production APIs, implementing error recovery patterns, or integrating error monitoring services.",
       "keywords": ["api-error-handling","api","error","handling","rest","graphql","endpoints","http"],
       "category": "api"
@@ -104,7 +104,7 @@
     {
       "name": "api-filtering-sorting",
       "source": "./plugins/api-filtering-sorting",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Builds flexible API filtering and sorting systems with query parameter parsing, validation, and security. Use when implementing search endpoints, building data grids, or creating dynamic query APIs.",
       "keywords": ["api-filtering-sorting","api","filtering","sorting","rest","graphql","endpoints","http","validation"],
       "category": "api"
@@ -113,7 +113,7 @@
     {
       "name": "api-gateway-configuration",
       "source": "./plugins/api-gateway-configuration",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Configures API gateways for routing, authentication, rate limiting, and request transformation in microservice architectures. Use when setting up Kong, Nginx, AWS API Gateway, or Traefik for centralized API management.",
       "keywords": ["api-gateway-configuration","api","gateway","configuration","rest","graphql","endpoints","http","aws","authentication"],
       "category": "api"
@@ -122,7 +122,7 @@
     {
       "name": "api-pagination",
       "source": "./plugins/api-pagination",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Implements efficient API pagination using offset, cursor, and keyset strategies for large datasets. Use when building paginated endpoints, implementing infinite scroll, or optimizing database queries for collections.",
       "keywords": ["api-pagination","api","pagination","rest","graphql","endpoints","http"],
       "category": "api"
@@ -131,7 +131,7 @@
     {
       "name": "api-rate-limiting",
       "source": "./plugins/api-rate-limiting",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Implements API rate limiting using token bucket, sliding window, and Redis-based algorithms to protect against abuse. Use when securing public APIs, implementing tiered access, or preventing denial-of-service attacks.",
       "keywords": ["api-rate-limiting","api","rate","limiting","rest","graphql","endpoints","http"],
       "category": "api"
@@ -140,7 +140,7 @@
     {
       "name": "api-reference-documentation",
       "source": "./plugins/api-reference-documentation",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Creates professional API documentation using OpenAPI specifications with endpoints, authentication, and interactive examples. Use when documenting REST APIs, creating SDK references, or building developer portals.",
       "keywords": ["api-reference-documentation","api","reference","documentation","rest","graphql","endpoints","http","openapi","authentication"],
       "category": "api"
@@ -149,7 +149,7 @@
     {
       "name": "api-response-optimization",
       "source": "./plugins/api-response-optimization",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Optimizes API performance through payload reduction, caching strategies, and compression techniques. Use when improving API response times, reducing bandwidth usage, or implementing efficient caching.",
       "keywords": ["api-response-optimization","api","response","optimization","rest","graphql","endpoints","http","caching"],
       "category": "api"
@@ -158,7 +158,7 @@
     {
       "name": "api-security-hardening",
       "source": "./plugins/api-security-hardening",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "REST API security hardening with authentication, rate limiting, input validation, security headers. Use for production APIs, security audits, defense-in-depth, or encountering vulnerabilities, injection attacks, CORS issues.",
       "keywords": ["api-security-hardening","api","security","hardening","rest","graphql","endpoints","http","cors","authentication","validation"],
       "category": "api"
@@ -167,7 +167,7 @@
     {
       "name": "api-testing",
       "source": "./plugins/api-testing",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "HTTP API testing for TypeScript (Supertest) and Python (httpx, pytest). Test REST APIs, GraphQL, request/response validation, authentication, and error handling.",
       "keywords": ["api-testing","api","testing","rest","graphql","endpoints","http","authentication","validation"],
       "category": "api"
@@ -176,7 +176,7 @@
     {
       "name": "api-versioning-strategy",
       "source": "./plugins/api-versioning-strategy",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Implements API versioning using URL paths, headers, or query parameters with backward compatibility and deprecation strategies. Use when managing multiple API versions, planning breaking changes, or designing migration paths.",
       "keywords": ["api-versioning-strategy","api","versioning","strategy","rest","graphql","endpoints","http","url","migration"],
       "category": "api"
@@ -185,7 +185,7 @@
     {
       "name": "app-store-deployment",
       "source": "./plugins/app-store-deployment",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Publishes mobile applications to iOS App Store and Google Play with code signing, versioning, and CI/CD automation. Use when preparing app releases, configuring signing certificates, or setting up automated deployment pipelines.",
       "keywords": ["app-store-deployment","app","store","mobile","native"],
       "category": "mobile"
@@ -194,7 +194,7 @@
     {
       "name": "architecture-patterns",
       "source": "./plugins/architecture-patterns",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Implement proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design. Use when architecting complex backend systems or refactoring existing applications for better maintainability.",
       "keywords": ["architecture-patterns","architecture","patterns","microservices","refactoring"],
       "category": "architecture"
@@ -203,7 +203,7 @@
     {
       "name": "auto-animate",
       "source": "./plugins/auto-animate",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity.",
       "keywords": ["auto-animate","auto","animate","frontend","components","ssr","autoanimate"],
       "category": "frontend"
@@ -212,7 +212,7 @@
     {
       "name": "base-ui-react",
       "source": "./plugins/base-ui-react",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues.",
       "keywords": ["base-ui-react","base","react","frontend","components","mui","migration"],
       "category": "frontend"
@@ -221,7 +221,7 @@
     {
       "name": "better-auth",
       "source": "./plugins/better-auth",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Skill for integrating Better Auth - comprehensive TypeScript authentication framework for Cloudflare D1, Next.js, Nuxt, and 15+ frameworks. Use when adding auth, encountering D1 adapter errors, or implementing OAuth/2FA/RBAC features.",
       "keywords": ["better-auth","better","auth","authentication","authorization","login","security","session","rbac"],
       "category": "auth"
@@ -230,7 +230,7 @@
     {
       "name": "better-chatbot",
       "source": "./plugins/better-chatbot",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "better-chatbot project conventions and standards. Use for contributing code, following three-tier tool system (MCP/Workflow/Default), or encountering server action validators, repository patterns, component design errors.",
       "keywords": ["better-chatbot","better","chatbot","tooling","workflow","mcp"],
       "category": "tooling"
@@ -239,7 +239,7 @@
     {
       "name": "better-chatbot-patterns",
       "source": "./plugins/better-chatbot-patterns",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Reusable better-chatbot patterns for custom deployments. Use for server action validators, tool abstraction, multi-AI providers, or encountering auth validation, FormData parsing, workflow execution errors.",
       "keywords": ["better-chatbot-patterns","better","chatbot","patterns","tooling","workflow","formdata","validation"],
       "category": "tooling"
@@ -248,7 +248,7 @@
     {
       "name": "bun",
       "source": "./plugins/bun",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Comprehensive Bun runtime toolkit covering runtime, package manager, bundler, testing, HTTP servers, WebSockets, databases, framework integrations (Hono, Next.js, Nuxt, TanStack Start, SvelteKit), deployment, and Node.js compatibility.",
       "keywords": ["bun","tooling","workflow","http","sveltekit","tanstack","websockets"],
       "category": "tooling"
@@ -257,7 +257,7 @@
     {
       "name": "chrome-devtools",
       "source": "./plugins/chrome-devtools",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Browser automation with Puppeteer CLI scripts. Use for screenshots, performance analysis, network monitoring, web scraping, form automation, or encountering JavaScript debugging, browser automation errors.",
       "keywords": ["chrome-devtools","chrome","devtools","tooling","workflow","cli"],
       "category": "tooling"
@@ -266,7 +266,7 @@
     {
       "name": "claude-agent-sdk",
       "source": "./plugins/claude-agent-sdk",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Anthropic Claude Agent SDK for autonomous agents and multi-step workflows. Use for subagents, tool orchestration, MCP servers, or encountering CLI not found, context length exceeded errors.",
       "keywords": ["claude-agent-sdk","claude","agent","sdk","machine-learning","llm","artificial-intelligence","cli","mcp"],
       "category": "ai"
@@ -275,7 +275,7 @@
     {
       "name": "claude-api",
       "source": "./plugins/claude-api",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Anthropic Messages API (Claude API) for integrations, streaming, prompt caching, tool use, vision. Use for chatbots, assistants, or encountering rate limits, 429 errors.",
       "keywords": ["claude-api","claude","api","machine-learning","llm","artificial-intelligence","caching"],
       "category": "ai"
@@ -284,7 +284,7 @@
     {
       "name": "claude-code-bash-patterns",
       "source": "./plugins/claude-code-bash-patterns",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Claude Code Bash tool patterns with hooks, automation, git workflows. Use for PreToolUse hooks, command chaining, CLI orchestration, custom commands, or encountering bash permissions, command failures, security guards, hook configurations.",
       "keywords": ["claude-code-bash-patterns","claude","code","bash","patterns","tooling","workflow","cli","pretooluse"],
       "category": "tooling"
@@ -293,7 +293,7 @@
     {
       "name": "claude-hook-writer",
       "source": "./plugins/claude-hook-writer",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Expert guidance for writing secure, reliable, and performant Claude Code hooks - validates design decisions, enforces best practices, and prevents common pitfalls. Use when creating, reviewing, or debugging Claude Code hooks.",
       "keywords": ["claude-hook-writer","claude","hook","writer","tooling","workflow"],
       "category": "tooling"
@@ -302,7 +302,7 @@
     {
       "name": "cloudflare-agents",
       "source": "./plugins/cloudflare-agents",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Build AI agents on Cloudflare Workers with MCP integration, tool use, and LLM providers.",
       "keywords": ["cloudflare-agents","cloudflare","agents","workers","edge","wrangler","llm","mcp"],
       "category": "cloudflare"
@@ -311,7 +311,7 @@
     {
       "name": "cloudflare-browser-rendering",
       "source": "./plugins/cloudflare-browser-rendering",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded.",
       "keywords": ["cloudflare-browser-rendering","cloudflare","browser","rendering","workers","edge","wrangler"],
       "category": "cloudflare"
@@ -320,7 +320,7 @@
     {
       "name": "cloudflare-cron-triggers",
       "source": "./plugins/cloudflare-cron-triggers",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors.",
       "keywords": ["cloudflare-cron-triggers","cloudflare","cron","triggers","workers","edge","wrangler"],
       "category": "cloudflare"
@@ -329,7 +329,7 @@
     {
       "name": "cloudflare-d1",
       "source": "./plugins/cloudflare-d1",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors.",
       "keywords": ["cloudflare-d1","cloudflare","workers","edge","wrangler","migration"],
       "category": "cloudflare"
@@ -338,7 +338,7 @@
     {
       "name": "cloudflare-durable-objects",
       "source": "./plugins/cloudflare-durable-objects",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors.",
       "keywords": ["cloudflare-durable-objects","cloudflare","durable","objects","workers","edge","wrangler","websocket","migration","real-time"],
       "category": "cloudflare"
@@ -347,7 +347,7 @@
     {
       "name": "cloudflare-email-routing",
       "source": "./plugins/cloudflare-email-routing",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues.",
       "keywords": ["cloudflare-email-routing","cloudflare","email","routing","workers","edge","wrangler","spf"],
       "category": "cloudflare"
@@ -356,7 +356,7 @@
     {
       "name": "cloudflare-hyperdrive",
       "source": "./plugins/cloudflare-hyperdrive",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused.",
       "keywords": ["cloudflare-hyperdrive","cloudflare","hyperdrive","workers","edge","wrangler","tls","mysql","postgresql","caching"],
       "category": "cloudflare"
@@ -365,7 +365,7 @@
     {
       "name": "cloudflare-images",
       "source": "./plugins/cloudflare-images",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "This skill should be used when the user asks to \"upload images to Cloudflare\", \"implement direct creator upload\", \"configure image transformations\", \"optimize WebP/AVIF\", \"create image variants\", \"generate signed URLs\", \"add image watermarks\", \"integrate with Next.js/Remix\", \"configure webhooks\", \"debug CORS errors\", \"troubleshoot error 5408/9401-9413\", or \"build responsive images with Cloudflare Images API\".",
       "keywords": ["cloudflare-images","cloudflare","images","workers","edge","wrangler","avif","cors","webp","webhooks"],
       "category": "cloudflare"
@@ -374,7 +374,7 @@
     {
       "name": "cloudflare-kv",
       "source": "./plugins/cloudflare-kv",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues.",
       "keywords": ["cloudflare-kv","cloudflare","workers","edge","wrangler","ttl","caching"],
       "category": "cloudflare"
@@ -383,7 +383,7 @@
     {
       "name": "cloudflare-manager",
       "source": "./plugins/cloudflare-manager",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Comprehensive Cloudflare account management for deploying Workers, KV Storage, R2, Pages, DNS, and Routes. Use when deploying cloudflare services, managing worker containers, configuring KV/R2 storage, or setting up DNS/routing. Requires CLOUDFLARE_API_KEY in .env and Bun runtime with dependencies installed.",
       "keywords": ["cloudflare-manager","cloudflare","manager","workers","edge","wrangler","dns"],
       "category": "cloudflare"
@@ -392,7 +392,7 @@
     {
       "name": "cloudflare-mcp-server",
       "source": "./plugins/cloudflare-mcp-server",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Build MCP (Model Context Protocol) servers on Cloudflare Workers with tools, resources, and prompts.",
       "keywords": ["cloudflare-mcp-server","cloudflare","mcp","server","workers","edge","wrangler"],
       "category": "cloudflare"
@@ -401,7 +401,7 @@
     {
       "name": "cloudflare-nextjs",
       "source": "./plugins/cloudflare-nextjs",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Deploy Next.js to Cloudflare Workers via OpenNext adapter. Use for SSR, ISR, App/Pages Router, or encountering worker size limits, runtime compatibility, connection scoping errors.",
       "keywords": ["cloudflare-nextjs","cloudflare","nextjs","workers","edge","wrangler","isr","ssr","opennext"],
       "category": "cloudflare"
@@ -410,7 +410,7 @@
     {
       "name": "cloudflare-queues",
       "source": "./plugins/cloudflare-queues",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "This skill should be used when the user asks to \"set up Cloudflare Queues\", \"create a message queue\", \"implement queue consumer\", \"process background jobs\", \"configure queue retry logic\", \"publish messages to queue\", \"implement dead letter queue\", or encountering \"queue timeout\", \"message retry\", \"throughput exceeded\", \"queue backlog\" errors.",
       "keywords": ["cloudflare-queues","cloudflare","queues","workers","edge","wrangler"],
       "category": "cloudflare"
@@ -419,7 +419,7 @@
     {
       "name": "cloudflare-r2",
       "source": "./plugins/cloudflare-r2",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Cloudflare R2 S3-compatible object storage with SQL, Iceberg, event notifications, and automation. Use for buckets, uploads, CORS, presigned URLs, large files, S3 migration, analytics, or encountering R2_ERROR, CORS failures, multipart issues.",
       "keywords": ["cloudflare-r2","cloudflare","workers","edge","wrangler","cors","sql","migration"],
       "category": "cloudflare"
@@ -428,7 +428,7 @@
     {
       "name": "cloudflare-sandbox",
       "source": "./plugins/cloudflare-sandbox",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations.",
       "keywords": ["cloudflare-sandbox","cloudflare","sandbox","workers","edge","wrangler"],
       "category": "cloudflare"
@@ -437,7 +437,7 @@
     {
       "name": "cloudflare-turnstile",
       "source": "./plugins/cloudflare-turnstile",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Cloudflare Turnstile CAPTCHA-alternative bot protection. Use for forms, login security, API protection, or encountering CSP errors, token validation failures, error codes 100*/300*/600*.",
       "keywords": ["cloudflare-turnstile","cloudflare","turnstile","workers","edge","wrangler","captcha","csp","validation"],
       "category": "cloudflare"
@@ -446,7 +446,7 @@
     {
       "name": "cloudflare-vectorize",
       "source": "./plugins/cloudflare-vectorize",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors.",
       "keywords": ["cloudflare-vectorize","cloudflare","vectorize","workers","edge","wrangler","rag"],
       "category": "cloudflare"
@@ -455,7 +455,7 @@
     {
       "name": "cloudflare-workers",
       "source": "./plugins/cloudflare-workers",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Comprehensive Cloudflare Workers platform guide covering runtime APIs, testing (Vitest), CI/CD, observability, framework integration, performance, security, and migration. Use for Workers development, deployment, debugging, or optimization.",
       "keywords": ["cloudflare-workers","cloudflare","workers","edge","wrangler","migration"],
       "category": "cloudflare"
@@ -464,7 +464,7 @@
     {
       "name": "cloudflare-workers-ai",
       "source": "./plugins/cloudflare-workers-ai",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors.",
       "keywords": ["cloudflare-workers-ai","cloudflare","workers","edge","wrangler","gpu"],
       "category": "cloudflare"
@@ -473,7 +473,7 @@
     {
       "name": "cloudflare-workflows",
       "source": "./plugins/cloudflare-workflows",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors.",
       "keywords": ["cloudflare-workflows","cloudflare","workflows","workers","edge","wrangler","nonretryableerror"],
       "category": "cloudflare"
@@ -482,7 +482,7 @@
     {
       "name": "cloudflare-zero-trust-access",
       "source": "./plugins/cloudflare-zero-trust-access",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers.",
       "keywords": ["cloudflare-zero-trust-access","cloudflare","zero","trust","access","workers","edge","wrangler","cors","jwt","authentication","validation"],
       "category": "cloudflare"
@@ -491,7 +491,7 @@
     {
       "name": "code-review",
       "source": "./plugins/code-review",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Code review practices with technical rigor and verification gates. Use for receiving feedback, requesting code-reviewer subagent reviews, or preventing false completion claims in pull requests.",
       "keywords": ["code-review","code","review","tooling","workflow"],
       "category": "tooling"
@@ -500,7 +500,7 @@
     {
       "name": "content-collections",
       "source": "./plugins/content-collections",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Content Collections TypeScript-first build tool for Markdown/MDX content. Use for blogs, docs, content sites with Vite + React, MDX components, type-safe Zod schemas, Contentlayer migration, or encountering TypeScript import errors, path alias issues, collection validation errors.",
       "keywords": ["content-collections","content","collections","cms","management","publishing","mdx","validation","migration"],
       "category": "cms"
@@ -509,7 +509,7 @@
     {
       "name": "csrf-protection",
       "source": "./plugins/csrf-protection",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Implements CSRF protection using synchronizer tokens, double-submit cookies, and SameSite attributes. Use when securing web forms, protecting state-changing endpoints, or implementing defense-in-depth authentication.",
       "keywords": ["csrf-protection","csrf","protection","security","vulnerability","xss","samesite","authentication"],
       "category": "security"
@@ -518,7 +518,7 @@
     {
       "name": "database-schema-design",
       "source": "./plugins/database-schema-design",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Database schema design for PostgreSQL/MySQL with normalization, relationships, constraints. Use for new databases, schema reviews, migrations, or encountering missing PKs/FKs, wrong data types, premature denormalization, EAV anti-pattern.",
       "keywords": ["database-schema-design","database","schema","design","orm","sql","query","migrations","eav","mysql","postgresql","migration"],
       "category": "database"
@@ -527,7 +527,7 @@
     {
       "name": "database-sharding",
       "source": "./plugins/database-sharding",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Database sharding for PostgreSQL/MySQL with hash/range/directory strategies. Use for horizontal scaling, multi-tenant isolation, billions of records, or encountering wrong shard keys, hotspots, cross-shard transactions, rebalancing issues.",
       "keywords": ["database-sharding","database","sharding","orm","sql","query","migrations","mysql","postgresql"],
       "category": "database"
@@ -536,7 +536,7 @@
     {
       "name": "defense-in-depth-validation",
       "source": "./plugins/defense-in-depth-validation",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Validate at every layer data passes through to make bugs impossible. Use when invalid data causes failures deep in execution, requiring validation at multiple system layers.",
       "keywords": ["defense-in-depth-validation","defense","depth","validation","security","vulnerability","protection","csrf","xss"],
       "category": "security"
@@ -545,7 +545,7 @@
     {
       "name": "dependency-upgrade",
       "source": "./plugins/dependency-upgrade",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Secure dependency upgrades with supply chain protection, cooldown periods, post-install script hardening, lockfile validation, and staged rollout across npm, Bun, pnpm, and Yarn. Use when upgrading dependencies, configuring security policies, or preventing supply chain attacks.",
       "keywords": ["dependency-upgrade","dependency","upgrade","tooling","workflow","validation"],
       "category": "tooling"
@@ -554,7 +554,7 @@
     {
       "name": "design-review",
       "source": "./plugins/design-review",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states.",
       "keywords": ["design-review","design","review","interface","user-experience","wcag"],
       "category": "design"
@@ -563,7 +563,7 @@
     {
       "name": "design-system-creation",
       "source": "./plugins/design-system-creation",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency.",
       "keywords": ["design-system-creation","design","system","creation","interface","user-experience"],
       "category": "design"
@@ -572,7 +572,7 @@
     {
       "name": "drizzle-orm-d1",
       "source": "./plugins/drizzle-orm-d1",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transaction errors, foreign key constraint failures, or schema inference issues.",
       "keywords": ["drizzle-orm-d1","drizzle","orm","database","sql","query","migrations","migration"],
       "category": "database"
@@ -581,7 +581,7 @@
     {
       "name": "elevenlabs-agents",
       "source": "./plugins/elevenlabs-agents",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "ElevenLabs Agents Platform for AI voice agents (React/JS/Native/Swift). Use for voice AI, RAG, tools, or encountering package deprecation, audio cutoff, CSP violations, webhook auth failures.",
       "keywords": ["elevenlabs-agents","elevenlabs","agents","machine-learning","llm","artificial-intelligence","csp","rag"],
       "category": "ai"
@@ -590,7 +590,7 @@
     {
       "name": "fastmcp",
       "source": "./plugins/fastmcp",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "FastMCP Python framework for MCP servers with tools, resources, storage backends (memory/disk/Redis/DynamoDB). Use for Claude tool exposure, OAuth Proxy, cloud deployment, or encountering storage, lifespan, middleware, circular import, async errors.",
       "keywords": ["fastmcp","tooling","workflow","mcp","dynamodb","async"],
       "category": "tooling"
@@ -599,7 +599,7 @@
     {
       "name": "feature-dev",
       "source": "./plugins/feature-dev",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Automate 7-phase feature development with specialized agents (code-explorer, code-architect, code-reviewer). Use for multi-file features, architectural decisions, or encountering ambiguous requirements, integration patterns, design approach errors.",
       "keywords": ["feature-dev","feature","dev","tooling","workflow"],
       "category": "tooling"
@@ -608,7 +608,7 @@
     {
       "name": "firecrawl-scraper",
       "source": "./plugins/firecrawl-scraper",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors.",
       "keywords": ["firecrawl-scraper","firecrawl","scraper","web","performance","pwa","llm"],
       "category": "web"
@@ -617,7 +617,7 @@
     {
       "name": "frontend-design",
       "source": "./plugins/frontend-design",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.",
       "keywords": ["frontend-design","frontend","design","tooling","workflow"],
       "category": "tooling"
@@ -626,7 +626,7 @@
     {
       "name": "gemini-cli",
       "source": "./plugins/gemini-cli",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool.",
       "keywords": ["gemini-cli","gemini","cli","machine-learning","llm","artificial-intelligence"],
       "category": "ai"
@@ -635,7 +635,7 @@
     {
       "name": "github-project-automation",
       "source": "./plugins/github-project-automation",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors.",
       "keywords": ["github-project-automation","github","project","automation","tooling","workflow","yaml","codeql"],
       "category": "tooling"
@@ -644,7 +644,7 @@
     {
       "name": "google-gemini-api",
       "source": "./plugins/google-gemini-api",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Google Gemini API with @google/genai SDK. Use for multimodal AI, thinking mode, function calling, or encountering SDK deprecation warnings, context errors, multimodal format errors.",
       "keywords": ["google-gemini-api","google","gemini","api","machine-learning","llm","artificial-intelligence"],
       "category": "ai"
@@ -653,7 +653,7 @@
     {
       "name": "google-gemini-embeddings",
       "source": "./plugins/google-gemini-embeddings",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Google Gemini embeddings API (gemini-embedding-001) for RAG and semantic search. Use for vector search, Vectorize integration, or encountering dimension mismatches, rate limits, text truncation.",
       "keywords": ["google-gemini-embeddings","google","gemini","embeddings","machine-learning","llm","artificial-intelligence","rag"],
       "category": "ai"
@@ -662,7 +662,7 @@
     {
       "name": "google-gemini-file-search",
       "source": "./plugins/google-gemini-file-search",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Google Gemini File Search for managed RAG with 100+ file formats. Use for document Q&A, knowledge bases, or encountering immutability errors, quota issues, polling failures. Supports Gemini 3 Pro/Flash (Gemini 2.5 legacy).",
       "keywords": ["google-gemini-file-search","google","gemini","file","search","machine-learning","llm","artificial-intelligence","rag"],
       "category": "ai"
@@ -671,7 +671,7 @@
     {
       "name": "graphql-implementation",
       "source": "./plugins/graphql-implementation",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Builds GraphQL APIs with schema design, resolvers, error handling, and performance optimization using Apollo or Graphene. Use when creating flexible query APIs, migrating from REST, or implementing real-time subscriptions.",
       "keywords": ["graphql-implementation","graphql","implementation","rest","endpoints","http","real-time"],
       "category": "api"
@@ -680,7 +680,7 @@
     {
       "name": "health-check-endpoints",
       "source": "./plugins/health-check-endpoints",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Health check endpoints for liveness, readiness, dependency monitoring. Use for Kubernetes, load balancers, auto-scaling, or encountering probe failures, startup delays, dependency checks, timeout configuration errors.",
       "keywords": ["health-check-endpoints","health","check","endpoints","architecture","patterns","microservices"],
       "category": "architecture"
@@ -689,7 +689,7 @@
     {
       "name": "hono-routing",
       "source": "./plugins/hono-routing",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors.",
       "keywords": ["hono-routing","hono","routing","web","performance","pwa","rpc","validation"],
       "category": "web"
@@ -698,7 +698,7 @@
     {
       "name": "hugo",
       "source": "./plugins/hugo",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors.",
       "keywords": ["hugo","cms","content","management","publishing"],
       "category": "cms"
@@ -707,7 +707,7 @@
     {
       "name": "idempotency-handling",
       "source": "./plugins/idempotency-handling",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Idempotent API operations with idempotency keys, Redis caching, DB constraints. Use for payment systems, webhook retries, safe retries, or encountering duplicate processing, race conditions, key expiry errors.",
       "keywords": ["idempotency-handling","idempotency","handling","tooling","workflow","caching"],
       "category": "tooling"
@@ -716,7 +716,7 @@
     {
       "name": "image-optimization",
       "source": "./plugins/image-optimization",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Optimizes images for web performance using modern formats, responsive techniques, and lazy loading strategies. Use when improving page load times, implementing responsive images, or preparing assets for production deployment.",
       "keywords": ["image-optimization","image","optimization","web","performance","pwa"],
       "category": "web"
@@ -725,7 +725,7 @@
     {
       "name": "inspira-ui",
       "source": "./plugins/inspira-ui",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "120+ Vue/Nuxt animated components with TailwindCSS v4, motion-v, GSAP, Three.js. Use for hero sections, 3D effects, interactive backgrounds, or encountering setup, CSS variables, motion-v integration errors.",
       "keywords": ["inspira-ui","inspira","frontend","components","css","gsap","tailwindcss"],
       "category": "frontend"
@@ -734,7 +734,7 @@
     {
       "name": "interaction-design",
       "source": "./plugins/interaction-design",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Creates intuitive user experiences through feedback patterns, microinteractions, and accessible interaction design. Use when designing loading states, error handling UX, animation guidelines, or touch interactions.",
       "keywords": ["interaction-design","interaction","design","interface","user-experience"],
       "category": "design"
@@ -743,7 +743,7 @@
     {
       "name": "internationalization-i18n",
       "source": "./plugins/internationalization-i18n",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Implements multi-language support using i18next, gettext, or Intl API with translation workflows and RTL support. Use when building multilingual applications, handling date/currency formatting, or supporting right-to-left languages.",
       "keywords": ["internationalization-i18n","internationalization","i18n","web","rtl"],
       "category": "web"
@@ -752,7 +752,7 @@
     {
       "name": "jest-generator",
       "source": "./plugins/jest-generator",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Generate Jest unit tests for JavaScript/TypeScript with mocking, coverage. Use for JS/TS modules, React components, test generation, or encountering missing coverage, improper mocking, test structure errors.",
       "keywords": ["jest-generator","jest","generator","testing","tests","unit-tests","quality"],
       "category": "testing"
@@ -761,7 +761,7 @@
     {
       "name": "kpi-dashboard-design",
       "source": "./plugins/kpi-dashboard-design",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Designs effective KPI dashboards with proper metric selection, visual hierarchy, and data visualization best practices. Use when building executive dashboards, creating analytics views, or presenting business metrics.",
       "keywords": ["kpi-dashboard-design","kpi","dashboard","design","interface","user-experience"],
       "category": "design"
@@ -770,7 +770,7 @@
     {
       "name": "logging-best-practices",
       "source": "./plugins/logging-best-practices",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Structured logging with proper levels, context, PII handling, centralized aggregation. Use for application logging, log management integration, distributed tracing, or encountering log bloat, PII exposure, missing context errors.",
       "keywords": ["logging-best-practices","logging","best","practices","tooling","workflow","pii"],
       "category": "tooling"
@@ -779,7 +779,7 @@
     {
       "name": "maz-ui",
       "source": "./plugins/maz-ui",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Maz-UI v4 - Modern Vue & Nuxt component library with 50+ standalone components, composables, directives, theming, i18n, and SSR support.",
       "keywords": ["maz-ui","maz","tooling","workflow","ssr"],
       "category": "tooling"
@@ -788,7 +788,7 @@
     {
       "name": "mcp-dynamic-orchestrator",
       "source": "./plugins/mcp-dynamic-orchestrator",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets.",
       "keywords": ["mcp-dynamic-orchestrator","mcp","dynamic","orchestrator","tooling","workflow"],
       "category": "tooling"
@@ -797,7 +797,7 @@
     {
       "name": "mcp-management",
       "source": "./plugins/mcp-management",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Manage MCP servers - discover, analyze, execute tools/prompts/resources. Use for MCP integrations, capability discovery, tool filtering, programmatic execution, or encountering context bloat, server configuration, tool execution errors.",
       "keywords": ["mcp-management","mcp","management","tooling","workflow"],
       "category": "tooling"
@@ -806,7 +806,7 @@
     {
       "name": "microservices-patterns",
       "source": "./plugins/microservices-patterns",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Design microservices architectures with service boundaries, event-driven communication, and resilience patterns. Use when building distributed systems, decomposing monoliths, or implementing microservices.",
       "keywords": ["microservices-patterns","microservices","patterns","architecture"],
       "category": "architecture"
@@ -815,7 +815,7 @@
     {
       "name": "ml-model-training",
       "source": "./plugins/ml-model-training",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Train ML models with scikit-learn, PyTorch, TensorFlow. Use for classification/regression, neural networks, hyperparameter tuning, or encountering overfitting, underfitting, convergence issues.",
       "keywords": ["ml-model-training","model","training","machine-learning","artificial-intelligence","pytorch","tensorflow"],
       "category": "ai"
@@ -824,7 +824,7 @@
     {
       "name": "ml-pipeline-automation",
       "source": "./plugins/ml-pipeline-automation",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Automate ML workflows with Airflow, Kubeflow, MLflow. Use for reproducible pipelines, retraining schedules, MLOps, or encountering task failures, dependency errors, experiment tracking issues.",
       "keywords": ["ml-pipeline-automation","pipeline","automation","machine-learning","llm","artificial-intelligence"],
       "category": "ai"
@@ -833,7 +833,7 @@
     {
       "name": "mobile-app-debugging",
       "source": "./plugins/mobile-app-debugging",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Mobile app debugging for iOS, Android, cross-platform frameworks. Use for crashes, memory leaks, performance issues, network problems, or encountering Xcode instruments, Android Profiler, React Native debugger, native bridge errors.",
       "keywords": ["mobile-app-debugging","mobile","app","debugging","native"],
       "category": "mobile"
@@ -842,7 +842,7 @@
     {
       "name": "mobile-app-testing",
       "source": "./plugins/mobile-app-testing",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Mobile app testing with unit tests, UI automation, performance testing. Use for test infrastructure, E2E tests, testing standards, or encountering test framework setup, device farms, flaky tests, platform-specific test errors.",
       "keywords": ["mobile-app-testing","mobile","app","testing","native","e2e"],
       "category": "mobile"
@@ -851,7 +851,7 @@
     {
       "name": "mobile-first-design",
       "source": "./plugins/mobile-first-design",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Designs responsive interfaces starting from mobile screens with progressive enhancement for larger devices. Use when building responsive websites, optimizing for mobile users, or implementing adaptive layouts.",
       "keywords": ["mobile-first-design","mobile","first","design","responsive-design","media-queries","breakpoints"],
       "category": "mobile"
@@ -860,7 +860,7 @@
     {
       "name": "mobile-offline-support",
       "source": "./plugins/mobile-offline-support",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Offline-first mobile apps with local storage, sync queues, conflict resolution. Use for offline functionality, data sync, connectivity handling, or encountering sync conflicts, queue management, storage limits, network transition errors.",
       "keywords": ["mobile-offline-support","mobile","offline","support","native"],
       "category": "mobile"
@@ -869,7 +869,7 @@
     {
       "name": "model-deployment",
       "source": "./plugins/model-deployment",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Deploy ML models with FastAPI, Docker, Kubernetes. Use for serving predictions, containerization, monitoring, drift detection, or encountering latency issues, health check failures, version conflicts.",
       "keywords": ["model-deployment","model","machine-learning","llm","artificial-intelligence","fastapi"],
       "category": "ai"
@@ -878,7 +878,7 @@
     {
       "name": "motion",
       "source": "./plugins/motion",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Motion (Framer Motion) React animation library. Use for drag-and-drop, scroll animations, gestures, SVG morphing, or encountering bundle size, complex transitions, spring physics errors.",
       "keywords": ["motion","frontend","components","svg"],
       "category": "frontend"
@@ -887,7 +887,7 @@
     {
       "name": "multi-ai-consultant",
       "source": "./plugins/multi-ai-consultant",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Consult external AIs (Gemini 2.5 Pro, OpenAI Codex, Claude) for second opinions. Use for debugging failures, architectural decisions, security validation, or need fresh perspective with synthesis.",
       "keywords": ["multi-ai-consultant","multi","consultant","machine-learning","llm","artificial-intelligence","openai","validation"],
       "category": "ai"
@@ -896,7 +896,7 @@
     {
       "name": "mutation-testing",
       "source": "./plugins/mutation-testing",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.",
       "keywords": ["mutation-testing","mutation","testing","tests","unit-tests","quality"],
       "category": "testing"
@@ -905,7 +905,7 @@
     {
       "name": "nano-banana-prompts",
       "source": "./plugins/nano-banana-prompts",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Generate optimized prompts for Gemini 2.5 Flash Image (Nano Banana). Use for image generation, crafting photo prompts, art styles, or multi-turn editing workflows with best practices.",
       "keywords": ["nano-banana-prompts","nano","banana","prompts","tooling","workflow"],
       "category": "tooling"
@@ -914,7 +914,7 @@
     {
       "name": "neon-vercel-postgres",
       "source": "./plugins/neon-vercel-postgres",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Neon + Vercel serverless Postgres for edge and serverless environments. Use for Cloudflare Workers, Vercel Edge, Next.js apps with HTTP/WebSocket connections, database branching (git-like), Drizzle/Prisma ORM integration, migrations, PITR backups, or encountering connection pool exhausted errors, TCP connection issues, SSL config problems.",
       "keywords": ["neon-vercel-postgres","neon","vercel","postgres","database","orm","sql","query","migrations","http","pitr","ssl","tcp","websocket","migration","edge"],
       "category": "database"
@@ -923,7 +923,7 @@
     {
       "name": "nextjs",
       "source": "./plugins/nextjs",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors.",
       "keywords": ["nextjs","frontend","components","ssr","migration","async"],
       "category": "frontend"
@@ -932,7 +932,7 @@
     {
       "name": "nuxt-content",
       "source": "./plugins/nuxt-content",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Nuxt Content v3 Git-backed CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Vercel deployment, SQL storage, MDC components, content collections.",
       "keywords": ["nuxt-content","nuxt","content","frontend","components","cms","mdc","sql","validation"],
       "category": "frontend"
@@ -941,7 +941,7 @@
     {
       "name": "nuxt-seo",
       "source": "./plugins/nuxt-seo",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Comprehensive guide for all 8 Nuxt SEO modules plus Pro modules. Use when building SEO-optimized Nuxt applications, implementing robots.txt/sitemaps, generating OG images, adding Schema.org data, managing meta tags, checking links, or encountering sitemap, robots.txt, OG image, schema validation, meta tag, canonical URL, or i18n SEO errors.",
       "keywords": ["nuxt-seo","nuxt","seo","frontend","components","url","validation"],
       "category": "frontend"
@@ -950,7 +950,7 @@
     {
       "name": "nuxt-studio",
       "source": "./plugins/nuxt-studio",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Visual CMS for Nuxt Content with Cloudflare deployment. Use when setting up Nuxt Studio, configuring OAuth authentication, deploying to Cloudflare Pages/Workers with subdomain routing, or troubleshooting Studio integration.",
       "keywords": ["nuxt-studio","nuxt","studio","frontend","components","cms","authentication"],
       "category": "frontend"
@@ -959,7 +959,7 @@
     {
       "name": "nuxt-ui-v4",
       "source": "./plugins/nuxt-ui-v4",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Nuxt UI v4 with 125+ accessible components, Tailwind v4, Reka UI, AI chat integration with reasoning and tool calling. Use for dashboards, forms, overlays, editors, page layouts, or encountering theming, composable, TypeScript errors.",
       "keywords": ["nuxt-ui-v4","nuxt","frontend","components"],
       "category": "frontend"
@@ -968,7 +968,7 @@
     {
       "name": "nuxt-v4",
       "source": "./plugins/nuxt-v4",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Comprehensive Nuxt 4 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 4 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 3, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
       "keywords": ["nuxt-v4","nuxt","frontend","components","ssr","migration"],
       "category": "frontend"
@@ -977,7 +977,7 @@
     {
       "name": "nuxt-v5",
       "source": "./plugins/nuxt-v5",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Comprehensive Nuxt 5 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 5 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 4, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
       "keywords": ["nuxt-v5","nuxt","frontend","components","ssr","migration"],
       "category": "frontend"
@@ -986,7 +986,7 @@
     {
       "name": "oauth-implementation",
       "source": "./plugins/oauth-implementation",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "OAuth 2.0 and OpenID Connect authentication with secure flows. Use for third-party integrations, SSO systems, token-based API access, or encountering authorization code flow, PKCE, token refresh, scope management errors.",
       "keywords": ["oauth-implementation","oauth","implementation","authentication","authorization","login","security","session","pkce","sso","openid"],
       "category": "auth"
@@ -995,7 +995,7 @@
     {
       "name": "openai-agents",
       "source": "./plugins/openai-agents",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "OpenAI Agents SDK for JavaScript/TypeScript (text + voice agents). Use for multi-agent workflows, tools, guardrails, or encountering Zod errors, MCP failures, infinite loops, tool call issues.",
       "keywords": ["openai-agents","openai","agents","machine-learning","llm","artificial-intelligence","mcp"],
       "category": "ai"
@@ -1004,7 +1004,7 @@
     {
       "name": "openai-api",
       "source": "./plugins/openai-api",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Complete guide for OpenAI APIs: Chat Completions (GPT-5.2, GPT-4o), Embeddings, Images (GPT-Image-1.5), Audio (Whisper + TTS + Transcribe), Moderation. Includes Node.js SDK and fetch approaches.",
       "keywords": ["openai-api","openai","api","machine-learning","llm","artificial-intelligence","gpt","tts"],
       "category": "ai"
@@ -1013,7 +1013,7 @@
     {
       "name": "openai-assistants",
       "source": "./plugins/openai-assistants",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "OpenAI Assistants API v2 for stateful chatbots with Code Interpreter, File Search, RAG. Use for threads, vector stores, or encountering active run errors, indexing delays. ⚠️ Sunset August 26, 2026.",
       "keywords": ["openai-assistants","openai","assistants","machine-learning","llm","artificial-intelligence","rag"],
       "category": "ai"
@@ -1022,7 +1022,7 @@
     {
       "name": "openai-responses",
       "source": "./plugins/openai-responses",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "OpenAI Responses API for stateful agentic applications with reasoning preservation. Use for MCP integration, built-in tools, background processing, or migrating from Chat Completions.",
       "keywords": ["openai-responses","openai","responses","machine-learning","llm","artificial-intelligence","mcp"],
       "category": "ai"
@@ -1031,7 +1031,7 @@
     {
       "name": "payment-gateway-integration",
       "source": "./plugins/payment-gateway-integration",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Integrates payment processing with Stripe, PayPal, or Square including subscriptions, webhooks, and PCI compliance. Use when implementing checkout flows, recurring billing, or handling refunds and disputes.",
       "keywords": ["payment-gateway-integration","payment","gateway","integration","web","pci","paypal","webhooks"],
       "category": "web"
@@ -1040,7 +1040,7 @@
     {
       "name": "pinia-colada",
       "source": "./plugins/pinia-colada",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors.",
       "keywords": ["pinia-colada","pinia","colada","frontend","components","ssr","tanstack","migration","async"],
       "category": "frontend"
@@ -1049,7 +1049,7 @@
     {
       "name": "pinia-v3",
       "source": "./plugins/pinia-v3",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors.",
       "keywords": ["pinia-v3","pinia","frontend","components","ssr","migration"],
       "category": "frontend"
@@ -1058,7 +1058,7 @@
     {
       "name": "plan-interview",
       "source": "./plugins/plan-interview",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Adaptive interview-driven spec generation with quality review. Automatically adjusts depth based on plan complexity.",
       "keywords": ["plan-interview","plan","interview","tooling","workflow"],
       "category": "tooling"
@@ -1067,7 +1067,7 @@
     {
       "name": "playwright",
       "source": "./plugins/playwright",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Browser automation and E2E testing with Playwright. Auto-detects dev servers, writes clean test scripts. Test pages, fill forms, take screenshots, check responsive design, validate UX, test login flows, check links, automate any browser task. Use for cross-browser testing, visual regression, API testing, component testing in TypeScript/JavaScript and Python projects.",
       "keywords": ["playwright","tooling","workflow","e2e"],
       "category": "tooling"
@@ -1076,7 +1076,7 @@
     {
       "name": "progressive-web-app",
       "source": "./plugins/progressive-web-app",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Builds Progressive Web Apps with service workers, web manifest, offline support, and installation prompts. Use when creating installable web experiences, implementing offline functionality, or adding push notifications to web apps.",
       "keywords": ["progressive-web-app","progressive","web","app","performance","pwa"],
       "category": "web"
@@ -1085,7 +1085,7 @@
     {
       "name": "push-notification-setup",
       "source": "./plugins/push-notification-setup",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Implements push notifications across iOS, Android, and web using Firebase Cloud Messaging and native services. Use when adding notification capabilities, handling background messages, or setting up notification channels.",
       "keywords": ["push-notification-setup","push","notification","setup","web","performance","pwa"],
       "category": "web"
@@ -1094,7 +1094,7 @@
     {
       "name": "react-best-practices",
       "source": "./plugins/react-best-practices",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "React and Next.js performance optimization guidelines from Vercel Engineering. Use when writing/reviewing/refactoring React code for optimal performance. Covers async patterns, bundle optimization, server/client components, re-render optimization.",
       "keywords": ["react-best-practices","react","best","practices","frontend","components","refactoring","async"],
       "category": "frontend"
@@ -1103,7 +1103,7 @@
     {
       "name": "react-composition-patterns",
       "source": "./plugins/react-composition-patterns",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "React composition patterns from Vercel Engineering. Use when building scalable components, avoiding boolean prop proliferation, implementing compound components, or managing component state. Covers architecture, state management, and implementation patterns.",
       "keywords": ["react-composition-patterns","react","composition","patterns","frontend","components","scalable","implementation"],
       "category": "frontend"
@@ -1112,7 +1112,7 @@
     {
       "name": "react-hook-form-zod",
       "source": "./plugins/react-hook-form-zod",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems.",
       "keywords": ["react-hook-form-zod","react","hook","form","zod","frontend","components","validation"],
       "category": "frontend"
@@ -1121,7 +1121,7 @@
     {
       "name": "react-native-skills",
       "source": "./plugins/react-native-skills",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "React Native and Expo best practices for building performant mobile apps. Use when building React Native components, optimizing list performance, implementing animations, or working with native modules.",
       "keywords": ["react-native-skills","react","native","skills","frontend","components"],
       "category": "frontend"
@@ -1130,7 +1130,7 @@
     {
       "name": "recommendation-engine",
       "source": "./plugins/recommendation-engine",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Build recommendation systems with collaborative filtering, matrix factorization, hybrid approaches. Use for product recommendations, personalization, or encountering cold start, sparsity, quality evaluation issues.",
       "keywords": ["recommendation-engine","recommendation","engine","data","analytics","processing","sql","queries"],
       "category": "data"
@@ -1139,7 +1139,7 @@
     {
       "name": "recommendation-system",
       "source": "./plugins/recommendation-system",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Deploy production recommendation systems with feature stores, caching, A/B testing. Use for personalization APIs, low latency serving, or encountering cache invalidation, experiment tracking, quality monitoring issues.",
       "keywords": ["recommendation-system","recommendation","system","data","analytics","processing","sql","queries","caching"],
       "category": "data"
@@ -1148,7 +1148,7 @@
     {
       "name": "responsive-web-design",
       "source": "./plugins/responsive-web-design",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Builds adaptive web interfaces using Flexbox, CSS Grid, and media queries with a mobile-first approach. Use when creating multi-device layouts, implementing flexible UI systems, or ensuring cross-browser compatibility.",
       "keywords": ["responsive-web-design","responsive","web","design","performance","pwa","css"],
       "category": "web"
@@ -1157,7 +1157,7 @@
     {
       "name": "rest-api-design",
       "source": "./plugins/rest-api-design",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Designs RESTful APIs with proper resource naming, HTTP methods, status codes, and response formats. Use when building new APIs, establishing API conventions, or designing developer-friendly interfaces.",
       "keywords": ["rest-api-design","rest","api","design","graphql","endpoints","http"],
       "category": "api"
@@ -1166,7 +1166,7 @@
     {
       "name": "root-cause-tracing",
       "source": "./plugins/root-cause-tracing",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Systematically trace bugs backward through call stack to find original trigger. Use when errors occur deep in execution and you need to trace back to find the original trigger.",
       "keywords": ["root-cause-tracing","root","cause","tracing","tooling","workflow"],
       "category": "tooling"
@@ -1175,7 +1175,7 @@
     {
       "name": "security-headers-configuration",
       "source": "./plugins/security-headers-configuration",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Configures HTTP security headers to protect against XSS, clickjacking, and MIME sniffing attacks. Use when hardening web applications, passing security audits, or implementing Content Security Policy.",
       "keywords": ["security-headers-configuration","security","headers","configuration","vulnerability","protection","csrf","xss","http","mime"],
       "category": "security"
@@ -1184,7 +1184,7 @@
     {
       "name": "seo-keyword-cluster-builder",
       "source": "./plugins/seo-keyword-cluster-builder",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Groups related keywords into topic clusters and creates content hub architecture recommendations with internal linking strategies. Use when planning content strategy, organizing keyword research, or building pillar page structures.",
       "keywords": ["seo-keyword-cluster-builder","seo","keyword","cluster","builder","search","keywords","ranking"],
       "category": "seo"
@@ -1193,7 +1193,7 @@
     {
       "name": "seo-optimizer",
       "source": "./plugins/seo-optimizer",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "SEO optimization with keyword analysis, readability assessment, technical validation, content quality. Use for search rankings, blog posts, content audits, or encountering keyword density, readability scores, meta tags, schema markup errors.",
       "keywords": ["seo-optimizer","seo","optimizer","search","keywords","ranking","validation"],
       "category": "seo"
@@ -1202,7 +1202,7 @@
     {
       "name": "sequential-thinking",
       "source": "./plugins/sequential-thinking",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Systematic step-by-step reasoning with revision and branching. Use for complex problems, multi-stage analysis, design planning, problem decomposition, or encountering unclear scope, alternative approaches needed, revision requirements.",
       "keywords": ["sequential-thinking","sequential","thinking","tooling","workflow"],
       "category": "tooling"
@@ -1211,7 +1211,7 @@
     {
       "name": "session-management",
       "source": "./plugins/session-management",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Implements secure session management with JWT tokens, Redis storage, refresh flows, and proper cookie configuration. Use when building authentication systems, managing user sessions, or implementing secure logout functionality.",
       "keywords": ["session-management","session","management","authentication","authorization","login","security","jwt"],
       "category": "auth"
@@ -1220,7 +1220,7 @@
     {
       "name": "shadcn-vue",
       "source": "./plugins/shadcn-vue",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors.",
       "keywords": ["shadcn-vue","shadcn","vue","frontend","components"],
       "category": "frontend"
@@ -1229,7 +1229,7 @@
     {
       "name": "sql-query-optimization",
       "source": "./plugins/sql-query-optimization",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "SQL query optimization for PostgreSQL/MySQL with indexing, EXPLAIN analysis. Use for slow queries, N+1 problems, missing indexes, or encountering sequential scans, OFFSET pagination, temp table spills, inefficient JOINs.",
       "keywords": ["sql-query-optimization","sql","query","optimization","data","analytics","processing","queries","explain","offset","mysql","postgresql"],
       "category": "data"
@@ -1238,7 +1238,7 @@
     {
       "name": "supabase-postgres-best-practices",
       "source": "./plugins/supabase-postgres-best-practices",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Postgres performance optimization and best practices from Supabase. 30 rules across 8 categories prioritized by impact.",
       "keywords": ["supabase-postgres-best-practices","supabase","postgres","best","practices","tooling","workflow"],
       "category": "tooling"
@@ -1247,7 +1247,7 @@
     {
       "name": "sveltia-cms",
       "source": "./plugins/sveltia-cms",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Sveltia CMS Git-backed content management (Decap/Netlify CMS successor). 5x smaller bundle (300 KB), GraphQL performance, solves 260+ issues. Use for static sites (Hugo, Jekyll, 11ty, Gatsby, Astro, Next.js), blogs, docs, i18n, or encountering OAuth errors, TOML/YAML issues, CORS problems, content listing errors.",
       "keywords": ["sveltia-cms","sveltia","cms","content","management","publishing","cors","toml","yaml","graphql"],
       "category": "cms"
@@ -1256,7 +1256,7 @@
     {
       "name": "swift-best-practices",
       "source": "./plugins/swift-best-practices",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "This skill should be used when writing or reviewing Swift code for iOS or macOS projects. Apply modern Swift 6+ best practices, concurrency patterns, API design guidelines, and migration strategies. Covers async/await, actors, MainActor, Sendable, typed throws, and Swift 6 breaking changes.",
       "keywords": ["swift-best-practices","swift","best","practices","mobile","native","mainactor","migration","async"],
       "category": "mobile"
@@ -1265,7 +1265,7 @@
     {
       "name": "swift-settingskit",
       "source": "./plugins/swift-settingskit",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "SettingsKit for SwiftUI settings interfaces (iOS, macOS, watchOS, tvOS, visionOS). Use for settings/preferences screens, searchable settings, nested navigation, @Observable/@Bindable state, or encountering settings update errors, navigation state issues.",
       "keywords": ["swift-settingskit","swift","settingskit","mobile","native","swiftui"],
       "category": "mobile"
@@ -1274,7 +1274,7 @@
     {
       "name": "systematic-debugging",
       "source": "./plugins/systematic-debugging",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Four-phase debugging framework that ensures root cause investigation before attempting fixes. Never jump to solutions. Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes.",
       "keywords": ["systematic-debugging","systematic","debugging","tooling","workflow"],
       "category": "tooling"
@@ -1283,7 +1283,7 @@
     {
       "name": "tailwind-v4-shadcn",
       "source": "./plugins/tailwind-v4-shadcn",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React. Use when: initializing React projects with Tailwind v4, setting up shadcn/ui, implementing dark mode, debugging CSS variable issues, fixing theme switching, migrating from Tailwind v3, or encountering color/theming problems. Covers: @theme inline pattern, CSS variable architecture, dark mode with ThemeProvider, component composition, vite.config setup, common v4 gotchas, and production-tested patterns.",
       "keywords": ["tailwind-v4-shadcn","tailwind","shadcn","frontend","components","css","themeprovider"],
       "category": "frontend"
@@ -1292,7 +1292,7 @@
     {
       "name": "tanstack-ai",
       "source": "./plugins/tanstack-ai",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and tool definitions.",
       "keywords": ["tanstack-ai","tanstack","machine-learning","llm","artificial-intelligence","chatclient","openai"],
       "category": "ai"
@@ -1301,7 +1301,7 @@
     {
       "name": "tanstack-query",
       "source": "./plugins/tanstack-query",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors.",
       "keywords": ["tanstack-query","tanstack","query","frontend","components","migration","caching"],
       "category": "frontend"
@@ -1310,7 +1310,7 @@
     {
       "name": "tanstack-router",
       "source": "./plugins/tanstack-router",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "TanStack Router type-safe file-based routing for React. Use for SPAs, TanStack Query integration, Cloudflare Workers, or encountering devtools, type safety, loader, Vite bundling errors.",
       "keywords": ["tanstack-router","tanstack","router","frontend","components"],
       "category": "frontend"
@@ -1319,7 +1319,7 @@
     {
       "name": "tanstack-start",
       "source": "./plugins/tanstack-start",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "TanStack Start (RC) full-stack React with server functions, SSR, Cloudflare Workers. Use for Next.js migration, edge rendering, or encountering hydration, auth, data pattern errors.",
       "keywords": ["tanstack-start","tanstack","start","frontend","components","ssr","migration","edge"],
       "category": "frontend"
@@ -1328,7 +1328,7 @@
     {
       "name": "tanstack-table",
       "source": "./plugins/tanstack-table",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "TanStack Table v8 headless data tables with server-side features for Cloudflare Workers + D1. Use for pagination, filtering, sorting, virtualization, or encountering state management, TanStack Query coordination, URL sync errors.",
       "keywords": ["tanstack-table","tanstack","table","frontend","components","url"],
       "category": "frontend"
@@ -1337,7 +1337,7 @@
     {
       "name": "technical-specification",
       "source": "./plugins/technical-specification",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Creates detailed technical specifications for software projects covering requirements, architecture, APIs, and testing strategies. Use when planning features, documenting system design, or creating architecture decision records.",
       "keywords": ["technical-specification","technical","specification","documentation","docs","technical-writing","specs"],
       "category": "documentation"
@@ -1346,7 +1346,7 @@
     {
       "name": "test-quality-analysis",
       "source": "./plugins/test-quality-analysis",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Detect test smells, overmocking, flaky tests, and coverage issues. Analyze test effectiveness, maintainability, and reliability. Use when reviewing tests or improving test quality.",
       "keywords": ["test-quality-analysis","test","quality","analysis","testing","tests","unit-tests"],
       "category": "testing"
@@ -1355,7 +1355,7 @@
     {
       "name": "thesys-generative-ui",
       "source": "./plugins/thesys-generative-ui",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "AI-powered generative UI with Thesys - create React components from natural language.",
       "keywords": ["thesys-generative-ui","thesys","generative","machine-learning","llm","artificial-intelligence"],
       "category": "ai"
@@ -1364,7 +1364,7 @@
     {
       "name": "threejs",
       "source": "./plugins/threejs",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Comprehensive Three.js skills for building 3D web experiences",
       "keywords": ["threejs","tooling","workflow"],
       "category": "tooling"
@@ -1373,7 +1373,7 @@
     {
       "name": "turborepo",
       "source": "./plugins/turborepo",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Turborepo high-performance monorepo build system. Use for monorepo setup, build optimization, task pipelines, caching strategies, or multi-package orchestration.",
       "keywords": ["turborepo","tooling","workflow","caching"],
       "category": "tooling"
@@ -1382,7 +1382,7 @@
     {
       "name": "typescript-mcp",
       "source": "./plugins/typescript-mcp",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "MCP servers with TypeScript on Cloudflare Workers using @modelcontextprotocol/sdk. Use for API integrations, stateless tools, edge deployments, or encountering export syntax, schema validation, memory leak, CORS, auth errors.",
       "keywords": ["typescript-mcp","mcp","tooling","workflow","cors","validation","edge"],
       "category": "tooling"
@@ -1391,7 +1391,7 @@
     {
       "name": "ultracite",
       "source": "./plugins/ultracite",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Ultracite multi-provider linting/formatting (Biome, ESLint, Oxlint). Use for v6/v7 setup, provider selection, Git hooks, MCP integration, AI hooks, migrations, or encountering configuration, type-aware linting, monorepo errors.",
       "keywords": ["ultracite","frontend","components","mcp","migration"],
       "category": "frontend"
@@ -1400,7 +1400,7 @@
     {
       "name": "vercel-blob",
       "source": "./plugins/vercel-blob",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Vercel Blob object storage with CDN for Next.js. Use for file uploads (images, PDFs, videos), presigned URLs, user-generated content, file management, or encountering BLOB_READ_WRITE_TOKEN errors, file size limits, client upload token errors.",
       "keywords": ["vercel-blob","vercel","blob","database","orm","sql","query","migrations","cdn"],
       "category": "database"
@@ -1409,7 +1409,7 @@
     {
       "name": "vercel-kv",
       "source": "./plugins/vercel-kv",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Vercel KV (Redis-compatible key-value storage via Upstash). Use for Next.js caching, sessions, rate limiting, TTL data storage, or encountering KV_REST_API_URL errors, rate limit issues, JSON serialization errors. Provides strong consistency vs eventual consistency.",
       "keywords": ["vercel-kv","vercel","database","orm","sql","query","migrations","json","ttl","caching"],
       "category": "database"
@@ -1418,7 +1418,7 @@
     {
       "name": "verification-before-completion",
       "source": "./plugins/verification-before-completion",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Run verification commands and confirm output before claiming success. Use when about to claim work is complete, fixed, or passing, before committing or creating PRs.",
       "keywords": ["verification-before-completion","verification","before","completion","tooling","workflow"],
       "category": "tooling"
@@ -1427,7 +1427,7 @@
     {
       "name": "vitest-testing",
       "source": "./plugins/vitest-testing",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Modern TypeScript/JavaScript testing with Vitest. Fast unit and integration tests, native ESM support, Vite-powered HMR, and comprehensive mocking. Use for testing TS/JS projects.",
       "keywords": ["vitest-testing","vitest","testing","tests","unit-tests","quality","esm","hmr"],
       "category": "testing"
@@ -1436,7 +1436,7 @@
     {
       "name": "vulnerability-scanning",
       "source": "./plugins/vulnerability-scanning",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Implements automated security scanning for dependencies, code, and containers using tools like Trivy, Snyk, and npm audit. Use when setting up CI/CD security gates, conducting pre-deployment audits, or meeting compliance requirements.",
       "keywords": ["vulnerability-scanning","vulnerability","scanning","security","protection","csrf","xss"],
       "category": "security"
@@ -1445,7 +1445,7 @@
     {
       "name": "web-performance-audit",
       "source": "./plugins/web-performance-audit",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Web performance audits with Core Web Vitals, bottleneck identification, optimization recommendations. Use for page load times, performance reviews, UX optimization, or encountering LCP, FID, CLS issues, resource blocking, render delays.",
       "keywords": ["web-performance-audit","web","performance","audit","pwa","cls","fid","lcp"],
       "category": "web"
@@ -1454,7 +1454,7 @@
     {
       "name": "web-performance-optimization",
       "source": "./plugins/web-performance-optimization",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Optimizes web application performance through code splitting, lazy loading, caching strategies, and Core Web Vitals monitoring. Use when improving page load times, implementing service workers, or reducing bundle sizes.",
       "keywords": ["web-performance-optimization","web","performance","optimization","pwa","caching"],
       "category": "web"
@@ -1463,7 +1463,7 @@
     {
       "name": "websocket-implementation",
       "source": "./plugins/websocket-implementation",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Implements real-time WebSocket communication with connection management, room-based messaging, and horizontal scaling. Use when building chat systems, live notifications, collaborative tools, or real-time dashboards.",
       "keywords": ["websocket-implementation","websocket","implementation","http","real-time"],
       "category": "api"
@@ -1472,7 +1472,7 @@
     {
       "name": "woocommerce-backend-dev",
       "source": "./plugins/woocommerce-backend-dev",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Add or modify WooCommerce backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code in WooCommerce projects.",
       "keywords": ["woocommerce-backend-dev","woocommerce","backend","dev","wordpress","ecommerce","shop","php"],
       "category": "woocommerce"
@@ -1481,7 +1481,7 @@
     {
       "name": "woocommerce-code-review",
       "source": "./plugins/woocommerce-code-review",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Review WooCommerce code changes for coding standards compliance. Use when reviewing code locally, performing automated PR reviews, or checking code quality in WooCommerce projects.",
       "keywords": ["woocommerce-code-review","woocommerce","code","review","wordpress","ecommerce","shop"],
       "category": "woocommerce"
@@ -1490,7 +1490,7 @@
     {
       "name": "woocommerce-copy-guidelines",
       "source": "./plugins/woocommerce-copy-guidelines",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Guidelines for UI text and copy in WooCommerce. Use when writing user-facing text, labels, buttons, messages, or documentation in WooCommerce projects.",
       "keywords": ["woocommerce-copy-guidelines","woocommerce","copy","guidelines","wordpress","ecommerce","shop"],
       "category": "woocommerce"
@@ -1499,7 +1499,7 @@
     {
       "name": "woocommerce-dev-cycle",
       "source": "./plugins/woocommerce-dev-cycle",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Run tests, linting, and quality checks for WooCommerce development. Use when running tests, fixing code style, or following the development workflow in WooCommerce projects.",
       "keywords": ["woocommerce-dev-cycle","woocommerce","dev","cycle","wordpress","ecommerce","shop"],
       "category": "woocommerce"
@@ -1508,7 +1508,7 @@
     {
       "name": "wordpress-plugin-core",
       "source": "./plugins/wordpress-plugin-core",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors.",
       "keywords": ["wordpress-plugin-core","wordpress","plugin","core","cms","content","management","publishing","csrf","rest","sql","xss"],
       "category": "cms"
@@ -1517,7 +1517,7 @@
     {
       "name": "xss-prevention",
       "source": "./plugins/xss-prevention",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Prevents Cross-Site Scripting attacks through input sanitization, output encoding, and Content Security Policy. Use when handling user-generated content, implementing rich text editors, or securing web applications.",
       "keywords": ["xss-prevention","xss","prevention","security","vulnerability","protection","csrf"],
       "category": "security"
@@ -1526,7 +1526,7 @@
     {
       "name": "zod",
       "source": "./plugins/zod",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies (2kb gzipped).",
       "keywords": ["zod","tooling","workflow","json","openapi","validation"],
       "category": "tooling"
@@ -1535,7 +1535,7 @@
     {
       "name": "zustand-state-management",
       "source": "./plugins/zustand-state-management",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "description": "Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loops.",
       "keywords": ["zustand-state-management","zustand","state","management","frontend","components","ssr","migration"],
       "category": "frontend"

--- a/.github/workflows/validate-frontmatter.yml
+++ b/.github/workflows/validate-frontmatter.yml
@@ -43,6 +43,29 @@ jobs:
             exit 1
           fi
 
+      - name: Check no Keywords in description
+        if: github.event_name == 'pull_request'
+        run: |
+          FOUND=0
+          for f in $(find plugins -name 'SKILL.md' -type f); do
+            if ruby -r yaml -e '
+              content = File.read(ARGV[0])
+              fm = content.match(/\A---\n(.*?)\n---/m)
+              exit(0) unless fm
+              desc = fm[1][/description:.*$/m]
+              exit(0) unless desc
+              exit(1) if desc.include?("Keywords:")
+            ' "$f"; then
+              echo "::error file=$f::Keywords must be in metadata.keywords, not in description"
+              FOUND=$((FOUND + 1))
+            fi
+          done
+          if [ "$FOUND" -gt 0 ]; then
+            echo "::error::$FOUND SKILL.md file(s) have Keywords in description (should be in metadata.keywords)"
+            exit 1
+          fi
+          echo "No Keywords found in description fields."
+
       - name: Validate all SKILL.md frontmatter
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: ./scripts/validate-frontmatter.sh

--- a/.github/workflows/validate-frontmatter.yml
+++ b/.github/workflows/validate-frontmatter.yml
@@ -47,21 +47,19 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           FOUND=0
-          for f in $(find plugins -name 'SKILL.md' -type f); do
-            if ruby -r yaml -e '
-              content = File.read(ARGV[0])
-              fm = content.match(/\A---\n(.*?)\n---/m)
-              exit(0) unless fm
-              desc = fm[1][/description:.*$/m]
-              exit(0) unless desc
-              exit(1) if desc.include?("Keywords:")
-            ' "$f"; then
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep 'SKILL\.md$' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No SKILL.md files changed, skipping keyword check"
+            exit 0
+          fi
+          for f in $CHANGED; do
+            if grep -q 'Keywords:' "$f" 2>/dev/null; then
               echo "::error file=$f::Keywords must be in metadata.keywords, not in description"
               FOUND=$((FOUND + 1))
             fi
           done
           if [ "$FOUND" -gt 0 ]; then
-            echo "::error::$FOUND SKILL.md file(s) have Keywords in description (should be in metadata.keywords)"
+            echo "::error::$FOUND SKILL.md file(s) have Keywords in frontmatter (should be in metadata.keywords)"
             exit 1
           fi
           echo "No Keywords found in description fields."

--- a/plugins/access-control-rbac/.claude-plugin/plugin.json
+++ b/plugins/access-control-rbac/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "access-control-rbac",
   "description": "Role-based access control (RBAC) with permissions and policies. Use for admin dashboards, enterprise access, multi-tenant apps, fine-grained authorization, or encountering permission hierarchies, role inheritance, policy conflicts.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/aceternity-ui/.claude-plugin/plugin.json
+++ b/plugins/aceternity-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aceternity-ui",
   "description": "100+ animated React components (Aceternity UI) for Next.js with Tailwind. Use for hero sections, parallax, 3D effects, or encountering animation, shadcn CLI integration errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ai-elements-chatbot/.claude-plugin/plugin.json
+++ b/plugins/ai-elements-chatbot/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-elements-chatbot",
   "description": "shadcn/ui AI chat components for conversational interfaces. Use for streaming chat, tool/function displays, reasoning visualization, or encountering Next.js App Router setup, Tailwind v4 integration, AI SDK v5 migration errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ai-elements-chatbot/skills/ai-elements-chatbot/SKILL.md
+++ b/plugins/ai-elements-chatbot/skills/ai-elements-chatbot/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: ai-elements-chatbot
-description: shadcn/ui AI chat components for conversational interfaces. Use for streaming chat, tool/function displays, reasoning visualization, or encountering Next.js App Router setup, Tailwind v4 integration, AI SDK v5 migration errors.
+description: >-
+  shadcn/ui AI chat components for conversational interfaces. Use for streaming chat, tool/function displays, reasoning visualization, or encountering Next.js App Router setup, Tailwind v4 integration, AI SDK v5 migration errors.
 
-  Keywords: ai-elements, vercel-ai-sdk, shadcn, chatbot, conversational-ai, streaming-ui, chat-interface, ai-chat, message-components, conversation-ui, tool-calling, reasoning-display, source-citations, markdown-streaming, function-calling, ai-responses, prompt-input, code-highlighting, web-preview, branch-navigation, thinking-display, perplexity-style, claude-artifacts
+    Keywords: ai-elements, vercel-ai-sdk, shadcn, chatbot, conversational-ai, streaming-ui, chat-interface, ai-chat, message-components, conversation-ui, tool-calling, reasoning-display, source-citations, markdown-streaming, function-calling, ai-responses, prompt-input, code-highlighting, web-preview, branch-navigation, thinking-display, perplexity-style, claude-artifacts
 license: MIT
 metadata:
   version: "2.0.0"

--- a/plugins/ai-elements-chatbot/skills/ai-elements-chatbot/SKILL.md
+++ b/plugins/ai-elements-chatbot/skills/ai-elements-chatbot/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: ai-elements-chatbot
-description: >-
-  shadcn/ui AI chat components for conversational interfaces. Use for streaming chat, tool/function displays, reasoning visualization, or encountering Next.js App Router setup, Tailwind v4 integration, AI SDK v5 migration errors.
-
-    Keywords: ai-elements, vercel-ai-sdk, shadcn, chatbot, conversational-ai, streaming-ui, chat-interface, ai-chat, message-components, conversation-ui, tool-calling, reasoning-display, source-citations, markdown-streaming, function-calling, ai-responses, prompt-input, code-highlighting, web-preview, branch-navigation, thinking-display, perplexity-style, claude-artifacts
+description: "shadcn/ui AI chat components for conversational interfaces. Use for streaming chat, tool/function displays, reasoning visualization, or encountering Next.js App Router setup, Tailwind v4 integration, AI SDK v5 migration errors."
 license: MIT
 metadata:
   version: "2.0.0"
@@ -13,8 +10,31 @@ metadata:
   errors_prevented: 8
   templates_included: 0
   references_included: 3
+  keywords:
+    - ai-elements
+    - vercel-ai-sdk
+    - shadcn
+    - chatbot
+    - conversational-ai
+    - streaming-ui
+    - chat-interface
+    - ai-chat
+    - message-components
+    - conversation-ui
+    - tool-calling
+    - reasoning-display
+    - source-citations
+    - markdown-streaming
+    - function-calling
+    - ai-responses
+    - prompt-input
+    - code-highlighting
+    - web-preview
+    - branch-navigation
+    - thinking-display
+    - perplexity-style
+    - claude-artifacts
 ---
-
 # AI Elements Chatbot Components
 
 **Status**: Production Ready ✅ | **Last Verified**: 2025-11-18

--- a/plugins/ai-sdk-core/.claude-plugin/plugin.json
+++ b/plugins/ai-sdk-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-sdk-core",
   "description": "Vercel AI SDK v5 for backend AI (text generation, structured output, tools, agents). Multi-provider. Use for server-side AI or encountering AI_APICallError, AI_NoObjectGeneratedError, streaming failures.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ai-sdk-core/skills/ai-sdk-core/SKILL.md
+++ b/plugins/ai-sdk-core/skills/ai-sdk-core/SKILL.md
@@ -1,15 +1,34 @@
 ---
 name: ai-sdk-core
-description: >-
-  Vercel AI SDK v5 for backend AI (text generation, structured output, tools, agents). Multi-provider. Use for server-side AI or encountering AI_APICallError, AI_NoObjectGeneratedError, streaming failures.
+description: "Vercel AI SDK v5 for backend AI (text generation, structured output, tools, agents). Multi-provider. Use for server-side AI or encountering AI_APICallError, AI_NoObjectGeneratedError, streaming failures."
 
-    Keywords: ai sdk core, vercel ai sdk, generateText, streamText, generateObject, streamObject,
-    ai sdk node, ai sdk server, zod ai schema, ai tools calling, ai agent class, openai sdk, anthropic sdk,
-    google gemini sdk, workers-ai-provider, ai streaming backend, multi-provider ai, ai sdk errors,
-    AI_APICallError, AI_NoObjectGeneratedError, streamText fails, worker startup limit ai
+metadata:
+  keywords:
+    - ai sdk core
+    - vercel ai sdk
+    - generateText
+    - streamText
+    - generateObject
+    - streamObject
+    - ai sdk node
+    - ai sdk server
+    - zod ai schema
+    - ai tools calling
+    - ai agent class
+    - openai sdk
+    - anthropic sdk
+    - google gemini sdk
+    - workers-ai-provider
+    - ai streaming backend
+    - multi-provider ai
+    - ai sdk errors
+    - AI_APICallError
+    - AI_NoObjectGeneratedError
+    - streamText fails
+    - worker startup limit ai
+
 license: MIT
 ---
-
 # AI SDK Core
 
 Production-ready backend AI with Vercel AI SDK v5.

--- a/plugins/ai-sdk-core/skills/ai-sdk-core/SKILL.md
+++ b/plugins/ai-sdk-core/skills/ai-sdk-core/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: ai-sdk-core
-description: Vercel AI SDK v5 for backend AI (text generation, structured output, tools, agents). Multi-provider. Use for server-side AI or encountering AI_APICallError, AI_NoObjectGeneratedError, streaming failures.
+description: >-
+  Vercel AI SDK v5 for backend AI (text generation, structured output, tools, agents). Multi-provider. Use for server-side AI or encountering AI_APICallError, AI_NoObjectGeneratedError, streaming failures.
 
-  Keywords: ai sdk core, vercel ai sdk, generateText, streamText, generateObject, streamObject,
-  ai sdk node, ai sdk server, zod ai schema, ai tools calling, ai agent class, openai sdk, anthropic sdk,
-  google gemini sdk, workers-ai-provider, ai streaming backend, multi-provider ai, ai sdk errors,
-  AI_APICallError, AI_NoObjectGeneratedError, streamText fails, worker startup limit ai
+    Keywords: ai sdk core, vercel ai sdk, generateText, streamText, generateObject, streamObject,
+    ai sdk node, ai sdk server, zod ai schema, ai tools calling, ai agent class, openai sdk, anthropic sdk,
+    google gemini sdk, workers-ai-provider, ai streaming backend, multi-provider ai, ai sdk errors,
+    AI_APICallError, AI_NoObjectGeneratedError, streamText fails, worker startup limit ai
 license: MIT
 ---
 

--- a/plugins/ai-sdk-ui/.claude-plugin/plugin.json
+++ b/plugins/ai-sdk-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-sdk-ui",
   "description": "Vercel AI SDK v5 React hooks (useChat, useCompletion, useObject) for AI chat interfaces. Use for React/Next.js AI apps or encountering parse stream errors, no response, streaming issues.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ai-sdk-ui/skills/ai-sdk-ui/SKILL.md
+++ b/plugins/ai-sdk-ui/skills/ai-sdk-ui/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: ai-sdk-ui
-description: Vercel AI SDK v5 React hooks (useChat, useCompletion, useObject) for AI chat interfaces. Use for React/Next.js AI apps or encountering parse stream errors, no response, streaming issues.
+description: >-
+  Vercel AI SDK v5 React hooks (useChat, useCompletion, useObject) for AI chat interfaces. Use for React/Next.js AI apps or encountering parse stream errors, no response, streaming issues.
 
-  Keywords: ai sdk ui, useChat hook, useCompletion hook, useObject hook, react ai chat, ai chat interface,
-  streaming ai ui, nextjs ai chat, vercel ai ui, react streaming, ai sdk react, chat message state,
-  ai file attachments, message persistence, useChat error, streaming failed ui, parse stream error,
-  useChat no response, react ai hooks, nextjs app router ai, nextjs pages router ai
+    Keywords: ai sdk ui, useChat hook, useCompletion hook, useObject hook, react ai chat, ai chat interface,
+    streaming ai ui, nextjs ai chat, vercel ai ui, react streaming, ai sdk react, chat message state,
+    ai file attachments, message persistence, useChat error, streaming failed ui, parse stream error,
+    useChat no response, react ai hooks, nextjs app router ai, nextjs pages router ai
 license: MIT
 ---
 

--- a/plugins/ai-sdk-ui/skills/ai-sdk-ui/SKILL.md
+++ b/plugins/ai-sdk-ui/skills/ai-sdk-ui/SKILL.md
@@ -1,15 +1,33 @@
 ---
 name: ai-sdk-ui
-description: >-
-  Vercel AI SDK v5 React hooks (useChat, useCompletion, useObject) for AI chat interfaces. Use for React/Next.js AI apps or encountering parse stream errors, no response, streaming issues.
+description: "Vercel AI SDK v5 React hooks (useChat, useCompletion, useObject) for AI chat interfaces. Use for React/Next.js AI apps or encountering parse stream errors, no response, streaming issues."
 
-    Keywords: ai sdk ui, useChat hook, useCompletion hook, useObject hook, react ai chat, ai chat interface,
-    streaming ai ui, nextjs ai chat, vercel ai ui, react streaming, ai sdk react, chat message state,
-    ai file attachments, message persistence, useChat error, streaming failed ui, parse stream error,
-    useChat no response, react ai hooks, nextjs app router ai, nextjs pages router ai
+metadata:
+  keywords:
+    - ai sdk ui
+    - useChat hook
+    - useCompletion hook
+    - useObject hook
+    - react ai chat
+    - ai chat interface
+    - streaming ai ui
+    - nextjs ai chat
+    - vercel ai ui
+    - react streaming
+    - ai sdk react
+    - chat message state
+    - ai file attachments
+    - message persistence
+    - useChat error
+    - streaming failed ui
+    - parse stream error
+    - useChat no response
+    - react ai hooks
+    - nextjs app router ai
+    - nextjs pages router ai
+
 license: MIT
 ---
-
 # AI SDK UI - Frontend React Hooks
 
 Frontend React hooks for AI-powered user interfaces with Vercel AI SDK v5.

--- a/plugins/api-authentication/.claude-plugin/plugin.json
+++ b/plugins/api-authentication/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-authentication",
   "description": "Secure API authentication with JWT, OAuth 2.0, API keys. Use for authentication systems, third-party integrations, service-to-service communication, or encountering token management, security headers, auth flow errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-changelog-versioning/.claude-plugin/plugin.json
+++ b/plugins/api-changelog-versioning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-changelog-versioning",
   "description": "Creates comprehensive API changelogs documenting breaking changes, deprecations, and migration strategies for API consumers. Use when managing API versions, communicating breaking changes, or creating upgrade guides.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-contract-testing/.claude-plugin/plugin.json
+++ b/plugins/api-contract-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-contract-testing",
   "description": "Verifies API contracts between services using consumer-driven contracts, schema validation, and tools like Pact. Use when testing microservices communication, preventing breaking changes, or validating OpenAPI specifications.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-design-principles/.claude-plugin/plugin.json
+++ b/plugins/api-design-principles/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-design-principles",
   "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewing API specifications, or establishing API design standards.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-error-handling/.claude-plugin/plugin.json
+++ b/plugins/api-error-handling/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-error-handling",
   "description": "Implements standardized API error responses with proper status codes, logging, and user-friendly messages. Use when building production APIs, implementing error recovery patterns, or integrating error monitoring services.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-filtering-sorting/.claude-plugin/plugin.json
+++ b/plugins/api-filtering-sorting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-filtering-sorting",
   "description": "Builds flexible API filtering and sorting systems with query parameter parsing, validation, and security. Use when implementing search endpoints, building data grids, or creating dynamic query APIs.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-gateway-configuration/.claude-plugin/plugin.json
+++ b/plugins/api-gateway-configuration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-gateway-configuration",
   "description": "Configures API gateways for routing, authentication, rate limiting, and request transformation in microservice architectures. Use when setting up Kong, Nginx, AWS API Gateway, or Traefik for centralized API management.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-pagination/.claude-plugin/plugin.json
+++ b/plugins/api-pagination/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-pagination",
   "description": "Implements efficient API pagination using offset, cursor, and keyset strategies for large datasets. Use when building paginated endpoints, implementing infinite scroll, or optimizing database queries for collections.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-rate-limiting/.claude-plugin/plugin.json
+++ b/plugins/api-rate-limiting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-rate-limiting",
   "description": "Implements API rate limiting using token bucket, sliding window, and Redis-based algorithms to protect against abuse. Use when securing public APIs, implementing tiered access, or preventing denial-of-service attacks.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-reference-documentation/.claude-plugin/plugin.json
+++ b/plugins/api-reference-documentation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-reference-documentation",
   "description": "Creates professional API documentation using OpenAPI specifications with endpoints, authentication, and interactive examples. Use when documenting REST APIs, creating SDK references, or building developer portals.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-response-optimization/.claude-plugin/plugin.json
+++ b/plugins/api-response-optimization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-response-optimization",
   "description": "Optimizes API performance through payload reduction, caching strategies, and compression techniques. Use when improving API response times, reducing bandwidth usage, or implementing efficient caching.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-security-hardening/.claude-plugin/plugin.json
+++ b/plugins/api-security-hardening/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-security-hardening",
   "description": "REST API security hardening with authentication, rate limiting, input validation, security headers. Use for production APIs, security audits, defense-in-depth, or encountering vulnerabilities, injection attacks, CORS issues.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-testing/.claude-plugin/plugin.json
+++ b/plugins/api-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-testing",
   "description": "HTTP API testing for TypeScript (Supertest) and Python (httpx, pytest). Test REST APIs, GraphQL, request/response validation, authentication, and error handling.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-versioning-strategy/.claude-plugin/plugin.json
+++ b/plugins/api-versioning-strategy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-versioning-strategy",
   "description": "Implements API versioning using URL paths, headers, or query parameters with backward compatibility and deprecation strategies. Use when managing multiple API versions, planning breaking changes, or designing migration paths.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/app-store-deployment/.claude-plugin/plugin.json
+++ b/plugins/app-store-deployment/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "app-store-deployment",
   "description": "Publishes mobile applications to iOS App Store and Google Play with code signing, versioning, and CI/CD automation. Use when preparing app releases, configuring signing certificates, or setting up automated deployment pipelines.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/architecture-patterns/.claude-plugin/plugin.json
+++ b/plugins/architecture-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "architecture-patterns",
   "description": "Implement proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design. Use when architecting complex backend systems or refactoring existing applications for better maintainability.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/auto-animate/.claude-plugin/plugin.json
+++ b/plugins/auto-animate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-animate",
   "description": "AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/auto-animate/skills/auto-animate/SKILL.md
+++ b/plugins/auto-animate/skills/auto-animate/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: auto-animate
-description: AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity.
+description: >-
+  AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity.
 
-  Keywords: auto-animate, @formkit/auto-animate, formkit, zero-config animation, automatic animations, drop-in animation,
-  list animations, accordion animation, toast animation, form validation animation, lightweight animation, 2kb animation,
-  prefers-reduced-motion, accessible animations, vite react animation, cloudflare workers animation, ssr safe animation
+    Keywords: auto-animate, @formkit/auto-animate, formkit, zero-config animation, automatic animations, drop-in animation,
+    list animations, accordion animation, toast animation, form validation animation, lightweight animation, 2kb animation,
+    prefers-reduced-motion, accessible animations, vite react animation, cloudflare workers animation, ssr safe animation
 license: MIT
 ---
 

--- a/plugins/auto-animate/skills/auto-animate/SKILL.md
+++ b/plugins/auto-animate/skills/auto-animate/SKILL.md
@@ -1,14 +1,29 @@
 ---
 name: auto-animate
-description: >-
-  AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity.
+description: "AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity."
 
-    Keywords: auto-animate, @formkit/auto-animate, formkit, zero-config animation, automatic animations, drop-in animation,
-    list animations, accordion animation, toast animation, form validation animation, lightweight animation, 2kb animation,
-    prefers-reduced-motion, accessible animations, vite react animation, cloudflare workers animation, ssr safe animation
+metadata:
+  keywords:
+    - auto-animate
+    - "@formkit/auto-animate"
+    - formkit
+    - zero-config animation
+    - automatic animations
+    - drop-in animation
+    - list animations
+    - accordion animation
+    - toast animation
+    - form validation animation
+    - lightweight animation
+    - 2kb animation
+    - prefers-reduced-motion
+    - accessible animations
+    - vite react animation
+    - cloudflare workers animation
+    - ssr safe animation
+
 license: MIT
 ---
-
 # AutoAnimate
 
 **Status**: Production Ready ✅

--- a/plugins/base-ui-react/.claude-plugin/plugin.json
+++ b/plugins/base-ui-react/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "base-ui-react",
   "description": "MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/base-ui-react/skills/base-ui-react/SKILL.md
+++ b/plugins/base-ui-react/skills/base-ui-react/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: base-ui-react
-description: >-
-  MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues.
-
-    Keywords: base-ui, @base-ui-components/react, mui base ui, unstyled components, accessible components,
-    render props, radix alternative, radix migration, floating-ui, positioner pattern, headless ui,
-    accessible dialog, accessible select, accessible popover, accessible tooltip, accessible accordion,
-    number field, cloudflare workers ui, beta components
+description: "MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues."
 license: MIT
 metadata:
   version: "2.0.0"
@@ -16,8 +10,27 @@ metadata:
   errors_prevented: 10
   templates_included: 7
   references_included: 3
+  keywords:
+    - base-ui
+    - "@base-ui-components/react"
+    - mui base ui
+    - unstyled components
+    - accessible components
+    - render props
+    - radix alternative
+    - radix migration
+    - floating-ui
+    - positioner pattern
+    - headless ui
+    - accessible dialog
+    - accessible select
+    - accessible popover
+    - accessible tooltip
+    - accessible accordion
+    - number field
+    - cloudflare workers ui
+    - beta components
 ---
-
 # Base UI React
 
 **Status**: Beta (v1.0.0-beta.4) ⚠️ | **Last Verified**: 2025-11-18

--- a/plugins/base-ui-react/skills/base-ui-react/SKILL.md
+++ b/plugins/base-ui-react/skills/base-ui-react/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: base-ui-react
-description: MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues.
+description: >-
+  MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues.
 
-  Keywords: base-ui, @base-ui-components/react, mui base ui, unstyled components, accessible components,
-  render props, radix alternative, radix migration, floating-ui, positioner pattern, headless ui,
-  accessible dialog, accessible select, accessible popover, accessible tooltip, accessible accordion,
-  number field, cloudflare workers ui, beta components
+    Keywords: base-ui, @base-ui-components/react, mui base ui, unstyled components, accessible components,
+    render props, radix alternative, radix migration, floating-ui, positioner pattern, headless ui,
+    accessible dialog, accessible select, accessible popover, accessible tooltip, accessible accordion,
+    number field, cloudflare workers ui, beta components
 license: MIT
 metadata:
   version: "2.0.0"

--- a/plugins/better-auth/.claude-plugin/plugin.json
+++ b/plugins/better-auth/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-auth",
   "description": "Skill for integrating Better Auth - comprehensive TypeScript authentication framework for Cloudflare D1, Next.js, Nuxt, and 15+ frameworks. Use when adding auth, encountering D1 adapter errors, or implementing OAuth/2FA/RBAC features.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/better-chatbot-patterns/.claude-plugin/plugin.json
+++ b/plugins/better-chatbot-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-chatbot-patterns",
   "description": "Reusable better-chatbot patterns for custom deployments. Use for server action validators, tool abstraction, multi-AI providers, or encountering auth validation, FormData parsing, workflow execution errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/better-chatbot-patterns/skills/better-chatbot-patterns/SKILL.md
+++ b/plugins/better-chatbot-patterns/skills/better-chatbot-patterns/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: better-chatbot-patterns
-description: >-
-  Reusable better-chatbot patterns for custom deployments. Use for server action validators, tool abstraction, multi-AI providers, or encountering auth validation, FormData parsing, workflow execution errors.
-
-    Keywords: AI chatbot patterns, server action validators, tool abstraction, multi-AI providers, workflow execution, MCP integration, validated actions, tool type checking, Vercel AI SDK patterns, chatbot architecture
+description: "Reusable better-chatbot patterns for custom deployments. Use for server action validators, tool abstraction, multi-AI providers, or encountering auth validation, FormData parsing, workflow execution errors."
 license: MIT
 metadata:
   version: 1.0.0
@@ -13,8 +10,18 @@ metadata:
   tech_stack: Next.js 15, Vercel AI SDK 5, Zod, Zustand
   token_savings: ~65%
   errors_prevented: 5
+  keywords:
+    - AI chatbot patterns
+    - server action validators
+    - tool abstraction
+    - multi-AI providers
+    - workflow execution
+    - MCP integration
+    - validated actions
+    - tool type checking
+    - Vercel AI SDK patterns
+    - chatbot architecture
 ---
-
 # better-chatbot-patterns
 
 **Status**: Production Ready

--- a/plugins/better-chatbot-patterns/skills/better-chatbot-patterns/SKILL.md
+++ b/plugins/better-chatbot-patterns/skills/better-chatbot-patterns/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: better-chatbot-patterns
-description: Reusable better-chatbot patterns for custom deployments. Use for server action validators, tool abstraction, multi-AI providers, or encountering auth validation, FormData parsing, workflow execution errors.
+description: >-
+  Reusable better-chatbot patterns for custom deployments. Use for server action validators, tool abstraction, multi-AI providers, or encountering auth validation, FormData parsing, workflow execution errors.
 
-  Keywords: AI chatbot patterns, server action validators, tool abstraction, multi-AI providers, workflow execution, MCP integration, validated actions, tool type checking, Vercel AI SDK patterns, chatbot architecture
+    Keywords: AI chatbot patterns, server action validators, tool abstraction, multi-AI providers, workflow execution, MCP integration, validated actions, tool type checking, Vercel AI SDK patterns, chatbot architecture
 license: MIT
 metadata:
   version: 1.0.0

--- a/plugins/better-chatbot/.claude-plugin/plugin.json
+++ b/plugins/better-chatbot/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-chatbot",
   "description": "better-chatbot project conventions and standards. Use for contributing code, following three-tier tool system (MCP/Workflow/Default), or encountering server action validators, repository patterns, component design errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/better-chatbot/skills/better-chatbot/SKILL.md
+++ b/plugins/better-chatbot/skills/better-chatbot/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: better-chatbot
-description: better-chatbot project conventions and standards. Use for contributing code, following three-tier tool system (MCP/Workflow/Default), or encountering server action validators, repository patterns, component design errors.
+description: >-
+  better-chatbot project conventions and standards. Use for contributing code, following three-tier tool system (MCP/Workflow/Default), or encountering server action validators, repository patterns, component design errors.
 
-  Keywords: better-chatbot, chatbot contribution, better-chatbot standards, chatbot development, AI chatbot patterns, API architecture, three-tier tool system, repository pattern, progressive enhancement, defensive programming, streaming-first, compound component pattern, Next.js chatbot, Vercel AI SDK chatbot, MCP tools, workflow builder, server action validators, tool abstraction, DAG workflows, shared business logic, safe() wrapper, tool lifecycle
+    Keywords: better-chatbot, chatbot contribution, better-chatbot standards, chatbot development, AI chatbot patterns, API architecture, three-tier tool system, repository pattern, progressive enhancement, defensive programming, streaming-first, compound component pattern, Next.js chatbot, Vercel AI SDK chatbot, MCP tools, workflow builder, server action validators, tool abstraction, DAG workflows, shared business logic, safe() wrapper, tool lifecycle
 license: MIT
 metadata:
   version: 3.0.0

--- a/plugins/better-chatbot/skills/better-chatbot/SKILL.md
+++ b/plugins/better-chatbot/skills/better-chatbot/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: better-chatbot
-description: >-
-  better-chatbot project conventions and standards. Use for contributing code, following three-tier tool system (MCP/Workflow/Default), or encountering server action validators, repository patterns, component design errors.
-
-    Keywords: better-chatbot, chatbot contribution, better-chatbot standards, chatbot development, AI chatbot patterns, API architecture, three-tier tool system, repository pattern, progressive enhancement, defensive programming, streaming-first, compound component pattern, Next.js chatbot, Vercel AI SDK chatbot, MCP tools, workflow builder, server action validators, tool abstraction, DAG workflows, shared business logic, safe() wrapper, tool lifecycle
+description: "better-chatbot project conventions and standards. Use for contributing code, following three-tier tool system (MCP/Workflow/Default), or encountering server action validators, repository patterns, component design errors."
 license: MIT
 metadata:
   version: 3.0.0
@@ -14,8 +11,30 @@ metadata:
   token_savings: ~75%
   errors_prevented: 8
   optimization_date: 2025-12-17
+  keywords:
+    - better-chatbot
+    - chatbot contribution
+    - better-chatbot standards
+    - chatbot development
+    - AI chatbot patterns
+    - API architecture
+    - three-tier tool system
+    - repository pattern
+    - progressive enhancement
+    - defensive programming
+    - streaming-first
+    - compound component pattern
+    - Next.js chatbot
+    - Vercel AI SDK chatbot
+    - MCP tools
+    - workflow builder
+    - server action validators
+    - tool abstraction
+    - DAG workflows
+    - shared business logic
+    - safe() wrapper
+    - tool lifecycle
 ---
-
 # better-chatbot Contribution & Standards Skill
 
 **Status**: Production Ready

--- a/plugins/bun/.claude-plugin/plugin.json
+++ b/plugins/bun/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bun",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Comprehensive Bun runtime toolkit covering runtime, package manager, bundler, testing, HTTP servers, WebSockets, databases, framework integrations (Hono, Next.js, Nuxt, TanStack Start, SvelteKit), deployment, and Node.js compatibility.",
   "author": {
     "name": "Claude Skills",

--- a/plugins/bun/skills/bun-ffi/SKILL.md
+++ b/plugins/bun/skills/bun-ffi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bun-ffi
-description: This skill should be used when the user asks about "bun:ffi", "foreign function interface", "calling C from Bun", "native libraries", "dlopen", "shared libraries", "calling native code", or integrating C/C++ libraries with Bun.
+description: "This skill should be used when the user asks about \"bun:ffi\", \"foreign function interface\", \"calling C from Bun\", \"native libraries\", \"dlopen\", \"shared libraries\", \"calling native code\", or integrating C/C++ libraries with Bun."
 metadata:
   version: "1.0.0"
 license: MIT

--- a/plugins/bun/skills/bun-file-io/SKILL.md
+++ b/plugins/bun/skills/bun-file-io/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bun-file-io
-description: Use for Bun file I/O: Bun.file, Bun.write, streams, directories, glob patterns, metadata.
+description: "Use for Bun file I/O: Bun.file, Bun.write, streams, directories, glob patterns, metadata."
 metadata:
   version: "1.0.0"
 license: MIT

--- a/plugins/bun/skills/bun-sqlite/SKILL.md
+++ b/plugins/bun/skills/bun-sqlite/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bun-sqlite
-description: Use for bun:sqlite, SQLite operations, prepared statements, transactions, and queries.
+description: "Use for bun:sqlite, SQLite operations, prepared statements, transactions, and queries."
 metadata:
   version: "1.0.0"
 license: MIT

--- a/plugins/bun/skills/bun-test-basics/SKILL.md
+++ b/plugins/bun/skills/bun-test-basics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bun-test-basics
-description: Use for bun:test syntax, assertions, describe/it, test.skip/only/each, and basic patterns.
+description: "Use for bun:test syntax, assertions, describe/it, test.skip/only/each, and basic patterns."
 metadata:
   version: "1.0.0"
 license: MIT

--- a/plugins/bun/skills/bun-test-lifecycle/SKILL.md
+++ b/plugins/bun/skills/bun-test-lifecycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bun-test-lifecycle
-description: Use for test lifecycle hooks: beforeAll, afterAll, beforeEach, afterEach, fixtures, preload.
+description: "Use for test lifecycle hooks: beforeAll, afterAll, beforeEach, afterEach, fixtures, preload."
 metadata:
   version: "1.0.0"
 license: MIT

--- a/plugins/chrome-devtools/.claude-plugin/plugin.json
+++ b/plugins/chrome-devtools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chrome-devtools",
   "description": "Browser automation with Puppeteer CLI scripts. Use for screenshots, performance analysis, network monitoring, web scraping, form automation, or encountering JavaScript debugging, browser automation errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/claude-agent-sdk/.claude-plugin/plugin.json
+++ b/plugins/claude-agent-sdk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-agent-sdk",
   "description": "Anthropic Claude Agent SDK for autonomous agents and multi-step workflows. Use for subagents, tool orchestration, MCP servers, or encountering CLI not found, context length exceeded errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/claude-agent-sdk/skills/claude-agent-sdk/SKILL.md
+++ b/plugins/claude-agent-sdk/skills/claude-agent-sdk/SKILL.md
@@ -1,12 +1,29 @@
 ---
 name: claude-agent-sdk
-description: >-
-  Anthropic Claude Agent SDK for autonomous agents and multi-step workflows. Use for subagents, tool orchestration, MCP servers, or encountering CLI not found, context length exceeded errors.
+description: "Anthropic Claude Agent SDK for autonomous agents and multi-step workflows. Use for subagents, tool orchestration, MCP servers, or encountering CLI not found, context length exceeded errors."
 
-    Keywords: claude agent sdk, @anthropic-ai/claude-agent-sdk, query(), createSdkMcpServer, AgentDefinition, tool(), claude subagents, mcp servers, autonomous agents, agentic loops, session management, permissionMode, canUseTool, multi-agent orchestration, settingSources, CLI not found, context length exceeded
+metadata:
+  keywords:
+    - claude agent sdk
+    - "@anthropic-ai/claude-agent-sdk"
+    - query()
+    - createSdkMcpServer
+    - AgentDefinition
+    - tool()
+    - claude subagents
+    - mcp servers
+    - autonomous agents
+    - agentic loops
+    - session management
+    - permissionMode
+    - canUseTool
+    - multi-agent orchestration
+    - settingSources
+    - CLI not found
+    - context length exceeded
+
 license: MIT
 ---
-
 # Claude Agent SDK
 
 **Status**: Production Ready

--- a/plugins/claude-agent-sdk/skills/claude-agent-sdk/SKILL.md
+++ b/plugins/claude-agent-sdk/skills/claude-agent-sdk/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: claude-agent-sdk
-description: Anthropic Claude Agent SDK for autonomous agents and multi-step workflows. Use for subagents, tool orchestration, MCP servers, or encountering CLI not found, context length exceeded errors.
+description: >-
+  Anthropic Claude Agent SDK for autonomous agents and multi-step workflows. Use for subagents, tool orchestration, MCP servers, or encountering CLI not found, context length exceeded errors.
 
-  Keywords: claude agent sdk, @anthropic-ai/claude-agent-sdk, query(), createSdkMcpServer, AgentDefinition, tool(), claude subagents, mcp servers, autonomous agents, agentic loops, session management, permissionMode, canUseTool, multi-agent orchestration, settingSources, CLI not found, context length exceeded
+    Keywords: claude agent sdk, @anthropic-ai/claude-agent-sdk, query(), createSdkMcpServer, AgentDefinition, tool(), claude subagents, mcp servers, autonomous agents, agentic loops, session management, permissionMode, canUseTool, multi-agent orchestration, settingSources, CLI not found, context length exceeded
 license: MIT
 ---
 

--- a/plugins/claude-api/.claude-plugin/plugin.json
+++ b/plugins/claude-api/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-api",
   "description": "Anthropic Messages API (Claude API) for integrations, streaming, prompt caching, tool use, vision. Use for chatbots, assistants, or encountering rate limits, 429 errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/claude-api/skills/claude-api/SKILL.md
+++ b/plugins/claude-api/skills/claude-api/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: claude-api
-description: >-
-  Anthropic Messages API (Claude API) for integrations, streaming, prompt caching, tool use, vision. Use for chatbots, assistants, or encountering rate limits, 429 errors.
-
-    Keywords: claude api, anthropic api, messages api, @anthropic-ai/sdk, claude streaming, prompt caching, tool use, vision, extended thinking, claude 3.5 sonnet, claude 3.7 sonnet, claude sonnet 4, function calling, SSE, rate limits, 429 errors
+description: "Anthropic Messages API (Claude API) for integrations, streaming, prompt caching, tool use, vision. Use for chatbots, assistants, or encountering rate limits, 429 errors."
 license: MIT
 metadata:
   version: "2.0.0"
@@ -11,8 +8,24 @@ metadata:
   sdk_version: "@anthropic-ai/sdk@0.70.1"
   templates_included: 12
   references_included: 7
+  keywords:
+    - claude api
+    - anthropic api
+    - messages api
+    - "@anthropic-ai/sdk"
+    - claude streaming
+    - prompt caching
+    - tool use
+    - vision
+    - extended thinking
+    - claude 3.5 sonnet
+    - claude 3.7 sonnet
+    - claude sonnet 4
+    - function calling
+    - SSE
+    - rate limits
+    - 429 errors
 ---
-
 # Claude API (Anthropic Messages API)
 
 **Status**: Production Ready | **SDK**: @anthropic-ai/sdk@0.70.1

--- a/plugins/claude-api/skills/claude-api/SKILL.md
+++ b/plugins/claude-api/skills/claude-api/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: claude-api
-description: Anthropic Messages API (Claude API) for integrations, streaming, prompt caching, tool use, vision. Use for chatbots, assistants, or encountering rate limits, 429 errors.
+description: >-
+  Anthropic Messages API (Claude API) for integrations, streaming, prompt caching, tool use, vision. Use for chatbots, assistants, or encountering rate limits, 429 errors.
 
-  Keywords: claude api, anthropic api, messages api, @anthropic-ai/sdk, claude streaming, prompt caching, tool use, vision, extended thinking, claude 3.5 sonnet, claude 3.7 sonnet, claude sonnet 4, function calling, SSE, rate limits, 429 errors
+    Keywords: claude api, anthropic api, messages api, @anthropic-ai/sdk, claude streaming, prompt caching, tool use, vision, extended thinking, claude 3.5 sonnet, claude 3.7 sonnet, claude sonnet 4, function calling, SSE, rate limits, 429 errors
 license: MIT
 metadata:
   version: "2.0.0"

--- a/plugins/claude-code-bash-patterns/.claude-plugin/plugin.json
+++ b/plugins/claude-code-bash-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-bash-patterns",
   "description": "Claude Code Bash tool patterns with hooks, automation, git workflows. Use for PreToolUse hooks, command chaining, CLI orchestration, custom commands, or encountering bash permissions, command failures, security guards, hook configurations.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/claude-hook-writer/.claude-plugin/plugin.json
+++ b/plugins/claude-hook-writer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hook-writer",
   "description": "Expert guidance for writing secure, reliable, and performant Claude Code hooks - validates design decisions, enforces best practices, and prevents common pitfalls. Use when creating, reviewing, or debugging Claude Code hooks.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-agents/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-agents",
   "description": "Build AI agents on Cloudflare Workers with MCP integration, tool use, and LLM providers.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-browser-rendering/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-browser-rendering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-browser-rendering",
   "description": "Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-browser-rendering/skills/cloudflare-browser-rendering/SKILL.md
+++ b/plugins/cloudflare-browser-rendering/skills/cloudflare-browser-rendering/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: cloudflare-browser-rendering
-description: Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded.
+description: >-
+  Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded.
 
-  Keywords: browser rendering cloudflare, @cloudflare/puppeteer, @cloudflare/playwright,
-  puppeteer workers, playwright workers, screenshot cloudflare, pdf generation workers,
-  web scraping cloudflare, headless chrome workers, browser automation, puppeteer.launch,
-  playwright.chromium.launch, browser binding, session management, puppeteer.sessions,
-  puppeteer.connect, browser.close, browser.disconnect, XPath not supported, browser timeout,
-  concurrency limit, keep_alive, page.screenshot, page.pdf, page.goto, page.evaluate,
-  incognito context, session reuse, batch scraping, crawling websites
+    Keywords: browser rendering cloudflare, @cloudflare/puppeteer, @cloudflare/playwright,
+    puppeteer workers, playwright workers, screenshot cloudflare, pdf generation workers,
+    web scraping cloudflare, headless chrome workers, browser automation, puppeteer.launch,
+    playwright.chromium.launch, browser binding, session management, puppeteer.sessions,
+    puppeteer.connect, browser.close, browser.disconnect, XPath not supported, browser timeout,
+    concurrency limit, keep_alive, page.screenshot, page.pdf, page.goto, page.evaluate,
+    incognito context, session reuse, batch scraping, crawling websites
 license: MIT
 metadata:
   version: "1.0.0"

--- a/plugins/cloudflare-browser-rendering/skills/cloudflare-browser-rendering/SKILL.md
+++ b/plugins/cloudflare-browser-rendering/skills/cloudflare-browser-rendering/SKILL.md
@@ -1,15 +1,6 @@
 ---
 name: cloudflare-browser-rendering
-description: >-
-  Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded.
-
-    Keywords: browser rendering cloudflare, @cloudflare/puppeteer, @cloudflare/playwright,
-    puppeteer workers, playwright workers, screenshot cloudflare, pdf generation workers,
-    web scraping cloudflare, headless chrome workers, browser automation, puppeteer.launch,
-    playwright.chromium.launch, browser binding, session management, puppeteer.sessions,
-    puppeteer.connect, browser.close, browser.disconnect, XPath not supported, browser timeout,
-    concurrency limit, keep_alive, page.screenshot, page.pdf, page.goto, page.evaluate,
-    incognito context, session reuse, batch scraping, crawling websites
+description: "Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded."
 license: MIT
 metadata:
   version: "1.0.0"
@@ -21,8 +12,38 @@ metadata:
   production_tested: true
   errors_prevented: 6
   references_included: 6
+  keywords:
+    - browser rendering cloudflare
+    - "@cloudflare/puppeteer"
+    - "@cloudflare/playwright"
+    - puppeteer workers
+    - playwright workers
+    - screenshot cloudflare
+    - pdf generation workers
+    - web scraping cloudflare
+    - headless chrome workers
+    - browser automation
+    - puppeteer.launch
+    - playwright.chromium.launch
+    - browser binding
+    - session management
+    - puppeteer.sessions
+    - puppeteer.connect
+    - browser.close
+    - browser.disconnect
+    - XPath not supported
+    - browser timeout
+    - concurrency limit
+    - keep_alive
+    - page.screenshot
+    - page.pdf
+    - page.goto
+    - page.evaluate
+    - incognito context
+    - session reuse
+    - batch scraping
+    - crawling websites
 ---
-
 # Cloudflare Browser Rendering - Complete Reference
 
 Production-ready knowledge domain for building browser automation workflows with Cloudflare Browser Rendering.

--- a/plugins/cloudflare-cron-triggers/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-cron-triggers/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-cron-triggers",
   "description": "Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-cron-triggers/skills/cloudflare-cron-triggers/SKILL.md
+++ b/plugins/cloudflare-cron-triggers/skills/cloudflare-cron-triggers/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: cloudflare-cron-triggers
-description: Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors.
+description: >-
+  Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors.
 
-  Keywords: cloudflare cron, cron triggers, scheduled workers, scheduled handler, periodic tasks,
-  background jobs, scheduled tasks, cron expression, wrangler crons, scheduled event, green compute,
-  workflow triggers, maintenance tasks, scheduled() handler, ScheduledController, UTC timezone
+    Keywords: cloudflare cron, cron triggers, scheduled workers, scheduled handler, periodic tasks,
+    background jobs, scheduled tasks, cron expression, wrangler crons, scheduled event, green compute,
+    workflow triggers, maintenance tasks, scheduled() handler, ScheduledController, UTC timezone
 license: MIT
 ---
 

--- a/plugins/cloudflare-cron-triggers/skills/cloudflare-cron-triggers/SKILL.md
+++ b/plugins/cloudflare-cron-triggers/skills/cloudflare-cron-triggers/SKILL.md
@@ -1,14 +1,28 @@
 ---
 name: cloudflare-cron-triggers
-description: >-
-  Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors.
+description: "Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors."
 
-    Keywords: cloudflare cron, cron triggers, scheduled workers, scheduled handler, periodic tasks,
-    background jobs, scheduled tasks, cron expression, wrangler crons, scheduled event, green compute,
-    workflow triggers, maintenance tasks, scheduled() handler, ScheduledController, UTC timezone
+metadata:
+  keywords:
+    - cloudflare cron
+    - cron triggers
+    - scheduled workers
+    - scheduled handler
+    - periodic tasks
+    - background jobs
+    - scheduled tasks
+    - cron expression
+    - wrangler crons
+    - scheduled event
+    - green compute
+    - workflow triggers
+    - maintenance tasks
+    - scheduled() handler
+    - ScheduledController
+    - UTC timezone
+
 license: MIT
 ---
-
 # Cloudflare Cron Triggers
 
 **Status**: Production Ready ✅

--- a/plugins/cloudflare-d1/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-d1/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-d1",
   "description": "Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-d1/skills/cloudflare-d1/SKILL.md
+++ b/plugins/cloudflare-d1/skills/cloudflare-d1/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: cloudflare-d1
-description: Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors.
-Keywords: d1, d1 database, cloudflare d1, wrangler d1, d1 migrations, d1 bindings, sqlite workers,
-  edge database, d1 queries, sql cloudflare, prepared statements, batch queries,
-  d1 api, wrangler migrations, D1_ERROR, D1_EXEC_ERROR, statement too long, database bindings,
-  sqlite cloudflare, sql workers api, d1 indexes, query optimization, d1 schema, read replication,
-  read replica, withSession, Sessions API, global replication, database replication, served_by_region,
-  bookmarks, sequential consistency
+description: >-
+  Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors.
+  Keywords: d1, d1 database, cloudflare d1, wrangler d1, d1 migrations, d1 bindings, sqlite workers,
+    edge database, d1 queries, sql cloudflare, prepared statements, batch queries,
+    d1 api, wrangler migrations, D1_ERROR, D1_EXEC_ERROR, statement too long, database bindings,
+    sqlite cloudflare, sql workers api, d1 indexes, query optimization, d1 schema, read replication,
+    read replica, withSession, Sessions API, global replication, database replication, served_by_region,
+    bookmarks, sequential consistency
 license: MIT
 metadata:
   version: "3.0.0"

--- a/plugins/cloudflare-d1/skills/cloudflare-d1/SKILL.md
+++ b/plugins/cloudflare-d1/skills/cloudflare-d1/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: cloudflare-d1
-description: >-
-  Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors.
-  Keywords: d1, d1 database, cloudflare d1, wrangler d1, d1 migrations, d1 bindings, sqlite workers,
-    edge database, d1 queries, sql cloudflare, prepared statements, batch queries,
-    d1 api, wrangler migrations, D1_ERROR, D1_EXEC_ERROR, statement too long, database bindings,
-    sqlite cloudflare, sql workers api, d1 indexes, query optimization, d1 schema, read replication,
-    read replica, withSession, Sessions API, global replication, database replication, served_by_region,
-    bookmarks, sequential consistency
+description: "Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors."
 license: MIT
 metadata:
   version: "3.0.0"
@@ -20,8 +13,40 @@ metadata:
   wrangler_version: "4.50.0"
   workers_types_version: "4.20251125.0"
   drizzle_orm_version: "0.44.7"
+  keywords:
+    - d1
+    - d1 database
+    - cloudflare d1
+    - wrangler d1
+    - d1 migrations
+    - d1 bindings
+    - sqlite workers
+    - edge database
+    - d1 queries
+    - sql cloudflare
+    - prepared statements
+    - batch queries
+    - d1 api
+    - wrangler migrations
+    - D1_ERROR
+    - D1_EXEC_ERROR
+    - statement too long
+    - database bindings
+    - sqlite cloudflare
+    - sql workers api
+    - d1 indexes
+    - query optimization
+    - d1 schema
+    - read replication
+    - read replica
+    - withSession
+    - Sessions API
+    - global replication
+    - database replication
+    - served_by_region
+    - bookmarks
+    - sequential consistency
 ---
-
 # Cloudflare D1 Database
 
 **Status**: Production Ready ✅ | **Last Verified**: 2025-01-15

--- a/plugins/cloudflare-durable-objects/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-durable-objects/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-durable-objects",
   "description": "Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-durable-objects/skills/cloudflare-durable-objects/SKILL.md
+++ b/plugins/cloudflare-durable-objects/skills/cloudflare-durable-objects/SKILL.md
@@ -1,12 +1,45 @@
 ---
 name: cloudflare-durable-objects
-description: >-
-  Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors.
+description: "Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors."
 
-    Keywords: durable objects, cloudflare do, DurableObject class, do bindings, websocket hibernation, do state api, ctx.storage.sql, ctx.acceptWebSocket, webSocketMessage, alarm() handler, storage.setAlarm, idFromName, newUniqueId, getByName, DurableObjectStub, serializeAttachment, real-time cloudflare, multiplayer cloudflare, chat room workers, coordination cloudflare, stateful workers, new_sqlite_classes, do migrations, location hints, RPC methods, blockConcurrencyWhile, "do class export", "new_sqlite_classes", "migrations required", "websocket hibernation", "alarm api error", "global uniqueness", "binding not found"
+metadata:
+  keywords:
+    - durable objects
+    - cloudflare do
+    - DurableObject class
+    - do bindings
+    - websocket hibernation
+    - do state api
+    - ctx.storage.sql
+    - ctx.acceptWebSocket
+    - webSocketMessage
+    - alarm() handler
+    - storage.setAlarm
+    - idFromName
+    - newUniqueId
+    - getByName
+    - DurableObjectStub
+    - serializeAttachment
+    - real-time cloudflare
+    - multiplayer cloudflare
+    - chat room workers
+    - coordination cloudflare
+    - stateful workers
+    - new_sqlite_classes
+    - do migrations
+    - location hints
+    - RPC methods
+    - blockConcurrencyWhile
+    - "\"do class export\""
+    - "\"new_sqlite_classes\""
+    - "\"migrations required\""
+    - "\"websocket hibernation\""
+    - "\"alarm api error\""
+    - "\"global uniqueness\""
+    - "\"binding not found\""
+
 license: MIT
 ---
-
 # Cloudflare Durable Objects
 
 **Status**: Production Ready ✅

--- a/plugins/cloudflare-durable-objects/skills/cloudflare-durable-objects/SKILL.md
+++ b/plugins/cloudflare-durable-objects/skills/cloudflare-durable-objects/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: cloudflare-durable-objects
-description: Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors.
+description: >-
+  Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors.
 
-  Keywords: durable objects, cloudflare do, DurableObject class, do bindings, websocket hibernation, do state api, ctx.storage.sql, ctx.acceptWebSocket, webSocketMessage, alarm() handler, storage.setAlarm, idFromName, newUniqueId, getByName, DurableObjectStub, serializeAttachment, real-time cloudflare, multiplayer cloudflare, chat room workers, coordination cloudflare, stateful workers, new_sqlite_classes, do migrations, location hints, RPC methods, blockConcurrencyWhile, "do class export", "new_sqlite_classes", "migrations required", "websocket hibernation", "alarm api error", "global uniqueness", "binding not found"
+    Keywords: durable objects, cloudflare do, DurableObject class, do bindings, websocket hibernation, do state api, ctx.storage.sql, ctx.acceptWebSocket, webSocketMessage, alarm() handler, storage.setAlarm, idFromName, newUniqueId, getByName, DurableObjectStub, serializeAttachment, real-time cloudflare, multiplayer cloudflare, chat room workers, coordination cloudflare, stateful workers, new_sqlite_classes, do migrations, location hints, RPC methods, blockConcurrencyWhile, "do class export", "new_sqlite_classes", "migrations required", "websocket hibernation", "alarm api error", "global uniqueness", "binding not found"
 license: MIT
 ---
 

--- a/plugins/cloudflare-email-routing/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-email-routing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-email-routing",
   "description": "Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-email-routing/skills/cloudflare-email-routing/SKILL.md
+++ b/plugins/cloudflare-email-routing/skills/cloudflare-email-routing/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: cloudflare-email-routing
-description: >-
-  Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues.
-
-    Keywords: Cloudflare Email Routing, Email Workers, send email, receive email, email forwarding, email allowlist, email blocklist, postal-mime, mimetext, cloudflare:email, EmailMessage, ForwardableEmailMessage, EmailEvent, MX records, SPF, DKIM, email worker binding, send_email binding, wrangler email, email handler, email routing worker, "Email Trigger not available", "failed to call worker", email delivery failed, email not forwarding, destination address not verified
+description: "Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues."
 license: MIT
 metadata:
   version: "2.0.0"
@@ -13,8 +10,34 @@ metadata:
   errors_prevented: 8
   templates_included: 0
   references_included: 1
+  keywords:
+    - Cloudflare Email Routing
+    - Email Workers
+    - send email
+    - receive email
+    - email forwarding
+    - email allowlist
+    - email blocklist
+    - postal-mime
+    - mimetext
+    - "cloudflare:email"
+    - EmailMessage
+    - ForwardableEmailMessage
+    - EmailEvent
+    - MX records
+    - SPF
+    - DKIM
+    - email worker binding
+    - send_email binding
+    - wrangler email
+    - email handler
+    - email routing worker
+    - "\"Email Trigger not available\""
+    - "\"failed to call worker\""
+    - email delivery failed
+    - email not forwarding
+    - destination address not verified
 ---
-
 # Cloudflare Email Routing
 
 **Status**: Production Ready ✅ | **Last Verified**: 2025-11-18

--- a/plugins/cloudflare-email-routing/skills/cloudflare-email-routing/SKILL.md
+++ b/plugins/cloudflare-email-routing/skills/cloudflare-email-routing/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: cloudflare-email-routing
-description: Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues.
+description: >-
+  Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues.
 
-  Keywords: Cloudflare Email Routing, Email Workers, send email, receive email, email forwarding, email allowlist, email blocklist, postal-mime, mimetext, cloudflare:email, EmailMessage, ForwardableEmailMessage, EmailEvent, MX records, SPF, DKIM, email worker binding, send_email binding, wrangler email, email handler, email routing worker, "Email Trigger not available", "failed to call worker", email delivery failed, email not forwarding, destination address not verified
+    Keywords: Cloudflare Email Routing, Email Workers, send email, receive email, email forwarding, email allowlist, email blocklist, postal-mime, mimetext, cloudflare:email, EmailMessage, ForwardableEmailMessage, EmailEvent, MX records, SPF, DKIM, email worker binding, send_email binding, wrangler email, email handler, email routing worker, "Email Trigger not available", "failed to call worker", email delivery failed, email not forwarding, destination address not verified
 license: MIT
 metadata:
   version: "2.0.0"

--- a/plugins/cloudflare-hyperdrive/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-hyperdrive/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-hyperdrive",
   "description": "Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-hyperdrive/skills/cloudflare-hyperdrive/SKILL.md
+++ b/plugins/cloudflare-hyperdrive/skills/cloudflare-hyperdrive/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: cloudflare-hyperdrive
-description: >-
-  Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused.
-
-    Keywords: hyperdrive, cloudflare hyperdrive, workers hyperdrive, postgres workers, mysql workers, connection pooling, query caching, node-postgres, pg, postgres.js, mysql2, drizzle hyperdrive, prisma hyperdrive, workers rds, workers aurora, workers neon, workers supabase, database acceleration, hybrid architecture, cloudflare tunnel database, wrangler hyperdrive, hyperdrive bindings, local development hyperdrive
+description: "Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused."
 license: MIT
 metadata:
   version: "2.0.0"
@@ -13,8 +10,31 @@ metadata:
   errors_prevented: 6
   templates_included: 0
   references_included: 1
+  keywords:
+    - hyperdrive
+    - cloudflare hyperdrive
+    - workers hyperdrive
+    - postgres workers
+    - mysql workers
+    - connection pooling
+    - query caching
+    - node-postgres
+    - pg
+    - postgres.js
+    - mysql2
+    - drizzle hyperdrive
+    - prisma hyperdrive
+    - workers rds
+    - workers aurora
+    - workers neon
+    - workers supabase
+    - database acceleration
+    - hybrid architecture
+    - cloudflare tunnel database
+    - wrangler hyperdrive
+    - hyperdrive bindings
+    - local development hyperdrive
 ---
-
 # Cloudflare Hyperdrive
 
 **Status**: Production Ready ✅ | **Last Verified**: 2025-11-18

--- a/plugins/cloudflare-hyperdrive/skills/cloudflare-hyperdrive/SKILL.md
+++ b/plugins/cloudflare-hyperdrive/skills/cloudflare-hyperdrive/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: cloudflare-hyperdrive
-description: Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused.
+description: >-
+  Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused.
 
-  Keywords: hyperdrive, cloudflare hyperdrive, workers hyperdrive, postgres workers, mysql workers, connection pooling, query caching, node-postgres, pg, postgres.js, mysql2, drizzle hyperdrive, prisma hyperdrive, workers rds, workers aurora, workers neon, workers supabase, database acceleration, hybrid architecture, cloudflare tunnel database, wrangler hyperdrive, hyperdrive bindings, local development hyperdrive
+    Keywords: hyperdrive, cloudflare hyperdrive, workers hyperdrive, postgres workers, mysql workers, connection pooling, query caching, node-postgres, pg, postgres.js, mysql2, drizzle hyperdrive, prisma hyperdrive, workers rds, workers aurora, workers neon, workers supabase, database acceleration, hybrid architecture, cloudflare tunnel database, wrangler hyperdrive, hyperdrive bindings, local development hyperdrive
 license: MIT
 metadata:
   version: "2.0.0"

--- a/plugins/cloudflare-images/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-images/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-images",
   "description": "This skill should be used when the user asks to \"upload images to Cloudflare\", \"implement direct creator upload\", \"configure image transformations\", \"optimize WebP/AVIF\", \"create image variants\", \"generate signed URLs\", \"add image watermarks\", \"integrate with Next.js/Remix\", \"configure webhooks\", \"debug CORS errors\", \"troubleshoot error 5408/9401-9413\", or \"build responsive images with Cloudflare Images API\".",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-images/skills/cloudflare-images/SKILL.md
+++ b/plugins/cloudflare-images/skills/cloudflare-images/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: cloudflare-images
-description: >-
-  This skill should be used when the user asks to "upload images to Cloudflare", "implement direct creator upload", "configure image transformations", "optimize WebP/AVIF", "create image variants", "generate signed URLs", "add image watermarks", "integrate with Next.js/Remix", "configure webhooks", "debug CORS errors", "troubleshoot error 5408/9401-9413", or "build responsive images with Cloudflare Images API".
-
-    Keywords: cloudflare images, image upload cloudflare, imagedelivery.net, cloudflare image transformations, /cdn-cgi/image/, direct creator upload, image variants, cf.image workers, signed urls images, flexible variants, webp avif conversion, responsive images cloudflare, error 5408, error 9401, error 9403, CORS direct upload, multipart/form-data, image optimization cloudflare, image watermarks, webhooks images, nextjs cloudflare images, remix cloudflare images, custom domains images, content credentials, c2pa
+description: "This skill should be used when the user asks to \"upload images to Cloudflare\", \"implement direct creator upload\", \"configure image transformations\", \"optimize WebP/AVIF\", \"create image variants\", \"generate signed URLs\", \"add image watermarks\", \"integrate with Next.js/Remix\", \"configure webhooks\", \"debug CORS errors\", \"troubleshoot error 5408/9401-9413\", or \"build responsive images with Cloudflare Images API\"."
 license: MIT
 metadata:
   version: "3.0.0"
@@ -21,8 +18,33 @@ metadata:
   examples_included: 3
   diagrams_included: 3
   scripts_included: 5
+  keywords:
+    - cloudflare images
+    - image upload cloudflare
+    - imagedelivery.net
+    - cloudflare image transformations
+    - /cdn-cgi/image/
+    - direct creator upload
+    - image variants
+    - cf.image workers
+    - signed urls images
+    - flexible variants
+    - webp avif conversion
+    - responsive images cloudflare
+    - error 5408
+    - error 9401
+    - error 9403
+    - CORS direct upload
+    - multipart/form-data
+    - image optimization cloudflare
+    - image watermarks
+    - webhooks images
+    - nextjs cloudflare images
+    - remix cloudflare images
+    - custom domains images
+    - content credentials
+    - c2pa
 ---
-
 # Cloudflare Images
 
 **Status**: Production Ready ✅ | **Version**: 3.0.0 | **Last Verified**: 2025-12-27

--- a/plugins/cloudflare-images/skills/cloudflare-images/SKILL.md
+++ b/plugins/cloudflare-images/skills/cloudflare-images/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: cloudflare-images
-description: This skill should be used when the user asks to "upload images to Cloudflare", "implement direct creator upload", "configure image transformations", "optimize WebP/AVIF", "create image variants", "generate signed URLs", "add image watermarks", "integrate with Next.js/Remix", "configure webhooks", "debug CORS errors", "troubleshoot error 5408/9401-9413", or "build responsive images with Cloudflare Images API".
+description: >-
+  This skill should be used when the user asks to "upload images to Cloudflare", "implement direct creator upload", "configure image transformations", "optimize WebP/AVIF", "create image variants", "generate signed URLs", "add image watermarks", "integrate with Next.js/Remix", "configure webhooks", "debug CORS errors", "troubleshoot error 5408/9401-9413", or "build responsive images with Cloudflare Images API".
 
-  Keywords: cloudflare images, image upload cloudflare, imagedelivery.net, cloudflare image transformations, /cdn-cgi/image/, direct creator upload, image variants, cf.image workers, signed urls images, flexible variants, webp avif conversion, responsive images cloudflare, error 5408, error 9401, error 9403, CORS direct upload, multipart/form-data, image optimization cloudflare, image watermarks, webhooks images, nextjs cloudflare images, remix cloudflare images, custom domains images, content credentials, c2pa
+    Keywords: cloudflare images, image upload cloudflare, imagedelivery.net, cloudflare image transformations, /cdn-cgi/image/, direct creator upload, image variants, cf.image workers, signed urls images, flexible variants, webp avif conversion, responsive images cloudflare, error 5408, error 9401, error 9403, CORS direct upload, multipart/form-data, image optimization cloudflare, image watermarks, webhooks images, nextjs cloudflare images, remix cloudflare images, custom domains images, content credentials, c2pa
 license: MIT
 metadata:
   version: "3.0.0"

--- a/plugins/cloudflare-kv/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-kv/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-kv",
   "description": "Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-kv/skills/cloudflare-kv/SKILL.md
+++ b/plugins/cloudflare-kv/skills/cloudflare-kv/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: cloudflare-kv
-description: Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues.
+description: >-
+  Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues.
 
-  Keywords: kv storage, cloudflare kv, workers kv, kv namespace, kv bindings, kv cache, kv ttl, kv metadata,
-  kv list, kv pagination, cache optimization, edge caching, KV_ERROR, 429 too many requests, kv rate limit,
-  eventually consistent, wrangler kv, kv operations, key value storage
+    Keywords: kv storage, cloudflare kv, workers kv, kv namespace, kv bindings, kv cache, kv ttl, kv metadata,
+    kv list, kv pagination, cache optimization, edge caching, KV_ERROR, 429 too many requests, kv rate limit,
+    eventually consistent, wrangler kv, kv operations, key value storage
 license: MIT
 metadata:
   version: "3.0.0"

--- a/plugins/cloudflare-kv/skills/cloudflare-kv/SKILL.md
+++ b/plugins/cloudflare-kv/skills/cloudflare-kv/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: cloudflare-kv
-description: >-
-  Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues.
-
-    Keywords: kv storage, cloudflare kv, workers kv, kv namespace, kv bindings, kv cache, kv ttl, kv metadata,
-    kv list, kv pagination, cache optimization, edge caching, KV_ERROR, 429 too many requests, kv rate limit,
-    eventually consistent, wrangler kv, kv operations, key value storage
+description: "Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues."
 license: MIT
 metadata:
   version: "3.0.0"
@@ -15,8 +10,27 @@ metadata:
   errors_prevented: 5
   templates_included: 5
   references_included: 7
+  keywords:
+    - kv storage
+    - cloudflare kv
+    - workers kv
+    - kv namespace
+    - kv bindings
+    - kv cache
+    - kv ttl
+    - kv metadata
+    - kv list
+    - kv pagination
+    - cache optimization
+    - edge caching
+    - KV_ERROR
+    - 429 too many requests
+    - kv rate limit
+    - eventually consistent
+    - wrangler kv
+    - kv operations
+    - key value storage
 ---
-
 # Cloudflare Workers KV
 
 **Status**: Production Ready ✅ | **Last Verified**: 2025-12-27

--- a/plugins/cloudflare-manager/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-manager/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-manager",
   "description": "Comprehensive Cloudflare account management for deploying Workers, KV Storage, R2, Pages, DNS, and Routes. Use when deploying cloudflare services, managing worker containers, configuring KV/R2 storage, or setting up DNS/routing. Requires CLOUDFLARE_API_KEY in .env and Bun runtime with dependencies installed.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-mcp-server/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-mcp-server/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-mcp-server",
   "description": "Build MCP (Model Context Protocol) servers on Cloudflare Workers with tools, resources, and prompts.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-nextjs/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-nextjs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-nextjs",
   "description": "Deploy Next.js to Cloudflare Workers via OpenNext adapter. Use for SSR, ISR, App/Pages Router, or encountering worker size limits, runtime compatibility, connection scoping errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-nextjs/skills/cloudflare-nextjs/SKILL.md
+++ b/plugins/cloudflare-nextjs/skills/cloudflare-nextjs/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: cloudflare-nextjs
-description: Deploy Next.js to Cloudflare Workers via OpenNext adapter. Use for SSR, ISR, App/Pages Router, or encountering worker size limits, runtime compatibility, connection scoping errors.
+description: >-
+  Deploy Next.js to Cloudflare Workers via OpenNext adapter. Use for SSR, ISR, App/Pages Router, or encountering worker size limits, runtime compatibility, connection scoping errors.
 
-  Keywords: Cloudflare Next.js, OpenNext Cloudflare, @opennextjs/cloudflare, Next.js Workers, Next.js App Router Cloudflare, Next.js Pages Router Cloudflare, Next.js SSR Cloudflare, Next.js ISR, server components cloudflare, server actions cloudflare, Next.js middleware workers, nextjs d1, nextjs r2, nextjs kv, Next.js deployment, opennextjs-cloudflare cli, nodejs_compat, worker size limit, next.js runtime compatibility, database connection scoping, Next.js migration cloudflare
+    Keywords: Cloudflare Next.js, OpenNext Cloudflare, @opennextjs/cloudflare, Next.js Workers, Next.js App Router Cloudflare, Next.js Pages Router Cloudflare, Next.js SSR Cloudflare, Next.js ISR, server components cloudflare, server actions cloudflare, Next.js middleware workers, nextjs d1, nextjs r2, nextjs kv, Next.js deployment, opennextjs-cloudflare cli, nodejs_compat, worker size limit, next.js runtime compatibility, database connection scoping, Next.js migration cloudflare
 license: MIT
 metadata:
   version: 1.0.0

--- a/plugins/cloudflare-nextjs/skills/cloudflare-nextjs/SKILL.md
+++ b/plugins/cloudflare-nextjs/skills/cloudflare-nextjs/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: cloudflare-nextjs
-description: >-
-  Deploy Next.js to Cloudflare Workers via OpenNext adapter. Use for SSR, ISR, App/Pages Router, or encountering worker size limits, runtime compatibility, connection scoping errors.
-
-    Keywords: Cloudflare Next.js, OpenNext Cloudflare, @opennextjs/cloudflare, Next.js Workers, Next.js App Router Cloudflare, Next.js Pages Router Cloudflare, Next.js SSR Cloudflare, Next.js ISR, server components cloudflare, server actions cloudflare, Next.js middleware workers, nextjs d1, nextjs r2, nextjs kv, Next.js deployment, opennextjs-cloudflare cli, nodejs_compat, worker size limit, next.js runtime compatibility, database connection scoping, Next.js migration cloudflare
+description: "Deploy Next.js to Cloudflare Workers via OpenNext adapter. Use for SSR, ISR, App/Pages Router, or encountering worker size limits, runtime compatibility, connection scoping errors."
 license: MIT
 metadata:
   version: 1.0.0
@@ -19,8 +16,29 @@ metadata:
   errors_prevented: 10
   official_docs: "https://opennext.js.org/cloudflare"
   cloudflare_guide: "https://developers.cloudflare.com/workers/framework-guides/web-apps/nextjs/"
+  keywords:
+    - Cloudflare Next.js
+    - OpenNext Cloudflare
+    - "@opennextjs/cloudflare"
+    - Next.js Workers
+    - Next.js App Router Cloudflare
+    - Next.js Pages Router Cloudflare
+    - Next.js SSR Cloudflare
+    - Next.js ISR
+    - server components cloudflare
+    - server actions cloudflare
+    - Next.js middleware workers
+    - nextjs d1
+    - nextjs r2
+    - nextjs kv
+    - Next.js deployment
+    - opennextjs-cloudflare cli
+    - nodejs_compat
+    - worker size limit
+    - next.js runtime compatibility
+    - database connection scoping
+    - Next.js migration cloudflare
 ---
-
 # Cloudflare Next.js Deployment Skill
 
 Deploy Next.js applications to Cloudflare Workers using the OpenNext Cloudflare adapter for production-ready serverless Next.js hosting.

--- a/plugins/cloudflare-queues/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-queues/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-queues",
   "description": "This skill should be used when the user asks to \"set up Cloudflare Queues\", \"create a message queue\", \"implement queue consumer\", \"process background jobs\", \"configure queue retry logic\", \"publish messages to queue\", \"implement dead letter queue\", or encountering \"queue timeout\", \"message retry\", \"throughput exceeded\", \"queue backlog\" errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-queues/skills/cloudflare-queues/SKILL.md
+++ b/plugins/cloudflare-queues/skills/cloudflare-queues/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: cloudflare-queues
-description: >-
-  This skill should be used when the user asks to "set up Cloudflare Queues", "create a message queue", "implement queue consumer", "process background jobs", "configure queue retry logic", "publish messages to queue", "implement dead letter queue", or encountering "queue timeout", "message retry", "throughput exceeded", "queue backlog" errors.
-
-    Keywords: cloudflare queues, queues workers, message queue, queue bindings, async processing,
-    background jobs, queue consumer, queue producer, batch processing, dead letter queue, dlq,
-    message retry, queue ack, consumer concurrency, queue backlog, wrangler queues
+description: "This skill should be used when the user asks to \"set up Cloudflare Queues\", \"create a message queue\", \"implement queue consumer\", \"process background jobs\", \"configure queue retry logic\", \"publish messages to queue\", \"implement dead letter queue\", or encountering \"queue timeout\", \"message retry\", \"throughput exceeded\", \"queue backlog\" errors."
 license: MIT
 metadata:
   version: "3.0.0"
@@ -17,8 +12,24 @@ metadata:
   references_included: 11
   agents_included: 2
   commands_included: 3
+  keywords:
+    - cloudflare queues
+    - queues workers
+    - message queue
+    - queue bindings
+    - async processing
+    - background jobs
+    - queue consumer
+    - queue producer
+    - batch processing
+    - dead letter queue
+    - dlq
+    - message retry
+    - queue ack
+    - consumer concurrency
+    - queue backlog
+    - wrangler queues
 ---
-
 # Cloudflare Queues
 
 **Status**: Production Ready ✅ | **Last Verified**: 2025-12-27

--- a/plugins/cloudflare-queues/skills/cloudflare-queues/SKILL.md
+++ b/plugins/cloudflare-queues/skills/cloudflare-queues/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: cloudflare-queues
-description: This skill should be used when the user asks to "set up Cloudflare Queues", "create a message queue", "implement queue consumer", "process background jobs", "configure queue retry logic", "publish messages to queue", "implement dead letter queue", or encountering "queue timeout", "message retry", "throughput exceeded", "queue backlog" errors.
+description: >-
+  This skill should be used when the user asks to "set up Cloudflare Queues", "create a message queue", "implement queue consumer", "process background jobs", "configure queue retry logic", "publish messages to queue", "implement dead letter queue", or encountering "queue timeout", "message retry", "throughput exceeded", "queue backlog" errors.
 
-  Keywords: cloudflare queues, queues workers, message queue, queue bindings, async processing,
-  background jobs, queue consumer, queue producer, batch processing, dead letter queue, dlq,
-  message retry, queue ack, consumer concurrency, queue backlog, wrangler queues
+    Keywords: cloudflare queues, queues workers, message queue, queue bindings, async processing,
+    background jobs, queue consumer, queue producer, batch processing, dead letter queue, dlq,
+    message retry, queue ack, consumer concurrency, queue backlog, wrangler queues
 license: MIT
 metadata:
   version: "3.0.0"

--- a/plugins/cloudflare-r2/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-r2/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-r2",
   "description": "Cloudflare R2 S3-compatible object storage with SQL, Iceberg, event notifications, and automation. Use for buckets, uploads, CORS, presigned URLs, large files, S3 migration, analytics, or encountering R2_ERROR, CORS failures, multipart issues.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-r2/skills/cloudflare-r2/SKILL.md
+++ b/plugins/cloudflare-r2/skills/cloudflare-r2/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: cloudflare-r2
-description: Cloudflare R2 S3-compatible object storage. Use for buckets, uploads, CORS, presigned URLs, or encountering R2_ERROR, CORS failures, multipart issues.
+description: >-
+  Cloudflare R2 S3-compatible object storage. Use for buckets, uploads, CORS, presigned URLs, or encountering R2_ERROR, CORS failures, multipart issues.
 
-  Keywords: r2, r2 storage, cloudflare r2, r2 bucket, r2 upload, r2 download, r2 binding, object storage,
-  s3 compatible, r2 cors, presigned urls, multipart upload, r2 api, r2 workers, file upload, asset storage,
-  R2_ERROR, R2Bucket, r2 metadata, custom metadata, http metadata, content-type, cache-control,
-  aws4fetch, s3 client, bulk delete, r2 list, storage class
+    Keywords: r2, r2 storage, cloudflare r2, r2 bucket, r2 upload, r2 download, r2 binding, object storage,
+    s3 compatible, r2 cors, presigned urls, multipart upload, r2 api, r2 workers, file upload, asset storage,
+    R2_ERROR, R2Bucket, r2 metadata, custom metadata, http metadata, content-type, cache-control,
+    aws4fetch, s3 client, bulk delete, r2 list, storage class
 license: MIT
 metadata:
   version: "3.0.0"

--- a/plugins/cloudflare-r2/skills/cloudflare-r2/SKILL.md
+++ b/plugins/cloudflare-r2/skills/cloudflare-r2/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: cloudflare-r2
-description: >-
-  Cloudflare R2 S3-compatible object storage. Use for buckets, uploads, CORS, presigned URLs, or encountering R2_ERROR, CORS failures, multipart issues.
-
-    Keywords: r2, r2 storage, cloudflare r2, r2 bucket, r2 upload, r2 download, r2 binding, object storage,
-    s3 compatible, r2 cors, presigned urls, multipart upload, r2 api, r2 workers, file upload, asset storage,
-    R2_ERROR, R2Bucket, r2 metadata, custom metadata, http metadata, content-type, cache-control,
-    aws4fetch, s3 client, bulk delete, r2 list, storage class
+description: "Cloudflare R2 S3-compatible object storage. Use for buckets, uploads, CORS, presigned URLs, or encountering R2_ERROR, CORS failures, multipart issues."
 license: MIT
 metadata:
   version: "3.0.0"
@@ -22,8 +16,36 @@ metadata:
   wrangler_version: "4.50.0"
   workers_types_version: "4.20251126.0"
   aws4fetch_version: "1.0.20"
+  keywords:
+    - r2
+    - r2 storage
+    - cloudflare r2
+    - r2 bucket
+    - r2 upload
+    - r2 download
+    - r2 binding
+    - object storage
+    - s3 compatible
+    - r2 cors
+    - presigned urls
+    - multipart upload
+    - r2 api
+    - r2 workers
+    - file upload
+    - asset storage
+    - R2_ERROR
+    - R2Bucket
+    - r2 metadata
+    - custom metadata
+    - http metadata
+    - content-type
+    - cache-control
+    - aws4fetch
+    - s3 client
+    - bulk delete
+    - r2 list
+    - storage class
 ---
-
 # Cloudflare R2 Object Storage
 
 **Status**: Production Ready ✅ | **Last Verified**: 2025-12-27 | **v3.0.0**

--- a/plugins/cloudflare-sandbox/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-sandbox/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-sandbox",
   "description": "Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-sandbox/skills/cloudflare-sandbox/SKILL.md
+++ b/plugins/cloudflare-sandbox/skills/cloudflare-sandbox/SKILL.md
@@ -1,12 +1,33 @@
 ---
 name: cloudflare-sandbox
-description: >-
-  Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations.
+description: "Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations."
 
-    Keywords: cloudflare sandbox, container execution, code execution, isolated environment, durable objects, linux container, python execution, node execution, git operations, code interpreter, AI agents, session management, ephemeral container, workspace, sandbox SDK, @cloudflare/sandbox, exec(), getSandbox(), runCode(), gitCheckout(), ubuntu container
+metadata:
+  keywords:
+    - cloudflare sandbox
+    - container execution
+    - code execution
+    - isolated environment
+    - durable objects
+    - linux container
+    - python execution
+    - node execution
+    - git operations
+    - code interpreter
+    - AI agents
+    - session management
+    - ephemeral container
+    - workspace
+    - sandbox SDK
+    - "@cloudflare/sandbox"
+    - exec()
+    - getSandbox()
+    - runCode()
+    - gitCheckout()
+    - ubuntu container
+
 license: MIT
 ---
-
 # Cloudflare Sandboxes SDK
 
 **Status**: Production Ready (Open Beta)

--- a/plugins/cloudflare-sandbox/skills/cloudflare-sandbox/SKILL.md
+++ b/plugins/cloudflare-sandbox/skills/cloudflare-sandbox/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: cloudflare-sandbox
-description: Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations.
+description: >-
+  Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations.
 
-  Keywords: cloudflare sandbox, container execution, code execution, isolated environment, durable objects, linux container, python execution, node execution, git operations, code interpreter, AI agents, session management, ephemeral container, workspace, sandbox SDK, @cloudflare/sandbox, exec(), getSandbox(), runCode(), gitCheckout(), ubuntu container
+    Keywords: cloudflare sandbox, container execution, code execution, isolated environment, durable objects, linux container, python execution, node execution, git operations, code interpreter, AI agents, session management, ephemeral container, workspace, sandbox SDK, @cloudflare/sandbox, exec(), getSandbox(), runCode(), gitCheckout(), ubuntu container
 license: MIT
 ---
 

--- a/plugins/cloudflare-turnstile/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-turnstile/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-turnstile",
   "description": "Cloudflare Turnstile CAPTCHA-alternative bot protection. Use for forms, login security, API protection, or encountering CSP errors, token validation failures, error codes 100*/300*/600*.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-turnstile/skills/cloudflare-turnstile/SKILL.md
+++ b/plugins/cloudflare-turnstile/skills/cloudflare-turnstile/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: cloudflare-turnstile
-description: This skill should be used when the user asks to "add turnstile", "implement bot protection", "validate turnstile token", "fix turnstile error", "setup captcha alternative", or encounters error codes 100*/300*/600*, CSP errors, or token validation failures. Provides CAPTCHA-alternative protection for Cloudflare Workers, React, Next.js, and Hono.
+description: >-
+  This skill should be used when the user asks to "add turnstile", "implement bot protection", "validate turnstile token", "fix turnstile error", "setup captcha alternative", or encounters error codes 100*/300*/600*, CSP errors, or token validation failures. Provides CAPTCHA-alternative protection for Cloudflare Workers, React, Next.js, and Hono.
 
-  Keywords: turnstile, captcha, bot protection, cloudflare challenge, siteverify, recaptcha alternative, spam prevention, form protection, cf-turnstile, turnstile widget, token validation, managed challenge, invisible challenge, @marsidev/react-turnstile, hono turnstile, workers turnstile
+    Keywords: turnstile, captcha, bot protection, cloudflare challenge, siteverify, recaptcha alternative, spam prevention, form protection, cf-turnstile, turnstile widget, token validation, managed challenge, invisible challenge, @marsidev/react-turnstile, hono turnstile, workers turnstile
 license: MIT
 metadata:
   version: "1.1.0"

--- a/plugins/cloudflare-turnstile/skills/cloudflare-turnstile/SKILL.md
+++ b/plugins/cloudflare-turnstile/skills/cloudflare-turnstile/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: cloudflare-turnstile
-description: >-
-  This skill should be used when the user asks to "add turnstile", "implement bot protection", "validate turnstile token", "fix turnstile error", "setup captcha alternative", or encounters error codes 100*/300*/600*, CSP errors, or token validation failures. Provides CAPTCHA-alternative protection for Cloudflare Workers, React, Next.js, and Hono.
-
-    Keywords: turnstile, captcha, bot protection, cloudflare challenge, siteverify, recaptcha alternative, spam prevention, form protection, cf-turnstile, turnstile widget, token validation, managed challenge, invisible challenge, @marsidev/react-turnstile, hono turnstile, workers turnstile
+description: "This skill should be used when the user asks to \"add turnstile\", \"implement bot protection\", \"validate turnstile token\", \"fix turnstile error\", \"setup captcha alternative\", or encounters error codes 100*/300*/600*, CSP errors, or token validation failures. Provides CAPTCHA-alternative protection for Cloudflare Workers, React, Next.js, and Hono."
 license: MIT
 metadata:
   version: "1.1.0"
@@ -13,8 +10,24 @@ metadata:
   errors_prevented: 12
   templates_included: 7
   references_included: 8
+  keywords:
+    - turnstile
+    - captcha
+    - bot protection
+    - cloudflare challenge
+    - siteverify
+    - recaptcha alternative
+    - spam prevention
+    - form protection
+    - cf-turnstile
+    - turnstile widget
+    - token validation
+    - managed challenge
+    - invisible challenge
+    - "@marsidev/react-turnstile"
+    - hono turnstile
+    - workers turnstile
 ---
-
 # Cloudflare Turnstile
 
 **Status**: Production Ready ✅ | **Last Verified**: 2025-11-26

--- a/plugins/cloudflare-vectorize/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-vectorize/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-vectorize",
   "description": "Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-vectorize/skills/cloudflare-vectorize/SKILL.md
+++ b/plugins/cloudflare-vectorize/skills/cloudflare-vectorize/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: cloudflare-vectorize
-description: Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors.
+description: >-
+  Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors.
 
-  Keywords: vectorize, vector database, vector index, vector search, similarity search, semantic search,
-  nearest neighbor, knn search, ann search, RAG, retrieval augmented generation, chat with data,
-  document search, semantic Q&A, context retrieval, bge-base, @cf/baai/bge-base-en-v1.5,
-  text-embedding-3-small, text-embedding-3-large, Workers AI embeddings, openai embeddings,
-  insert vectors, upsert vectors, query vectors, delete vectors, metadata filtering, namespace filtering,
-  topK search, cosine similarity, euclidean distance, dot product, wrangler vectorize, metadata index,
-  create vectorize index, vectorize dimensions, vectorize metric, vectorize binding
+    Keywords: vectorize, vector database, vector index, vector search, similarity search, semantic search,
+    nearest neighbor, knn search, ann search, RAG, retrieval augmented generation, chat with data,
+    document search, semantic Q&A, context retrieval, bge-base, @cf/baai/bge-base-en-v1.5,
+    text-embedding-3-small, text-embedding-3-large, Workers AI embeddings, openai embeddings,
+    insert vectors, upsert vectors, query vectors, delete vectors, metadata filtering, namespace filtering,
+    topK search, cosine similarity, euclidean distance, dot product, wrangler vectorize, metadata index,
+    create vectorize index, vectorize dimensions, vectorize metric, vectorize binding
 license: MIT
 ---
 

--- a/plugins/cloudflare-vectorize/skills/cloudflare-vectorize/SKILL.md
+++ b/plugins/cloudflare-vectorize/skills/cloudflare-vectorize/SKILL.md
@@ -1,18 +1,49 @@
 ---
 name: cloudflare-vectorize
-description: >-
-  Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors.
+description: "Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors."
 
-    Keywords: vectorize, vector database, vector index, vector search, similarity search, semantic search,
-    nearest neighbor, knn search, ann search, RAG, retrieval augmented generation, chat with data,
-    document search, semantic Q&A, context retrieval, bge-base, @cf/baai/bge-base-en-v1.5,
-    text-embedding-3-small, text-embedding-3-large, Workers AI embeddings, openai embeddings,
-    insert vectors, upsert vectors, query vectors, delete vectors, metadata filtering, namespace filtering,
-    topK search, cosine similarity, euclidean distance, dot product, wrangler vectorize, metadata index,
-    create vectorize index, vectorize dimensions, vectorize metric, vectorize binding
+metadata:
+  keywords:
+    - vectorize
+    - vector database
+    - vector index
+    - vector search
+    - similarity search
+    - semantic search
+    - nearest neighbor
+    - knn search
+    - ann search
+    - RAG
+    - retrieval augmented generation
+    - chat with data
+    - document search
+    - semantic Q&A
+    - context retrieval
+    - bge-base
+    - "@cf/baai/bge-base-en-v1.5"
+    - text-embedding-3-small
+    - text-embedding-3-large
+    - Workers AI embeddings
+    - openai embeddings
+    - insert vectors
+    - upsert vectors
+    - query vectors
+    - delete vectors
+    - metadata filtering
+    - namespace filtering
+    - topK search
+    - cosine similarity
+    - euclidean distance
+    - dot product
+    - wrangler vectorize
+    - metadata index
+    - create vectorize index
+    - vectorize dimensions
+    - vectorize metric
+    - vectorize binding
+
 license: MIT
 ---
-
 # Cloudflare Vectorize
 
 Complete implementation guide for Cloudflare Vectorize - a globally distributed vector database for building semantic search, RAG (Retrieval Augmented Generation), and AI-powered applications with Cloudflare Workers.

--- a/plugins/cloudflare-workers-ai/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-workers-ai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-workers-ai",
   "description": "Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-workers-ai/skills/cloudflare-workers-ai/SKILL.md
+++ b/plugins/cloudflare-workers-ai/skills/cloudflare-workers-ai/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: cloudflare-workers-ai
-description: Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors.
+description: >-
+  Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors.
 
-  Keywords: workers ai, cloudflare ai, ai bindings, llm workers, @cf/meta/llama, workers ai models,
-  ai inference, cloudflare llm, ai streaming, text generation ai, ai embeddings, image generation ai,
-  workers ai rag, ai gateway, llama workers, flux image generation, stable diffusion workers,
-  vision models ai, ai chat completion, AI_ERROR, rate limit ai, model not found, token limit exceeded,
-  neurons exceeded, ai quota exceeded, streaming failed, model unavailable, workers ai hono,
-  ai gateway workers, vercel ai sdk workers, openai compatible workers, workers ai vectorize
+    Keywords: workers ai, cloudflare ai, ai bindings, llm workers, @cf/meta/llama, workers ai models,
+    ai inference, cloudflare llm, ai streaming, text generation ai, ai embeddings, image generation ai,
+    workers ai rag, ai gateway, llama workers, flux image generation, stable diffusion workers,
+    vision models ai, ai chat completion, AI_ERROR, rate limit ai, model not found, token limit exceeded,
+    neurons exceeded, ai quota exceeded, streaming failed, model unavailable, workers ai hono,
+    ai gateway workers, vercel ai sdk workers, openai compatible workers, workers ai vectorize
 license: MIT
 ---
 

--- a/plugins/cloudflare-workers-ai/skills/cloudflare-workers-ai/SKILL.md
+++ b/plugins/cloudflare-workers-ai/skills/cloudflare-workers-ai/SKILL.md
@@ -1,17 +1,44 @@
 ---
 name: cloudflare-workers-ai
-description: >-
-  Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors.
+description: "Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors."
 
-    Keywords: workers ai, cloudflare ai, ai bindings, llm workers, @cf/meta/llama, workers ai models,
-    ai inference, cloudflare llm, ai streaming, text generation ai, ai embeddings, image generation ai,
-    workers ai rag, ai gateway, llama workers, flux image generation, stable diffusion workers,
-    vision models ai, ai chat completion, AI_ERROR, rate limit ai, model not found, token limit exceeded,
-    neurons exceeded, ai quota exceeded, streaming failed, model unavailable, workers ai hono,
-    ai gateway workers, vercel ai sdk workers, openai compatible workers, workers ai vectorize
+metadata:
+  keywords:
+    - workers ai
+    - cloudflare ai
+    - ai bindings
+    - llm workers
+    - "@cf/meta/llama"
+    - workers ai models
+    - ai inference
+    - cloudflare llm
+    - ai streaming
+    - text generation ai
+    - ai embeddings
+    - image generation ai
+    - workers ai rag
+    - ai gateway
+    - llama workers
+    - flux image generation
+    - stable diffusion workers
+    - vision models ai
+    - ai chat completion
+    - AI_ERROR
+    - rate limit ai
+    - model not found
+    - token limit exceeded
+    - neurons exceeded
+    - ai quota exceeded
+    - streaming failed
+    - model unavailable
+    - workers ai hono
+    - ai gateway workers
+    - vercel ai sdk workers
+    - openai compatible workers
+    - workers ai vectorize
+
 license: MIT
 ---
-
 # Cloudflare Workers AI - Complete Reference
 
 Production-ready knowledge domain for building AI-powered applications with Cloudflare Workers AI.

--- a/plugins/cloudflare-workers/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-workers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-workers",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Comprehensive Cloudflare Workers platform guide covering runtime APIs, testing (Vitest), CI/CD, observability, framework integration, performance, security, and migration. Use for Workers development, deployment, debugging, or optimization.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-workflows/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-workflows",
   "description": "Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-workflows/skills/cloudflare-workflows/SKILL.md
+++ b/plugins/cloudflare-workflows/skills/cloudflare-workflows/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: cloudflare-workflows
-description: Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors.
+description: >-
+  Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors.
 
-  Keywords: cloudflare workflows, workflows workers, durable execution, workflow step,
-  WorkflowEntrypoint, step.do, step.sleep, workflow retries, NonRetryableError,
-  workflow state, wrangler workflows, workflow events, long-running tasks, step.sleepUntil,
-  step.waitForEvent, workflow bindings
+    Keywords: cloudflare workflows, workflows workers, durable execution, workflow step,
+    WorkflowEntrypoint, step.do, step.sleep, workflow retries, NonRetryableError,
+    workflow state, wrangler workflows, workflow events, long-running tasks, step.sleepUntil,
+    step.waitForEvent, workflow bindings
 license: MIT
 metadata:
   version: "3.0.0"

--- a/plugins/cloudflare-workflows/skills/cloudflare-workflows/SKILL.md
+++ b/plugins/cloudflare-workflows/skills/cloudflare-workflows/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: cloudflare-workflows
-description: >-
-  Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors.
-
-    Keywords: cloudflare workflows, workflows workers, durable execution, workflow step,
-    WorkflowEntrypoint, step.do, step.sleep, workflow retries, NonRetryableError,
-    workflow state, wrangler workflows, workflow events, long-running tasks, step.sleepUntil,
-    step.waitForEvent, workflow bindings
+description: "Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors."
 license: MIT
 metadata:
   version: "3.0.0"
@@ -19,8 +13,24 @@ metadata:
   agents_included: 3
   commands_included: 4
   scripts_included: 5
+  keywords:
+    - cloudflare workflows
+    - workflows workers
+    - durable execution
+    - workflow step
+    - WorkflowEntrypoint
+    - step.do
+    - step.sleep
+    - workflow retries
+    - NonRetryableError
+    - workflow state
+    - wrangler workflows
+    - workflow events
+    - long-running tasks
+    - step.sleepUntil
+    - step.waitForEvent
+    - workflow bindings
 ---
-
 # Cloudflare Workflows
 
 **Status**: Production Ready ✅ | **Last Verified**: 2025-12-27 | **Version**: 3.0.0

--- a/plugins/cloudflare-zero-trust-access/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-zero-trust-access/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-zero-trust-access",
   "description": "Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-zero-trust-access/skills/cloudflare-zero-trust-access/SKILL.md
+++ b/plugins/cloudflare-zero-trust-access/skills/cloudflare-zero-trust-access/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: cloudflare-zero-trust-access
-description: >-
-  Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers.
-
-    Keywords: Cloudflare Access, Zero Trust, Cloudflare Zero Trust Access, Access authentication, JWT validation, access jwt, service tokens, hono cloudflare access, hono-cloudflare-access middleware, workers authentication, protect worker routes, admin authentication, access policy, identity providers, azure ad access, google workspace access, okta access, github access, rbac cloudflare, geographic restrictions, multi-tenant access, cors access, CORS preflight blocked, JWT header missing, access key cache, team mismatch, access claims
+description: "Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers."
 license: MIT
 allowed-tools:
   - Read
@@ -24,8 +21,35 @@ metadata:
   time_savings: "2.5 hours"
   production_tested: true
   last_verified: "2025-10-28"
+  keywords:
+    - Cloudflare Access
+    - Zero Trust
+    - Cloudflare Zero Trust Access
+    - Access authentication
+    - JWT validation
+    - access jwt
+    - service tokens
+    - hono cloudflare access
+    - hono-cloudflare-access middleware
+    - workers authentication
+    - protect worker routes
+    - admin authentication
+    - access policy
+    - identity providers
+    - azure ad access
+    - google workspace access
+    - okta access
+    - github access
+    - rbac cloudflare
+    - geographic restrictions
+    - multi-tenant access
+    - cors access
+    - CORS preflight blocked
+    - JWT header missing
+    - access key cache
+    - team mismatch
+    - access claims
 ---
-
 # Cloudflare Zero Trust Access Skill
 
 Integrate Cloudflare Zero Trust Access authentication with Cloudflare Workers applications using proven patterns and templates.

--- a/plugins/cloudflare-zero-trust-access/skills/cloudflare-zero-trust-access/SKILL.md
+++ b/plugins/cloudflare-zero-trust-access/skills/cloudflare-zero-trust-access/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: cloudflare-zero-trust-access
-description: Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers.
+description: >-
+  Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers.
 
-  Keywords: Cloudflare Access, Zero Trust, Cloudflare Zero Trust Access, Access authentication, JWT validation, access jwt, service tokens, hono cloudflare access, hono-cloudflare-access middleware, workers authentication, protect worker routes, admin authentication, access policy, identity providers, azure ad access, google workspace access, okta access, github access, rbac cloudflare, geographic restrictions, multi-tenant access, cors access, CORS preflight blocked, JWT header missing, access key cache, team mismatch, access claims
+    Keywords: Cloudflare Access, Zero Trust, Cloudflare Zero Trust Access, Access authentication, JWT validation, access jwt, service tokens, hono cloudflare access, hono-cloudflare-access middleware, workers authentication, protect worker routes, admin authentication, access policy, identity providers, azure ad access, google workspace access, okta access, github access, rbac cloudflare, geographic restrictions, multi-tenant access, cors access, CORS preflight blocked, JWT header missing, access key cache, team mismatch, access claims
 license: MIT
 allowed-tools:
   - Read

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review practices with technical rigor and verification gates. Use for receiving feedback, requesting code-reviewer subagent reviews, or preventing false completion claims in pull requests.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/content-collections/.claude-plugin/plugin.json
+++ b/plugins/content-collections/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "content-collections",
   "description": "Content Collections TypeScript-first build tool for Markdown/MDX content. Use for blogs, docs, content sites with Vite + React, MDX components, type-safe Zod schemas, Contentlayer migration, or encountering TypeScript import errors, path alias issues, collection validation errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/content-collections/skills/content-collections/SKILL.md
+++ b/plugins/content-collections/skills/content-collections/SKILL.md
@@ -1,19 +1,43 @@
 ---
 name: content-collections
-description: >-
-  Content Collections TypeScript-first build tool for Markdown/MDX content. Use for blogs, docs, content sites with Vite + React, MDX components, type-safe Zod schemas, Contentlayer migration, or encountering TypeScript import errors, path alias issues, collection validation errors.
+description: "Content Collections TypeScript-first build tool for Markdown/MDX content. Use for blogs, docs, content sites with Vite + React, MDX components, type-safe Zod schemas, Contentlayer migration, or encountering TypeScript import errors, path alias issues, collection validation errors."
 
-    Keywords: content-collections, @content-collections/core, @content-collections/vite,
-    @content-collections/mdx, MDX, markdown, Zod schema validation, type-safe content,
-    frontmatter, compileMDX, defineCollection, defineConfig, Vite plugin, tsconfig paths,
-    .content-collections/generated, MDXContent component, rehype plugins, remark plugins,
-    content schema, document transform, allPosts import, static site generation,
-    blog setup, documentation, Cloudflare Workers static assets, content validation errors,
-    module not found content-collections, path alias not working, MDX type errors,
-    transform function async, collection not updating
+metadata:
+  keywords:
+    - content-collections
+    - "@content-collections/core"
+    - "@content-collections/vite"
+    - "@content-collections/mdx"
+    - MDX
+    - markdown
+    - Zod schema validation
+    - type-safe content
+    - frontmatter
+    - compileMDX
+    - defineCollection
+    - defineConfig
+    - Vite plugin
+    - tsconfig paths
+    - .content-collections/generated
+    - MDXContent component
+    - rehype plugins
+    - remark plugins
+    - content schema
+    - document transform
+    - allPosts import
+    - static site generation
+    - blog setup
+    - documentation
+    - Cloudflare Workers static assets
+    - content validation errors
+    - module not found content-collections
+    - path alias not working
+    - MDX type errors
+    - transform function async
+    - collection not updating
+
 license: MIT
 ---
-
 # Content Collections
 
 **Status**: Production Ready ✅

--- a/plugins/content-collections/skills/content-collections/SKILL.md
+++ b/plugins/content-collections/skills/content-collections/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: content-collections
-description: Content Collections TypeScript-first build tool for Markdown/MDX content. Use for blogs, docs, content sites with Vite + React, MDX components, type-safe Zod schemas, Contentlayer migration, or encountering TypeScript import errors, path alias issues, collection validation errors.
+description: >-
+  Content Collections TypeScript-first build tool for Markdown/MDX content. Use for blogs, docs, content sites with Vite + React, MDX components, type-safe Zod schemas, Contentlayer migration, or encountering TypeScript import errors, path alias issues, collection validation errors.
 
-  Keywords: content-collections, @content-collections/core, @content-collections/vite,
-  @content-collections/mdx, MDX, markdown, Zod schema validation, type-safe content,
-  frontmatter, compileMDX, defineCollection, defineConfig, Vite plugin, tsconfig paths,
-  .content-collections/generated, MDXContent component, rehype plugins, remark plugins,
-  content schema, document transform, allPosts import, static site generation,
-  blog setup, documentation, Cloudflare Workers static assets, content validation errors,
-  module not found content-collections, path alias not working, MDX type errors,
-  transform function async, collection not updating
+    Keywords: content-collections, @content-collections/core, @content-collections/vite,
+    @content-collections/mdx, MDX, markdown, Zod schema validation, type-safe content,
+    frontmatter, compileMDX, defineCollection, defineConfig, Vite plugin, tsconfig paths,
+    .content-collections/generated, MDXContent component, rehype plugins, remark plugins,
+    content schema, document transform, allPosts import, static site generation,
+    blog setup, documentation, Cloudflare Workers static assets, content validation errors,
+    module not found content-collections, path alias not working, MDX type errors,
+    transform function async, collection not updating
 license: MIT
 ---
 

--- a/plugins/csrf-protection/.claude-plugin/plugin.json
+++ b/plugins/csrf-protection/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "csrf-protection",
   "description": "Implements CSRF protection using synchronizer tokens, double-submit cookies, and SameSite attributes. Use when securing web forms, protecting state-changing endpoints, or implementing defense-in-depth authentication.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/database-schema-design/.claude-plugin/plugin.json
+++ b/plugins/database-schema-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "database-schema-design",
   "description": "Database schema design for PostgreSQL/MySQL with normalization, relationships, constraints. Use for new databases, schema reviews, migrations, or encountering missing PKs/FKs, wrong data types, premature denormalization, EAV anti-pattern.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/database-sharding/.claude-plugin/plugin.json
+++ b/plugins/database-sharding/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "database-sharding",
   "description": "Database sharding for PostgreSQL/MySQL with hash/range/directory strategies. Use for horizontal scaling, multi-tenant isolation, billions of records, or encountering wrong shard keys, hotspots, cross-shard transactions, rebalancing issues.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/defense-in-depth-validation/.claude-plugin/plugin.json
+++ b/plugins/defense-in-depth-validation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "defense-in-depth-validation",
   "description": "Validate at every layer data passes through to make bugs impossible. Use when invalid data causes failures deep in execution, requiring validation at multiple system layers.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/dependency-upgrade/.claude-plugin/plugin.json
+++ b/plugins/dependency-upgrade/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependency-upgrade",
   "description": "Secure dependency upgrades with supply chain protection, cooldown periods, post-install script hardening, lockfile validation, and staged rollout across npm, Bun, pnpm, and Yarn. Use when upgrading dependencies, configuring security policies, or preventing supply chain attacks.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/design-review/.claude-plugin/plugin.json
+++ b/plugins/design-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "design-review",
   "description": "7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/design-review/skills/design-review/SKILL.md
+++ b/plugins/design-review/skills/design-review/SKILL.md
@@ -1,12 +1,30 @@
 ---
 name: design-review
-description: >-
-  7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states.
+description: "7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states."
 
-    Keywords: design review, UI audit, frontend review, accessibility audit, WCAG compliance,
-    responsive design, visual QA, UX review, component review, PR design check, layout issues,
-    accessibility violations, contrast problems, broken responsive, interaction bugs, keyboard
-    navigation, focus states, design system compliance, visual consistency, user experience
+metadata:
+  keywords:
+    - design review
+    - UI audit
+    - frontend review
+    - accessibility audit
+    - WCAG compliance
+    - responsive design
+    - visual QA
+    - UX review
+    - component review
+    - PR design check
+    - layout issues
+    - accessibility violations
+    - contrast problems
+    - broken responsive
+    - interaction bugs
+    - keyboard navigation
+    - focus states
+    - design system compliance
+    - visual consistency
+    - user experience
+
 license: MIT
 allowed-tools:
   - Read
@@ -14,7 +32,6 @@ allowed-tools:
   - Glob
   - Bash
 ---
-
 # Design Review Skill
 
 **Status**: Production Ready ✅

--- a/plugins/design-review/skills/design-review/SKILL.md
+++ b/plugins/design-review/skills/design-review/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: design-review
-description: 7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states.
+description: >-
+  7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states.
 
-  Keywords: design review, UI audit, frontend review, accessibility audit, WCAG compliance,
-  responsive design, visual QA, UX review, component review, PR design check, layout issues,
-  accessibility violations, contrast problems, broken responsive, interaction bugs, keyboard
-  navigation, focus states, design system compliance, visual consistency, user experience
+    Keywords: design review, UI audit, frontend review, accessibility audit, WCAG compliance,
+    responsive design, visual QA, UX review, component review, PR design check, layout issues,
+    accessibility violations, contrast problems, broken responsive, interaction bugs, keyboard
+    navigation, focus states, design system compliance, visual consistency, user experience
 license: MIT
 allowed-tools:
   - Read

--- a/plugins/design-system-creation/.claude-plugin/plugin.json
+++ b/plugins/design-system-creation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "design-system-creation",
   "description": "Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/design-system-creation/skills/design-system-creation/SKILL.md
+++ b/plugins/design-system-creation/skills/design-system-creation/SKILL.md
@@ -1,13 +1,36 @@
 ---
 name: design-system-creation
-description: >-
-  |
-    Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency.
+description: "| Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency."
 
-    Keywords: design-tokens, typography, spacing, color-palette, components, patterns, variables, dark-mode, theming, CSS-variables, accessibility, WCAG, responsive, grid-system, breakpoints, design-scale, semantic-tokens, component-library, style-guide, documentation, Figma, Storybook, brand-consistency, design-principles
+metadata:
+  keywords:
+    - design-tokens
+    - typography
+    - spacing
+    - color-palette
+    - components
+    - patterns
+    - variables
+    - dark-mode
+    - theming
+    - CSS-variables
+    - accessibility
+    - WCAG
+    - responsive
+    - grid-system
+    - breakpoints
+    - design-scale
+    - semantic-tokens
+    - component-library
+    - style-guide
+    - documentation
+    - Figma
+    - Storybook
+    - brand-consistency
+    - design-principles
+
 license: MIT
 ---
-
 # Design System Creation
 
 Build comprehensive design systems for consistent UI development across teams.

--- a/plugins/design-system-creation/skills/design-system-creation/SKILL.md
+++ b/plugins/design-system-creation/skills/design-system-creation/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: design-system-creation
-description: |
-  Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency.
+description: >-
+  |
+    Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency.
 
-  Keywords: design-tokens, typography, spacing, color-palette, components, patterns, variables, dark-mode, theming, CSS-variables, accessibility, WCAG, responsive, grid-system, breakpoints, design-scale, semantic-tokens, component-library, style-guide, documentation, Figma, Storybook, brand-consistency, design-principles
+    Keywords: design-tokens, typography, spacing, color-palette, components, patterns, variables, dark-mode, theming, CSS-variables, accessibility, WCAG, responsive, grid-system, breakpoints, design-scale, semantic-tokens, component-library, style-guide, documentation, Figma, Storybook, brand-consistency, design-principles
 license: MIT
 ---
 

--- a/plugins/drizzle-orm-d1/.claude-plugin/plugin.json
+++ b/plugins/drizzle-orm-d1/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drizzle-orm-d1",
   "description": "Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transaction errors, foreign key constraint failures, or schema inference issues.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/drizzle-orm-d1/skills/drizzle-orm-d1/SKILL.md
+++ b/plugins/drizzle-orm-d1/skills/drizzle-orm-d1/SKILL.md
@@ -1,18 +1,44 @@
 ---
 name: drizzle-orm-d1
-description: >-
-  |
-    Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transaction errors, foreign key constraint failures, or schema inference issues.
+description: "| Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transaction errors, foreign key constraint failures, or schema inference issues."
 
-    Keywords: drizzle orm, drizzle d1, type-safe sql, drizzle schema, drizzle migrations,
-    drizzle kit, orm cloudflare, d1 orm, drizzle typescript, drizzle relations, drizzle transactions,
-    drizzle query builder, schema definition, prepared statements, drizzle batch, migration management,
-    relational queries, drizzle joins, D1_ERROR, BEGIN TRANSACTION d1, foreign key constraint,
-    migration failed, schema not found, d1 binding error, schema design, database indexes, soft deletes,
-    uuid primary keys, enum constraints, performance optimization, naming conventions, schema testing
+metadata:
+  keywords:
+    - drizzle orm
+    - drizzle d1
+    - type-safe sql
+    - drizzle schema
+    - drizzle migrations
+    - drizzle kit
+    - orm cloudflare
+    - d1 orm
+    - drizzle typescript
+    - drizzle relations
+    - drizzle transactions
+    - drizzle query builder
+    - schema definition
+    - prepared statements
+    - drizzle batch
+    - migration management
+    - relational queries
+    - drizzle joins
+    - D1_ERROR
+    - BEGIN TRANSACTION d1
+    - foreign key constraint
+    - migration failed
+    - schema not found
+    - d1 binding error
+    - schema design
+    - database indexes
+    - soft deletes
+    - uuid primary keys
+    - enum constraints
+    - performance optimization
+    - naming conventions
+    - schema testing
+
 license: MIT
 ---
-
 # Drizzle ORM for Cloudflare D1
 
 **Status**: Production Ready ✅

--- a/plugins/drizzle-orm-d1/skills/drizzle-orm-d1/SKILL.md
+++ b/plugins/drizzle-orm-d1/skills/drizzle-orm-d1/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: drizzle-orm-d1
-description: |
-  Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transaction errors, foreign key constraint failures, or schema inference issues.
+description: >-
+  |
+    Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transaction errors, foreign key constraint failures, or schema inference issues.
 
-  Keywords: drizzle orm, drizzle d1, type-safe sql, drizzle schema, drizzle migrations,
-  drizzle kit, orm cloudflare, d1 orm, drizzle typescript, drizzle relations, drizzle transactions,
-  drizzle query builder, schema definition, prepared statements, drizzle batch, migration management,
-  relational queries, drizzle joins, D1_ERROR, BEGIN TRANSACTION d1, foreign key constraint,
-  migration failed, schema not found, d1 binding error, schema design, database indexes, soft deletes,
-  uuid primary keys, enum constraints, performance optimization, naming conventions, schema testing
+    Keywords: drizzle orm, drizzle d1, type-safe sql, drizzle schema, drizzle migrations,
+    drizzle kit, orm cloudflare, d1 orm, drizzle typescript, drizzle relations, drizzle transactions,
+    drizzle query builder, schema definition, prepared statements, drizzle batch, migration management,
+    relational queries, drizzle joins, D1_ERROR, BEGIN TRANSACTION d1, foreign key constraint,
+    migration failed, schema not found, d1 binding error, schema design, database indexes, soft deletes,
+    uuid primary keys, enum constraints, performance optimization, naming conventions, schema testing
 license: MIT
 ---
 

--- a/plugins/elevenlabs-agents/.claude-plugin/plugin.json
+++ b/plugins/elevenlabs-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "elevenlabs-agents",
   "description": "ElevenLabs Agents Platform for AI voice agents (React/JS/Native/Swift). Use for voice AI, RAG, tools, or encountering package deprecation, audio cutoff, CSP violations, webhook auth failures.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/elevenlabs-agents/skills/elevenlabs-agents/SKILL.md
+++ b/plugins/elevenlabs-agents/skills/elevenlabs-agents/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: elevenlabs-agents
-description: ElevenLabs Agents Platform for AI voice agents (React/JS/Native/Swift). Use for voice AI, RAG, tools, or encountering package deprecation, audio cutoff, CSP violations, webhook auth failures.
+description: >-
+  ElevenLabs Agents Platform for AI voice agents (React/JS/Native/Swift). Use for voice AI, RAG, tools, or encountering package deprecation, audio cutoff, CSP violations, webhook auth failures.
 
-  Keywords: ElevenLabs Agents, ElevenLabs voice agents, AI voice agents, conversational AI, @elevenlabs/react, @elevenlabs/client, @elevenlabs/react-native, @elevenlabs/elevenlabs-js, @elevenlabs/agents-cli, elevenlabs SDK, voice AI, TTS, text-to-speech, ASR, speech recognition, turn-taking model, WebRTC voice, WebSocket voice, ElevenLabs conversation, agent system prompt, agent tools, agent knowledge base, RAG voice agents, multi-voice agents, pronunciation dictionary, voice speed control, elevenlabs scribe, @11labs deprecated, Android audio cutoff, CSP violation elevenlabs, dynamic variables elevenlabs, case-sensitive tool names, webhook authentication
+    Keywords: ElevenLabs Agents, ElevenLabs voice agents, AI voice agents, conversational AI, @elevenlabs/react, @elevenlabs/client, @elevenlabs/react-native, @elevenlabs/elevenlabs-js, @elevenlabs/agents-cli, elevenlabs SDK, voice AI, TTS, text-to-speech, ASR, speech recognition, turn-taking model, WebRTC voice, WebSocket voice, ElevenLabs conversation, agent system prompt, agent tools, agent knowledge base, RAG voice agents, multi-voice agents, pronunciation dictionary, voice speed control, elevenlabs scribe, @11labs deprecated, Android audio cutoff, CSP violation elevenlabs, dynamic variables elevenlabs, case-sensitive tool names, webhook authentication
 license: MIT
 metadata:
   version: 1.1.0

--- a/plugins/elevenlabs-agents/skills/elevenlabs-agents/SKILL.md
+++ b/plugins/elevenlabs-agents/skills/elevenlabs-agents/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: elevenlabs-agents
-description: >-
-  ElevenLabs Agents Platform for AI voice agents (React/JS/Native/Swift). Use for voice AI, RAG, tools, or encountering package deprecation, audio cutoff, CSP violations, webhook auth failures.
-
-    Keywords: ElevenLabs Agents, ElevenLabs voice agents, AI voice agents, conversational AI, @elevenlabs/react, @elevenlabs/client, @elevenlabs/react-native, @elevenlabs/elevenlabs-js, @elevenlabs/agents-cli, elevenlabs SDK, voice AI, TTS, text-to-speech, ASR, speech recognition, turn-taking model, WebRTC voice, WebSocket voice, ElevenLabs conversation, agent system prompt, agent tools, agent knowledge base, RAG voice agents, multi-voice agents, pronunciation dictionary, voice speed control, elevenlabs scribe, @11labs deprecated, Android audio cutoff, CSP violation elevenlabs, dynamic variables elevenlabs, case-sensitive tool names, webhook authentication
+description: "ElevenLabs Agents Platform for AI voice agents (React/JS/Native/Swift). Use for voice AI, RAG, tools, or encountering package deprecation, audio cutoff, CSP violations, webhook auth failures."
 license: MIT
 metadata:
   version: 1.1.0
@@ -26,8 +23,41 @@ metadata:
     - https://github.com/elevenlabs/elevenlabs-examples
   errors_prevented: 17+
   token_savings: ~73%
+  keywords:
+    - ElevenLabs Agents
+    - ElevenLabs voice agents
+    - AI voice agents
+    - conversational AI
+    - "@elevenlabs/react"
+    - "@elevenlabs/client"
+    - "@elevenlabs/react-native"
+    - "@elevenlabs/elevenlabs-js"
+    - "@elevenlabs/agents-cli"
+    - elevenlabs SDK
+    - voice AI
+    - TTS
+    - text-to-speech
+    - ASR
+    - speech recognition
+    - turn-taking model
+    - WebRTC voice
+    - WebSocket voice
+    - ElevenLabs conversation
+    - agent system prompt
+    - agent tools
+    - agent knowledge base
+    - RAG voice agents
+    - multi-voice agents
+    - pronunciation dictionary
+    - voice speed control
+    - elevenlabs scribe
+    - "@11labs deprecated"
+    - Android audio cutoff
+    - CSP violation elevenlabs
+    - dynamic variables elevenlabs
+    - case-sensitive tool names
+    - webhook authentication
 ---
-
 # ElevenLabs Agents Platform
 
 ## Overview

--- a/plugins/fastmcp/.claude-plugin/plugin.json
+++ b/plugins/fastmcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fastmcp",
   "description": "FastMCP Python framework for MCP servers with tools, resources, storage backends (memory/disk/Redis/DynamoDB). Use for Claude tool exposure, OAuth Proxy, cloud deployment, or encountering storage, lifespan, middleware, circular import, async errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/fastmcp/skills/fastmcp/SKILL.md
+++ b/plugins/fastmcp/skills/fastmcp/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: fastmcp
-description: >-
-  FastMCP Python framework for MCP servers with tools, resources, storage backends (memory/disk/Redis/DynamoDB). Use for Claude tool exposure, OAuth Proxy, cloud deployment, or encountering storage, lifespan, middleware, circular import, async errors.
-
-    Keywords: FastMCP, MCP server Python, Model Context Protocol Python, fastmcp framework, mcp tools, mcp resources, mcp prompts, fastmcp storage, fastmcp memory storage, fastmcp disk storage, fastmcp redis, fastmcp dynamodb, fastmcp lifespan, fastmcp middleware, fastmcp oauth proxy, server composition mcp, fastmcp import, fastmcp mount, fastmcp cloud, fastmcp deployment, mcp authentication, fastmcp icons, openapi mcp, claude mcp server, fastmcp testing, storage misconfiguration, lifespan issues, middleware order, circular imports, module-level server, async await mcp
+description: "FastMCP Python framework for MCP servers with tools, resources, storage backends (memory/disk/Redis/DynamoDB). Use for Claude tool exposure, OAuth Proxy, cloud deployment, or encountering storage, lifespan, middleware, circular import, async errors."
 license: MIT
 metadata:
   version: "2.0.0"
@@ -13,8 +10,39 @@ metadata:
   errors_prevented: 25
   production_tested: true
   last_updated: "2025-11-18"
+  keywords:
+    - FastMCP
+    - MCP server Python
+    - Model Context Protocol Python
+    - fastmcp framework
+    - mcp tools
+    - mcp resources
+    - mcp prompts
+    - fastmcp storage
+    - fastmcp memory storage
+    - fastmcp disk storage
+    - fastmcp redis
+    - fastmcp dynamodb
+    - fastmcp lifespan
+    - fastmcp middleware
+    - fastmcp oauth proxy
+    - server composition mcp
+    - fastmcp import
+    - fastmcp mount
+    - fastmcp cloud
+    - fastmcp deployment
+    - mcp authentication
+    - fastmcp icons
+    - openapi mcp
+    - claude mcp server
+    - fastmcp testing
+    - storage misconfiguration
+    - lifespan issues
+    - middleware order
+    - circular imports
+    - module-level server
+    - async await mcp
 ---
-
 # FastMCP - Build MCP Servers in Python
 
 FastMCP is a Python framework for building Model Context Protocol (MCP) servers that expose tools, resources, and prompts to Large Language Models like Claude.

--- a/plugins/fastmcp/skills/fastmcp/SKILL.md
+++ b/plugins/fastmcp/skills/fastmcp/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: fastmcp
-description: FastMCP Python framework for MCP servers with tools, resources, storage backends (memory/disk/Redis/DynamoDB). Use for Claude tool exposure, OAuth Proxy, cloud deployment, or encountering storage, lifespan, middleware, circular import, async errors.
+description: >-
+  FastMCP Python framework for MCP servers with tools, resources, storage backends (memory/disk/Redis/DynamoDB). Use for Claude tool exposure, OAuth Proxy, cloud deployment, or encountering storage, lifespan, middleware, circular import, async errors.
 
-  Keywords: FastMCP, MCP server Python, Model Context Protocol Python, fastmcp framework, mcp tools, mcp resources, mcp prompts, fastmcp storage, fastmcp memory storage, fastmcp disk storage, fastmcp redis, fastmcp dynamodb, fastmcp lifespan, fastmcp middleware, fastmcp oauth proxy, server composition mcp, fastmcp import, fastmcp mount, fastmcp cloud, fastmcp deployment, mcp authentication, fastmcp icons, openapi mcp, claude mcp server, fastmcp testing, storage misconfiguration, lifespan issues, middleware order, circular imports, module-level server, async await mcp
+    Keywords: FastMCP, MCP server Python, Model Context Protocol Python, fastmcp framework, mcp tools, mcp resources, mcp prompts, fastmcp storage, fastmcp memory storage, fastmcp disk storage, fastmcp redis, fastmcp dynamodb, fastmcp lifespan, fastmcp middleware, fastmcp oauth proxy, server composition mcp, fastmcp import, fastmcp mount, fastmcp cloud, fastmcp deployment, mcp authentication, fastmcp icons, openapi mcp, claude mcp server, fastmcp testing, storage misconfiguration, lifespan issues, middleware order, circular imports, module-level server, async await mcp
 license: MIT
 metadata:
   version: "2.0.0"

--- a/plugins/feature-dev/.claude-plugin/plugin.json
+++ b/plugins/feature-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "feature-dev",
   "description": "Automate 7-phase feature development with specialized agents (code-explorer, code-architect, code-reviewer). Use for multi-file features, architectural decisions, or encountering ambiguous requirements, integration patterns, design approach errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/feature-dev/skills/feature-dev/SKILL.md
+++ b/plugins/feature-dev/skills/feature-dev/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: feature-dev
-description: Automate 7-phase feature development with specialized agents (code-explorer, code-architect, code-reviewer). Use for multi-file features, architectural decisions, or encountering ambiguous requirements, integration patterns, design approach errors.
+description: >-
+  Automate 7-phase feature development with specialized agents (code-explorer, code-architect, code-reviewer). Use for multi-file features, architectural decisions, or encountering ambiguous requirements, integration patterns, design approach errors.
 
-  Keywords: feature development, code exploration, architecture design, code review, workflow automation, slash command, agents, discovery phase, implementation planning, quality review
+    Keywords: feature development, code exploration, architecture design, code review, workflow automation, slash command, agents, discovery phase, implementation planning, quality review
 license: MIT
 allowed-tools: ["Read", "Write", "Edit", "Bash", "Task"]
 metadata:

--- a/plugins/feature-dev/skills/feature-dev/SKILL.md
+++ b/plugins/feature-dev/skills/feature-dev/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: feature-dev
-description: >-
-  Automate 7-phase feature development with specialized agents (code-explorer, code-architect, code-reviewer). Use for multi-file features, architectural decisions, or encountering ambiguous requirements, integration patterns, design approach errors.
-
-    Keywords: feature development, code exploration, architecture design, code review, workflow automation, slash command, agents, discovery phase, implementation planning, quality review
+description: "Automate 7-phase feature development with specialized agents (code-explorer, code-architect, code-reviewer). Use for multi-file features, architectural decisions, or encountering ambiguous requirements, integration patterns, design approach errors."
 license: MIT
 allowed-tools: ["Read", "Write", "Edit", "Bash", "Task"]
 metadata:
@@ -13,8 +10,18 @@ metadata:
     - code-explorer
     - code-architect
     - code-reviewer
+  keywords:
+    - feature development
+    - code exploration
+    - architecture design
+    - code review
+    - workflow automation
+    - slash command
+    - agents
+    - discovery phase
+    - implementation planning
+    - quality review
 ---
-
 # Feature Development Workflow
 
 A comprehensive, structured workflow for feature development with specialized agents for codebase exploration, architecture design, and quality review.

--- a/plugins/firecrawl-scraper/.claude-plugin/plugin.json
+++ b/plugins/firecrawl-scraper/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "firecrawl-scraper",
   "description": "Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/firecrawl-scraper/skills/firecrawl-scraper/SKILL.md
+++ b/plugins/firecrawl-scraper/skills/firecrawl-scraper/SKILL.md
@@ -1,12 +1,33 @@
 ---
 name: firecrawl-scraper
-description: >-
-  Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors.
+description: "Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors."
 
-    Keywords: firecrawl, firecrawl api, web scraping, web crawler, scrape website, crawl website, extract content, html to markdown, site crawler, content extraction, web automation, firecrawl-py, firecrawl-js, llm ready data, structured data extraction, bot bypass, javascript rendering, scraping api, crawling api, map urls, batch scraping
+metadata:
+  keywords:
+    - firecrawl
+    - firecrawl api
+    - web scraping
+    - web crawler
+    - scrape website
+    - crawl website
+    - extract content
+    - html to markdown
+    - site crawler
+    - content extraction
+    - web automation
+    - firecrawl-py
+    - firecrawl-js
+    - llm ready data
+    - structured data extraction
+    - bot bypass
+    - javascript rendering
+    - scraping api
+    - crawling api
+    - map urls
+    - batch scraping
+
 license: MIT
 ---
-
 # Firecrawl Web Scraper Skill
 
 **Status**: Production Ready ✅

--- a/plugins/firecrawl-scraper/skills/firecrawl-scraper/SKILL.md
+++ b/plugins/firecrawl-scraper/skills/firecrawl-scraper/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: firecrawl-scraper
-description: Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors.
+description: >-
+  Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors.
 
-  Keywords: firecrawl, firecrawl api, web scraping, web crawler, scrape website, crawl website, extract content, html to markdown, site crawler, content extraction, web automation, firecrawl-py, firecrawl-js, llm ready data, structured data extraction, bot bypass, javascript rendering, scraping api, crawling api, map urls, batch scraping
+    Keywords: firecrawl, firecrawl api, web scraping, web crawler, scrape website, crawl website, extract content, html to markdown, site crawler, content extraction, web automation, firecrawl-py, firecrawl-js, llm ready data, structured data extraction, bot bypass, javascript rendering, scraping api, crawling api, map urls, batch scraping
 license: MIT
 ---
 

--- a/plugins/frontend-design/.claude-plugin/plugin.json
+++ b/plugins/frontend-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend-design",
   "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/gemini-cli/.claude-plugin/plugin.json
+++ b/plugins/gemini-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gemini-cli",
   "description": "Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/gemini-cli/skills/gemini-cli/SKILL.md
+++ b/plugins/gemini-cli/skills/gemini-cli/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: gemini-cli
-description: >-
-  Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool.
-
-    Keywords: gemini-cli, google gemini, gemini command line, second opinion, model comparison, gemini-2.5-flash, gemini-2.5-pro, architectural decisions, debugging assistant, code review gemini, security audit gemini, 1M context window, AI pair programming, gemini consultation, flash vs pro, AI-to-AI prompting, peer review, codebase analysis, gemini CLI tool, shell gemini, command line AI assistant, gemini architecture advice, gemini debug help, gemini security scan, gemini code compare
+description: "Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool."
 license: MIT
 metadata:
   version: 2.1.0
@@ -12,8 +9,33 @@ metadata:
   last_verified: 2025-11-13
   token_savings: ~60-70%
   errors_prevented: 6+
+  keywords:
+    - gemini-cli
+    - google gemini
+    - gemini command line
+    - second opinion
+    - model comparison
+    - gemini-2.5-flash
+    - gemini-2.5-pro
+    - architectural decisions
+    - debugging assistant
+    - code review gemini
+    - security audit gemini
+    - 1M context window
+    - AI pair programming
+    - gemini consultation
+    - flash vs pro
+    - AI-to-AI prompting
+    - peer review
+    - codebase analysis
+    - gemini CLI tool
+    - shell gemini
+    - command line AI assistant
+    - gemini architecture advice
+    - gemini debug help
+    - gemini security scan
+    - gemini code compare
 ---
-
 # Gemini CLI
 
 **Leverage Gemini's 1M+ context window as your AI pair programmer within Claude Code workflows.**

--- a/plugins/gemini-cli/skills/gemini-cli/SKILL.md
+++ b/plugins/gemini-cli/skills/gemini-cli/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: gemini-cli
-description: Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool.
+description: >-
+  Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool.
 
-  Keywords: gemini-cli, google gemini, gemini command line, second opinion, model comparison, gemini-2.5-flash, gemini-2.5-pro, architectural decisions, debugging assistant, code review gemini, security audit gemini, 1M context window, AI pair programming, gemini consultation, flash vs pro, AI-to-AI prompting, peer review, codebase analysis, gemini CLI tool, shell gemini, command line AI assistant, gemini architecture advice, gemini debug help, gemini security scan, gemini code compare
+    Keywords: gemini-cli, google gemini, gemini command line, second opinion, model comparison, gemini-2.5-flash, gemini-2.5-pro, architectural decisions, debugging assistant, code review gemini, security audit gemini, 1M context window, AI pair programming, gemini consultation, flash vs pro, AI-to-AI prompting, peer review, codebase analysis, gemini CLI tool, shell gemini, command line AI assistant, gemini architecture advice, gemini debug help, gemini security scan, gemini code compare
 license: MIT
 metadata:
   version: 2.1.0

--- a/plugins/github-project-automation/.claude-plugin/plugin.json
+++ b/plugins/github-project-automation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github-project-automation",
   "description": "GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/github-project-automation/skills/github-project-automation/SKILL.md
+++ b/plugins/github-project-automation/skills/github-project-automation/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: github-project-automation
-description: GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors.
+description: >-
+  GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors.
 
-  Keywords: github actions, github workflow, ci/cd, issue templates, pull request templates,
-  dependabot, codeql, security scanning, yaml syntax, github automation, repository setup,
-  workflow templates, github actions matrix, secrets management, branch protection, codeowners,
-  github projects, continuous integration, continuous deployment, workflow syntax error,
-  action version pinning, runner version, github context, yaml indentation error
+    Keywords: github actions, github workflow, ci/cd, issue templates, pull request templates,
+    dependabot, codeql, security scanning, yaml syntax, github automation, repository setup,
+    workflow templates, github actions matrix, secrets management, branch protection, codeowners,
+    github projects, continuous integration, continuous deployment, workflow syntax error,
+    action version pinning, runner version, github context, yaml indentation error
 license: MIT
 metadata:
   version: 2.0.0

--- a/plugins/github-project-automation/skills/github-project-automation/SKILL.md
+++ b/plugins/github-project-automation/skills/github-project-automation/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: github-project-automation
-description: >-
-  GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors.
-
-    Keywords: github actions, github workflow, ci/cd, issue templates, pull request templates,
-    dependabot, codeql, security scanning, yaml syntax, github automation, repository setup,
-    workflow templates, github actions matrix, secrets management, branch protection, codeowners,
-    github projects, continuous integration, continuous deployment, workflow syntax error,
-    action version pinning, runner version, github context, yaml indentation error
+description: "GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors."
 license: MIT
 metadata:
   version: 2.0.0
@@ -16,8 +9,32 @@ metadata:
   errors_prevented: 18
   token_savings: ~75%
   complexity: 8/10
+  keywords:
+    - github actions
+    - github workflow
+    - ci/cd
+    - issue templates
+    - pull request templates
+    - dependabot
+    - codeql
+    - security scanning
+    - yaml syntax
+    - github automation
+    - repository setup
+    - workflow templates
+    - github actions matrix
+    - secrets management
+    - branch protection
+    - codeowners
+    - github projects
+    - continuous integration
+    - continuous deployment
+    - workflow syntax error
+    - action version pinning
+    - runner version
+    - github context
+    - yaml indentation error
 ---
-
 # GitHub Project Automation
 
 **Status**: Production Ready ✅

--- a/plugins/google-gemini-api/.claude-plugin/plugin.json
+++ b/plugins/google-gemini-api/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google-gemini-api",
   "description": "Google Gemini API with @google/genai SDK. Use for multimodal AI, thinking mode, function calling, or encountering SDK deprecation warnings, context errors, multimodal format errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/google-gemini-api/skills/google-gemini-api/SKILL.md
+++ b/plugins/google-gemini-api/skills/google-gemini-api/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: google-gemini-api
-description: Google Gemini API with @google/genai SDK. Use for multimodal AI, thinking mode, function calling, or encountering SDK deprecation warnings, context errors, multimodal format errors.
+description: >-
+  Google Gemini API with @google/genai SDK. Use for multimodal AI, thinking mode, function calling, or encountering SDK deprecation warnings, context errors, multimodal format errors.
 
-  Keywords: gemini api, @google/genai, gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite,
-  multimodal gemini, thinking mode, google ai, genai sdk, function calling gemini, streaming gemini,
-  gemini vision, gemini video, gemini audio, gemini pdf, system instructions, multi-turn chat,
-  deprecated @google/generative-ai, gemini context window, gemini models 2025, gemini 1m tokens,
-  gemini tool use, parallel function calling, compositional function calling
+    Keywords: gemini api, @google/genai, gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite,
+    multimodal gemini, thinking mode, google ai, genai sdk, function calling gemini, streaming gemini,
+    gemini vision, gemini video, gemini audio, gemini pdf, system instructions, multi-turn chat,
+    deprecated @google/generative-ai, gemini context window, gemini models 2025, gemini 1m tokens,
+    gemini tool use, parallel function calling, compositional function calling
 license: MIT
 ---
 

--- a/plugins/google-gemini-api/skills/google-gemini-api/SKILL.md
+++ b/plugins/google-gemini-api/skills/google-gemini-api/SKILL.md
@@ -1,16 +1,36 @@
 ---
 name: google-gemini-api
-description: >-
-  Google Gemini API with @google/genai SDK. Use for multimodal AI, thinking mode, function calling, or encountering SDK deprecation warnings, context errors, multimodal format errors.
+description: "Google Gemini API with @google/genai SDK. Use for multimodal AI, thinking mode, function calling, or encountering SDK deprecation warnings, context errors, multimodal format errors."
 
-    Keywords: gemini api, @google/genai, gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite,
-    multimodal gemini, thinking mode, google ai, genai sdk, function calling gemini, streaming gemini,
-    gemini vision, gemini video, gemini audio, gemini pdf, system instructions, multi-turn chat,
-    deprecated @google/generative-ai, gemini context window, gemini models 2025, gemini 1m tokens,
-    gemini tool use, parallel function calling, compositional function calling
+metadata:
+  keywords:
+    - gemini api
+    - "@google/genai"
+    - gemini-2.5-pro
+    - gemini-2.5-flash
+    - gemini-2.5-flash-lite
+    - multimodal gemini
+    - thinking mode
+    - google ai
+    - genai sdk
+    - function calling gemini
+    - streaming gemini
+    - gemini vision
+    - gemini video
+    - gemini audio
+    - gemini pdf
+    - system instructions
+    - multi-turn chat
+    - deprecated @google/generative-ai
+    - gemini context window
+    - gemini models 2025
+    - gemini 1m tokens
+    - gemini tool use
+    - parallel function calling
+    - compositional function calling
+
 license: MIT
 ---
-
 # Google Gemini API - Complete Guide
 
 **Package**: @google/genai@1.27.0 (⚠️ NOT @google/generative-ai)

--- a/plugins/google-gemini-embeddings/.claude-plugin/plugin.json
+++ b/plugins/google-gemini-embeddings/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google-gemini-embeddings",
   "description": "Google Gemini embeddings API (gemini-embedding-001) for RAG and semantic search. Use for vector search, Vectorize integration, or encountering dimension mismatches, rate limits, text truncation.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/google-gemini-embeddings/skills/google-gemini-embeddings/SKILL.md
+++ b/plugins/google-gemini-embeddings/skills/google-gemini-embeddings/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: google-gemini-embeddings
-description: >-
-  Google Gemini embeddings API (gemini-embedding-001) for RAG and semantic search. Use for vector search, Vectorize integration, or encountering dimension mismatches, rate limits, text truncation.
-
-    Keywords: gemini embeddings, gemini-embedding-001, google embeddings, semantic search, RAG, vector search, document clustering, similarity search, retrieval augmented generation, vectorize integration, cloudflare vectorize embeddings, 768 dimensions, embed content gemini, batch embeddings, embeddings api, cosine similarity, vector normalization, retrieval query, retrieval document, task types, dimension mismatch, embeddings rate limit, text truncation, @google/genai
+description: "Google Gemini embeddings API (gemini-embedding-001) for RAG and semantic search. Use for vector search, Vectorize integration, or encountering dimension mismatches, rate limits, text truncation."
 license: MIT
 metadata:
   version: 1.0.0
@@ -15,8 +12,32 @@ metadata:
   tokens_saved: "~60%"
   errors_prevented: 8
   production_tested: true
+  keywords:
+    - gemini embeddings
+    - gemini-embedding-001
+    - google embeddings
+    - semantic search
+    - RAG
+    - vector search
+    - document clustering
+    - similarity search
+    - retrieval augmented generation
+    - vectorize integration
+    - cloudflare vectorize embeddings
+    - 768 dimensions
+    - embed content gemini
+    - batch embeddings
+    - embeddings api
+    - cosine similarity
+    - vector normalization
+    - retrieval query
+    - retrieval document
+    - task types
+    - dimension mismatch
+    - embeddings rate limit
+    - text truncation
+    - "@google/genai"
 ---
-
 # Google Gemini Embeddings
 
 **Complete production-ready guide for Google Gemini embeddings API**

--- a/plugins/google-gemini-embeddings/skills/google-gemini-embeddings/SKILL.md
+++ b/plugins/google-gemini-embeddings/skills/google-gemini-embeddings/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: google-gemini-embeddings
-description: Google Gemini embeddings API (gemini-embedding-001) for RAG and semantic search. Use for vector search, Vectorize integration, or encountering dimension mismatches, rate limits, text truncation.
+description: >-
+  Google Gemini embeddings API (gemini-embedding-001) for RAG and semantic search. Use for vector search, Vectorize integration, or encountering dimension mismatches, rate limits, text truncation.
 
-  Keywords: gemini embeddings, gemini-embedding-001, google embeddings, semantic search, RAG, vector search, document clustering, similarity search, retrieval augmented generation, vectorize integration, cloudflare vectorize embeddings, 768 dimensions, embed content gemini, batch embeddings, embeddings api, cosine similarity, vector normalization, retrieval query, retrieval document, task types, dimension mismatch, embeddings rate limit, text truncation, @google/genai
+    Keywords: gemini embeddings, gemini-embedding-001, google embeddings, semantic search, RAG, vector search, document clustering, similarity search, retrieval augmented generation, vectorize integration, cloudflare vectorize embeddings, 768 dimensions, embed content gemini, batch embeddings, embeddings api, cosine similarity, vector normalization, retrieval query, retrieval document, task types, dimension mismatch, embeddings rate limit, text truncation, @google/genai
 license: MIT
 metadata:
   version: 1.0.0

--- a/plugins/google-gemini-file-search/.claude-plugin/plugin.json
+++ b/plugins/google-gemini-file-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google-gemini-file-search",
   "description": "Google Gemini File Search for managed RAG with 100+ file formats. Use for document Q&A, knowledge bases, or encountering immutability errors, quota issues, polling failures. Supports Gemini 3 Pro/Flash (Gemini 2.5 legacy).",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/graphql-implementation/.claude-plugin/plugin.json
+++ b/plugins/graphql-implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "graphql-implementation",
   "description": "Builds GraphQL APIs with schema design, resolvers, error handling, and performance optimization using Apollo or Graphene. Use when creating flexible query APIs, migrating from REST, or implementing real-time subscriptions.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/health-check-endpoints/.claude-plugin/plugin.json
+++ b/plugins/health-check-endpoints/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "health-check-endpoints",
   "description": "Health check endpoints for liveness, readiness, dependency monitoring. Use for Kubernetes, load balancers, auto-scaling, or encountering probe failures, startup delays, dependency checks, timeout configuration errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/hono-routing/.claude-plugin/plugin.json
+++ b/plugins/hono-routing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hono-routing",
   "description": "Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/hono-routing/skills/hono-routing/SKILL.md
+++ b/plugins/hono-routing/skills/hono-routing/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: hono-routing
-description: >-
-  Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors.
-
-    Keywords: hono, hono routing, hono middleware, hono rpc, hono validator, zod validator, valibot validator, type-safe api, hono context, hono error handling, HTTPException, c.req.valid, middleware composition, hono hooks, typed routes, hono client, middleware response not typed, hono validation failed, hono rpc type inference
+description: "Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors."
 
 license: MIT
 metadata:
@@ -13,8 +10,27 @@ metadata:
   errors_prevented: 12
   templates_included: 9
   references_included: 6
+  keywords:
+    - hono
+    - hono routing
+    - hono middleware
+    - hono rpc
+    - hono validator
+    - zod validator
+    - valibot validator
+    - type-safe api
+    - hono context
+    - hono error handling
+    - HTTPException
+    - c.req.valid
+    - middleware composition
+    - hono hooks
+    - typed routes
+    - hono client
+    - middleware response not typed
+    - hono validation failed
+    - hono rpc type inference
 ---
-
 # Hono Routing & Middleware
 
 **Status**: Production Ready ✅

--- a/plugins/hono-routing/skills/hono-routing/SKILL.md
+++ b/plugins/hono-routing/skills/hono-routing/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: hono-routing
-description: Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors.
+description: >-
+  Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors.
 
-  Keywords: hono, hono routing, hono middleware, hono rpc, hono validator, zod validator, valibot validator, type-safe api, hono context, hono error handling, HTTPException, c.req.valid, middleware composition, hono hooks, typed routes, hono client, middleware response not typed, hono validation failed, hono rpc type inference
+    Keywords: hono, hono routing, hono middleware, hono rpc, hono validator, zod validator, valibot validator, type-safe api, hono context, hono error handling, HTTPException, c.req.valid, middleware composition, hono hooks, typed routes, hono client, middleware response not typed, hono validation failed, hono rpc type inference
 
 license: MIT
 metadata:

--- a/plugins/hugo/.claude-plugin/plugin.json
+++ b/plugins/hugo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hugo",
   "description": "Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/hugo/skills/hugo/SKILL.md
+++ b/plugins/hugo/skills/hugo/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: hugo
-description: >-
-  Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors.
-
-    Keywords: hugo, hugo-extended, static-site-generator, ssg, go-templates, papermod, goldmark, markdown, blog, documentation, docs-site, landing-page, sveltia-cms, tina-cms, headless-cms, cloudflare-workers, workers-static-assets, wrangler, hugo-server, hugo-build, frontmatter, yaml-frontmatter, toml-config, hugo-themes, hugo-modules, multilingual, i18n, github-actions, version-mismatch, baseurl-error, theme-not-found, tailwind, tailwind-v4, tailwind-css, hugo-pipes, postcss, css-framework, utility-css, hugo-tailwind, tailwind-integration, hugo-assets
+description: "Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors."
 license: MIT
 metadata:
   version: "2.0.0"
@@ -15,8 +12,49 @@ metadata:
   errors_prevented: 15
   templates_included: 4
   references_included: 6
+  keywords:
+    - hugo
+    - hugo-extended
+    - static-site-generator
+    - ssg
+    - go-templates
+    - papermod
+    - goldmark
+    - markdown
+    - blog
+    - documentation
+    - docs-site
+    - landing-page
+    - sveltia-cms
+    - tina-cms
+    - headless-cms
+    - cloudflare-workers
+    - workers-static-assets
+    - wrangler
+    - hugo-server
+    - hugo-build
+    - frontmatter
+    - yaml-frontmatter
+    - toml-config
+    - hugo-themes
+    - hugo-modules
+    - multilingual
+    - i18n
+    - github-actions
+    - version-mismatch
+    - baseurl-error
+    - theme-not-found
+    - tailwind
+    - tailwind-v4
+    - tailwind-css
+    - hugo-pipes
+    - postcss
+    - css-framework
+    - utility-css
+    - hugo-tailwind
+    - tailwind-integration
+    - hugo-assets
 ---
-
 # Hugo Static Site Generator
 
 **Status**: Production Ready | **Last Updated**: 2025-11-21

--- a/plugins/hugo/skills/hugo/SKILL.md
+++ b/plugins/hugo/skills/hugo/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: hugo
-description: Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors.
+description: >-
+  Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors.
 
-  Keywords: hugo, hugo-extended, static-site-generator, ssg, go-templates, papermod, goldmark, markdown, blog, documentation, docs-site, landing-page, sveltia-cms, tina-cms, headless-cms, cloudflare-workers, workers-static-assets, wrangler, hugo-server, hugo-build, frontmatter, yaml-frontmatter, toml-config, hugo-themes, hugo-modules, multilingual, i18n, github-actions, version-mismatch, baseurl-error, theme-not-found, tailwind, tailwind-v4, tailwind-css, hugo-pipes, postcss, css-framework, utility-css, hugo-tailwind, tailwind-integration, hugo-assets
+    Keywords: hugo, hugo-extended, static-site-generator, ssg, go-templates, papermod, goldmark, markdown, blog, documentation, docs-site, landing-page, sveltia-cms, tina-cms, headless-cms, cloudflare-workers, workers-static-assets, wrangler, hugo-server, hugo-build, frontmatter, yaml-frontmatter, toml-config, hugo-themes, hugo-modules, multilingual, i18n, github-actions, version-mismatch, baseurl-error, theme-not-found, tailwind, tailwind-v4, tailwind-css, hugo-pipes, postcss, css-framework, utility-css, hugo-tailwind, tailwind-integration, hugo-assets
 license: MIT
 metadata:
   version: "2.0.0"

--- a/plugins/idempotency-handling/.claude-plugin/plugin.json
+++ b/plugins/idempotency-handling/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "idempotency-handling",
   "description": "Idempotent API operations with idempotency keys, Redis caching, DB constraints. Use for payment systems, webhook retries, safe retries, or encountering duplicate processing, race conditions, key expiry errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/image-optimization/.claude-plugin/plugin.json
+++ b/plugins/image-optimization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "image-optimization",
   "description": "Optimizes images for web performance using modern formats, responsive techniques, and lazy loading strategies. Use when improving page load times, implementing responsive images, or preparing assets for production deployment.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/inspira-ui/.claude-plugin/plugin.json
+++ b/plugins/inspira-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inspira-ui",
   "description": "120+ Vue/Nuxt animated components with TailwindCSS v4, motion-v, GSAP, Three.js. Use for hero sections, 3D effects, interactive backgrounds, or encountering setup, CSS variables, motion-v integration errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/interaction-design/.claude-plugin/plugin.json
+++ b/plugins/interaction-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "interaction-design",
   "description": "Creates intuitive user experiences through feedback patterns, microinteractions, and accessible interaction design. Use when designing loading states, error handling UX, animation guidelines, or touch interactions.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/internationalization-i18n/.claude-plugin/plugin.json
+++ b/plugins/internationalization-i18n/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "internationalization-i18n",
   "description": "Implements multi-language support using i18next, gettext, or Intl API with translation workflows and RTL support. Use when building multilingual applications, handling date/currency formatting, or supporting right-to-left languages.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/jest-generator/.claude-plugin/plugin.json
+++ b/plugins/jest-generator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jest-generator",
   "description": "Generate Jest unit tests for JavaScript/TypeScript with mocking, coverage. Use for JS/TS modules, React components, test generation, or encountering missing coverage, improper mocking, test structure errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/kpi-dashboard-design/.claude-plugin/plugin.json
+++ b/plugins/kpi-dashboard-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kpi-dashboard-design",
   "description": "Designs effective KPI dashboards with proper metric selection, visual hierarchy, and data visualization best practices. Use when building executive dashboards, creating analytics views, or presenting business metrics.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/logging-best-practices/.claude-plugin/plugin.json
+++ b/plugins/logging-best-practices/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "logging-best-practices",
   "description": "Structured logging with proper levels, context, PII handling, centralized aggregation. Use for application logging, log management integration, distributed tracing, or encountering log bloat, PII exposure, missing context errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/maz-ui/.claude-plugin/plugin.json
+++ b/plugins/maz-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maz-ui",
   "description": "Maz-UI v4 - Modern Vue & Nuxt component library with 50+ standalone components, composables, directives, theming, i18n, and SSR support.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mcp-dynamic-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/mcp-dynamic-orchestrator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-dynamic-orchestrator",
   "description": "Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mcp-dynamic-orchestrator/skills/mcp-dynamic-orchestrator/SKILL.md
+++ b/plugins/mcp-dynamic-orchestrator/skills/mcp-dynamic-orchestrator/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: mcp-dynamic-orchestrator
-description: >-
-  Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets.
+description: "Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets."
 
-    Keywords: MCP, code-mode, registry, dynamic tools, tool discovery, progressive disclosure
+metadata:
+  keywords:
+    - MCP
+    - code-mode
+    - registry
+    - dynamic tools
+    - tool discovery
+    - progressive disclosure
+
 license: MIT
 allowed-tools:
   - list_mcp_capabilities
   - describe_mcp
   - execute_mcp_code
 ---
-
 ## Overview
 
 Use this skill to:

--- a/plugins/mcp-dynamic-orchestrator/skills/mcp-dynamic-orchestrator/SKILL.md
+++ b/plugins/mcp-dynamic-orchestrator/skills/mcp-dynamic-orchestrator/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: mcp-dynamic-orchestrator
-description: Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets.
+description: >-
+  Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets.
 
-  Keywords: MCP, code-mode, registry, dynamic tools, tool discovery, progressive disclosure
+    Keywords: MCP, code-mode, registry, dynamic tools, tool discovery, progressive disclosure
 license: MIT
 allowed-tools:
   - list_mcp_capabilities

--- a/plugins/mcp-management/.claude-plugin/plugin.json
+++ b/plugins/mcp-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-management",
   "description": "Manage MCP servers - discover, analyze, execute tools/prompts/resources. Use for MCP integrations, capability discovery, tool filtering, programmatic execution, or encountering context bloat, server configuration, tool execution errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/microservices-patterns/.claude-plugin/plugin.json
+++ b/plugins/microservices-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "microservices-patterns",
   "description": "Design microservices architectures with service boundaries, event-driven communication, and resilience patterns. Use when building distributed systems, decomposing monoliths, or implementing microservices.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ml-model-training/.claude-plugin/plugin.json
+++ b/plugins/ml-model-training/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-model-training",
   "description": "Train ML models with scikit-learn, PyTorch, TensorFlow. Use for classification/regression, neural networks, hyperparameter tuning, or encountering overfitting, underfitting, convergence issues.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ml-pipeline-automation/.claude-plugin/plugin.json
+++ b/plugins/ml-pipeline-automation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-pipeline-automation",
   "description": "Automate ML workflows with Airflow, Kubeflow, MLflow. Use for reproducible pipelines, retraining schedules, MLOps, or encountering task failures, dependency errors, experiment tracking issues.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-app-debugging/.claude-plugin/plugin.json
+++ b/plugins/mobile-app-debugging/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-app-debugging",
   "description": "Mobile app debugging for iOS, Android, cross-platform frameworks. Use for crashes, memory leaks, performance issues, network problems, or encountering Xcode instruments, Android Profiler, React Native debugger, native bridge errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-app-testing/.claude-plugin/plugin.json
+++ b/plugins/mobile-app-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-app-testing",
   "description": "Mobile app testing with unit tests, UI automation, performance testing. Use for test infrastructure, E2E tests, testing standards, or encountering test framework setup, device farms, flaky tests, platform-specific test errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-first-design/.claude-plugin/plugin.json
+++ b/plugins/mobile-first-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-first-design",
   "description": "Designs responsive interfaces starting from mobile screens with progressive enhancement for larger devices. Use when building responsive websites, optimizing for mobile users, or implementing adaptive layouts.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-offline-support/.claude-plugin/plugin.json
+++ b/plugins/mobile-offline-support/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-offline-support",
   "description": "Offline-first mobile apps with local storage, sync queues, conflict resolution. Use for offline functionality, data sync, connectivity handling, or encountering sync conflicts, queue management, storage limits, network transition errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/model-deployment/.claude-plugin/plugin.json
+++ b/plugins/model-deployment/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "model-deployment",
   "description": "Deploy ML models with FastAPI, Docker, Kubernetes. Use for serving predictions, containerization, monitoring, drift detection, or encountering latency issues, health check failures, version conflicts.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/motion/.claude-plugin/plugin.json
+++ b/plugins/motion/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "motion",
   "description": "Motion (Framer Motion) React animation library. Use for drag-and-drop, scroll animations, gestures, SVG morphing, or encountering bundle size, complex transitions, spring physics errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/motion/skills/motion/SKILL.md
+++ b/plugins/motion/skills/motion/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: motion
-description: Motion (Framer Motion) React animation library. Use for drag-and-drop, scroll animations, gestures, SVG morphing, or encountering bundle size, complex transitions, spring physics errors.
+description: >-
+  Motion (Framer Motion) React animation library. Use for drag-and-drop, scroll animations, gestures, SVG morphing, or encountering bundle size, complex transitions, spring physics errors.
 
 license: MIT
 ---

--- a/plugins/multi-ai-consultant/.claude-plugin/plugin.json
+++ b/plugins/multi-ai-consultant/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "multi-ai-consultant",
   "description": "Consult external AIs (Gemini 2.5 Pro, OpenAI Codex, Claude) for second opinions. Use for debugging failures, architectural decisions, security validation, or need fresh perspective with synthesis.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mutation-testing/.claude-plugin/plugin.json
+++ b/plugins/mutation-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mutation-testing",
   "description": "Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nano-banana-prompts/.claude-plugin/plugin.json
+++ b/plugins/nano-banana-prompts/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nano-banana-prompts",
   "description": "Generate optimized prompts for Gemini 2.5 Flash Image (Nano Banana). Use for image generation, crafting photo prompts, art styles, or multi-turn editing workflows with best practices.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/neon-vercel-postgres/.claude-plugin/plugin.json
+++ b/plugins/neon-vercel-postgres/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "neon-vercel-postgres",
   "description": "Neon + Vercel serverless Postgres for edge and serverless environments. Use for Cloudflare Workers, Vercel Edge, Next.js apps with HTTP/WebSocket connections, database branching (git-like), Drizzle/Prisma ORM integration, migrations, PITR backups, or encountering connection pool exhausted errors, TCP connection issues, SSL config problems.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nextjs/.claude-plugin/plugin.json
+++ b/plugins/nextjs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nextjs",
   "description": "Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nextjs/skills/nextjs/SKILL.md
+++ b/plugins/nextjs/skills/nextjs/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: nextjs
-description: Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors.
+description: >-
+  Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors.
 
-  Keywords: Next.js 16, Next.js App Router, Next.js Pages Router, Server Components, React Server Components, Server Actions, Cache Components, use cache, Next.js 16 breaking changes, async params nextjs, proxy.ts migration, React 19.2, Next.js metadata, Next.js SEO, generateMetadata, static generation, dynamic rendering, streaming SSR, Suspense, parallel routes, intercepting routes, route groups, Next.js middleware, Next.js API routes, Route Handlers, revalidatePath, revalidateTag, next/navigation, useSearchParams, turbopack, next.config
+    Keywords: Next.js 16, Next.js App Router, Next.js Pages Router, Server Components, React Server Components, Server Actions, Cache Components, use cache, Next.js 16 breaking changes, async params nextjs, proxy.ts migration, React 19.2, Next.js metadata, Next.js SEO, generateMetadata, static generation, dynamic rendering, streaming SSR, Suspense, parallel routes, intercepting routes, route groups, Next.js middleware, Next.js API routes, Route Handlers, revalidatePath, revalidateTag, next/navigation, useSearchParams, turbopack, next.config
 license: MIT
 metadata:
   version: 1.0.0

--- a/plugins/nextjs/skills/nextjs/SKILL.md
+++ b/plugins/nextjs/skills/nextjs/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: nextjs
-description: >-
-  Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors.
-
-    Keywords: Next.js 16, Next.js App Router, Next.js Pages Router, Server Components, React Server Components, Server Actions, Cache Components, use cache, Next.js 16 breaking changes, async params nextjs, proxy.ts migration, React 19.2, Next.js metadata, Next.js SEO, generateMetadata, static generation, dynamic rendering, streaming SSR, Suspense, parallel routes, intercepting routes, route groups, Next.js middleware, Next.js API routes, Route Handlers, revalidatePath, revalidateTag, next/navigation, useSearchParams, turbopack, next.config
+description: "Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors."
 license: MIT
 metadata:
   version: 1.0.0
@@ -16,9 +13,40 @@ metadata:
   production_tested: true
   token_savings: 65-70%
   errors_prevented: 18+
+  keywords:
+    - Next.js 16
+    - Next.js App Router
+    - Next.js Pages Router
+    - Server Components
+    - React Server Components
+    - Server Actions
+    - Cache Components
+    - use cache
+    - Next.js 16 breaking changes
+    - async params nextjs
+    - proxy.ts migration
+    - React 19.2
+    - Next.js metadata
+    - Next.js SEO
+    - generateMetadata
+    - static generation
+    - dynamic rendering
+    - streaming SSR
+    - Suspense
+    - parallel routes
+    - intercepting routes
+    - route groups
+    - Next.js middleware
+    - Next.js API routes
+    - Route Handlers
+    - revalidatePath
+    - revalidateTag
+    - next/navigation
+    - useSearchParams
+    - turbopack
+    - next.config
 allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 ---
-
 # Next.js App Router - Production Patterns
 
 **Version**: Next.js 16.0.3

--- a/plugins/nuxt-content/.claude-plugin/plugin.json
+++ b/plugins/nuxt-content/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-content",
   "description": "Nuxt Content v3 Git-backed CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Vercel deployment, SQL storage, MDC components, content collections.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-content/skills/nuxt-content/SKILL.md
+++ b/plugins/nuxt-content/skills/nuxt-content/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: nuxt-content
-description: Nuxt Content v3 Git-based CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Vercel deployment, SQL storage, MDC components, content collections.
+description: >-
+  Nuxt Content v3 Git-based CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Vercel deployment, SQL storage, MDC components, content collections.
 
-  Keywords: nuxt content, @nuxt/content, content collections, git-based cms, markdown cms, mdc syntax, nuxt studio, content editing, queryCollection, cloudflare d1 deployment, vercel deployment, markdown components, prose components, content navigation, full-text search, type-safe queries, sql storage, content schema validation, zod validation, valibot, remote repositories, content queries, queryCollectionNavigation, queryCollectionSearchSections, ContentRenderer component
+    Keywords: nuxt content, @nuxt/content, content collections, git-based cms, markdown cms, mdc syntax, nuxt studio, content editing, queryCollection, cloudflare d1 deployment, vercel deployment, markdown components, prose components, content navigation, full-text search, type-safe queries, sql storage, content schema validation, zod validation, valibot, remote repositories, content queries, queryCollectionNavigation, queryCollectionSearchSections, ContentRenderer component
 license: MIT
 ---
 

--- a/plugins/nuxt-content/skills/nuxt-content/SKILL.md
+++ b/plugins/nuxt-content/skills/nuxt-content/SKILL.md
@@ -1,12 +1,37 @@
 ---
 name: nuxt-content
-description: >-
-  Nuxt Content v3 Git-based CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Vercel deployment, SQL storage, MDC components, content collections.
+description: "Nuxt Content v3 Git-based CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Vercel deployment, SQL storage, MDC components, content collections."
 
-    Keywords: nuxt content, @nuxt/content, content collections, git-based cms, markdown cms, mdc syntax, nuxt studio, content editing, queryCollection, cloudflare d1 deployment, vercel deployment, markdown components, prose components, content navigation, full-text search, type-safe queries, sql storage, content schema validation, zod validation, valibot, remote repositories, content queries, queryCollectionNavigation, queryCollectionSearchSections, ContentRenderer component
+metadata:
+  keywords:
+    - nuxt content
+    - "@nuxt/content"
+    - content collections
+    - git-based cms
+    - markdown cms
+    - mdc syntax
+    - nuxt studio
+    - content editing
+    - queryCollection
+    - cloudflare d1 deployment
+    - vercel deployment
+    - markdown components
+    - prose components
+    - content navigation
+    - full-text search
+    - type-safe queries
+    - sql storage
+    - content schema validation
+    - zod validation
+    - valibot
+    - remote repositories
+    - content queries
+    - queryCollectionNavigation
+    - queryCollectionSearchSections
+    - ContentRenderer component
+
 license: MIT
 ---
-
 # Nuxt Content v3
 
 **Status**: Production Ready

--- a/plugins/nuxt-seo/.claude-plugin/plugin.json
+++ b/plugins/nuxt-seo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-seo",
   "description": "Comprehensive guide for all 8 Nuxt SEO modules plus Pro modules. Use when building SEO-optimized Nuxt applications, implementing robots.txt/sitemaps, generating OG images, adding Schema.org data, managing meta tags, checking links, or encountering sitemap, robots.txt, OG image, schema validation, meta tag, canonical URL, or i18n SEO errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-seo/skills/nuxt-seo/SKILL.md
+++ b/plugins/nuxt-seo/skills/nuxt-seo/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   last_updated: 2026-04-02
   module_versions:
     nuxtjs_seo: 5.1.0
-    @nuxtjs/robots: 6.0.6
-    @nuxtjs/sitemap: 8.0.11
+    "@nuxtjs/robots": 6.0.6
+    "@nuxtjs/sitemap": 8.0.11
     nuxt_og_image: 6.3.1
     nuxt_schema_org: 6.0.4
     nuxt_link_checker: 5.0.6

--- a/plugins/nuxt-studio/.claude-plugin/plugin.json
+++ b/plugins/nuxt-studio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-studio",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Visual CMS for Nuxt Content with Cloudflare deployment. Use when setting up Nuxt Studio, configuring OAuth authentication, deploying to Cloudflare Pages/Workers with subdomain routing, or troubleshooting Studio integration.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-ui-v4/.claude-plugin/plugin.json
+++ b/plugins/nuxt-ui-v4/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-ui-v4",
   "description": "Nuxt UI v4 with 125+ accessible components, Tailwind v4, Reka UI, AI chat integration with reasoning and tool calling. Use for dashboards, forms, overlays, editors, page layouts, or encountering theming, composable, TypeScript errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-v4/.claude-plugin/plugin.json
+++ b/plugins/nuxt-v4/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-v4",
   "description": "Comprehensive Nuxt 4 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 4 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 3, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-v4/skills/nuxt-core/SKILL.md
+++ b/plugins/nuxt-v4/skills/nuxt-core/SKILL.md
@@ -1,18 +1,6 @@
 ---
 name: nuxt-core
-description: >-
-  |
-    Nuxt 4 core framework fundamentals: project setup, configuration, routing,
-    SEO, error handling, and directory structure.
-
-    Use when: creating new Nuxt 4 projects, configuring nuxt.config.ts,
-    setting up routing and middleware, implementing SEO with useHead/useSeoMeta,
-    handling errors with error.vue and NuxtErrorBoundary, or understanding
-    Nuxt 4 directory structure.
-
-    Keywords: Nuxt 4, nuxt.config.ts, file-based routing, pages directory,
-    definePageMeta, useHead, useSeoMeta, error.vue, NuxtErrorBoundary,
-    middleware, navigateTo, NuxtLink, app directory, runtime config
+description: "| Nuxt 4 core framework fundamentals: project setup, configuration, routing, SEO, error handling, and directory structure. Use when: creating new Nuxt 4 projects, configuring nuxt.config.ts, setting up routing and middleware, implementing SEO with useHead/useSeoMeta, handling errors with error.vue and NuxtErrorBoundary, or understanding Nuxt 4 directory structure."
 license: MIT
 metadata:
   version: 4.0.0
@@ -21,8 +9,22 @@ metadata:
   framework: Nuxt
   framework-version: 4.x
   last-verified: 2025-12-28
+  keywords:
+    - Nuxt 4
+    - nuxt.config.ts
+    - file-based routing
+    - pages directory
+    - definePageMeta
+    - useHead
+    - useSeoMeta
+    - error.vue
+    - NuxtErrorBoundary
+    - middleware
+    - navigateTo
+    - NuxtLink
+    - app directory
+    - runtime config
 ---
-
 # Nuxt 4 Core Fundamentals
 
 Project setup, configuration, routing, SEO, and error handling for Nuxt 4 applications.

--- a/plugins/nuxt-v4/skills/nuxt-core/SKILL.md
+++ b/plugins/nuxt-v4/skills/nuxt-core/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: nuxt-core
-description: |
-  Nuxt 4 core framework fundamentals: project setup, configuration, routing,
-  SEO, error handling, and directory structure.
+description: >-
+  |
+    Nuxt 4 core framework fundamentals: project setup, configuration, routing,
+    SEO, error handling, and directory structure.
 
-  Use when: creating new Nuxt 4 projects, configuring nuxt.config.ts,
-  setting up routing and middleware, implementing SEO with useHead/useSeoMeta,
-  handling errors with error.vue and NuxtErrorBoundary, or understanding
-  Nuxt 4 directory structure.
+    Use when: creating new Nuxt 4 projects, configuring nuxt.config.ts,
+    setting up routing and middleware, implementing SEO with useHead/useSeoMeta,
+    handling errors with error.vue and NuxtErrorBoundary, or understanding
+    Nuxt 4 directory structure.
 
-  Keywords: Nuxt 4, nuxt.config.ts, file-based routing, pages directory,
-  definePageMeta, useHead, useSeoMeta, error.vue, NuxtErrorBoundary,
-  middleware, navigateTo, NuxtLink, app directory, runtime config
+    Keywords: Nuxt 4, nuxt.config.ts, file-based routing, pages directory,
+    definePageMeta, useHead, useSeoMeta, error.vue, NuxtErrorBoundary,
+    middleware, navigateTo, NuxtLink, app directory, runtime config
 license: MIT
 metadata:
   version: 4.0.0

--- a/plugins/nuxt-v4/skills/nuxt-data/SKILL.md
+++ b/plugins/nuxt-v4/skills/nuxt-data/SKILL.md
@@ -1,17 +1,6 @@
 ---
 name: nuxt-data
-description: >-
-  |
-    Nuxt 4 data management: composables, data fetching with useFetch/useAsyncData,
-    and state management with useState and Pinia.
-
-    Use when: creating custom composables, fetching data with useFetch or useAsyncData,
-    managing global state with useState, integrating Pinia, debugging reactive data issues,
-    or implementing SSR-safe state patterns.
-
-    Keywords: useFetch, useAsyncData, $fetch, useState, composables, Pinia,
-    data fetching, state management, reactive, shallow reactivity, reactive keys,
-    transform, pending, error, refresh, dedupe, caching
+description: "| Nuxt 4 data management: composables, data fetching with useFetch/useAsyncData, and state management with useState and Pinia. Use when: creating custom composables, fetching data with useFetch or useAsyncData, managing global state with useState, integrating Pinia, debugging reactive data issues, or implementing SSR-safe state patterns."
 license: MIT
 metadata:
   version: 4.0.0
@@ -20,8 +9,25 @@ metadata:
   framework: Nuxt
   framework-version: 4.x
   last-verified: 2025-12-28
+  keywords:
+    - useFetch
+    - useAsyncData
+    - $fetch
+    - useState
+    - composables
+    - Pinia
+    - data fetching
+    - state management
+    - reactive
+    - shallow reactivity
+    - reactive keys
+    - transform
+    - pending
+    - error
+    - refresh
+    - dedupe
+    - caching
 ---
-
 # Nuxt 4 Data Management
 
 Composables, data fetching, and state management patterns for Nuxt 4 applications.

--- a/plugins/nuxt-v4/skills/nuxt-data/SKILL.md
+++ b/plugins/nuxt-v4/skills/nuxt-data/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: nuxt-data
-description: |
-  Nuxt 4 data management: composables, data fetching with useFetch/useAsyncData,
-  and state management with useState and Pinia.
+description: >-
+  |
+    Nuxt 4 data management: composables, data fetching with useFetch/useAsyncData,
+    and state management with useState and Pinia.
 
-  Use when: creating custom composables, fetching data with useFetch or useAsyncData,
-  managing global state with useState, integrating Pinia, debugging reactive data issues,
-  or implementing SSR-safe state patterns.
+    Use when: creating custom composables, fetching data with useFetch or useAsyncData,
+    managing global state with useState, integrating Pinia, debugging reactive data issues,
+    or implementing SSR-safe state patterns.
 
-  Keywords: useFetch, useAsyncData, $fetch, useState, composables, Pinia,
-  data fetching, state management, reactive, shallow reactivity, reactive keys,
-  transform, pending, error, refresh, dedupe, caching
+    Keywords: useFetch, useAsyncData, $fetch, useState, composables, Pinia,
+    data fetching, state management, reactive, shallow reactivity, reactive keys,
+    transform, pending, error, refresh, dedupe, caching
 license: MIT
 metadata:
   version: 4.0.0

--- a/plugins/nuxt-v4/skills/nuxt-production/SKILL.md
+++ b/plugins/nuxt-v4/skills/nuxt-production/SKILL.md
@@ -1,17 +1,6 @@
 ---
 name: nuxt-production
-description: >-
-  |
-    Nuxt 4 production optimization: hydration, performance, testing with Vitest,
-    deployment to Cloudflare/Vercel/Netlify, and v4 migration.
-
-    Use when: debugging hydration mismatches, optimizing performance and Core Web Vitals,
-    writing tests with Vitest, deploying to Cloudflare Pages/Workers/Vercel/Netlify,
-    or migrating from Nuxt 3 to Nuxt 4.
-
-    Keywords: hydration, hydration mismatch, ClientOnly, SSR, performance,
-    lazy loading, lazy hydration, Vitest, testing, deployment, Cloudflare Pages,
-    Cloudflare Workers, Vercel, Netlify, NuxtHub, migration, Nuxt 3 to Nuxt 4
+description: "| Nuxt 4 production optimization: hydration, performance, testing with Vitest, deployment to Cloudflare/Vercel/Netlify, and v4 migration. Use when: debugging hydration mismatches, optimizing performance and Core Web Vitals, writing tests with Vitest, deploying to Cloudflare Pages/Workers/Vercel/Netlify, or migrating from Nuxt 3 to Nuxt 4."
 license: MIT
 metadata:
   version: 4.0.0
@@ -20,8 +9,25 @@ metadata:
   framework: Nuxt
   framework-version: 4.x
   last-verified: 2025-12-28
+  keywords:
+    - hydration
+    - hydration mismatch
+    - ClientOnly
+    - SSR
+    - performance
+    - lazy loading
+    - lazy hydration
+    - Vitest
+    - testing
+    - deployment
+    - Cloudflare Pages
+    - Cloudflare Workers
+    - Vercel
+    - Netlify
+    - NuxtHub
+    - migration
+    - Nuxt 3 to Nuxt 4
 ---
-
 # Nuxt 4 Production Guide
 
 Hydration, performance, testing, deployment, and migration patterns.

--- a/plugins/nuxt-v4/skills/nuxt-production/SKILL.md
+++ b/plugins/nuxt-v4/skills/nuxt-production/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: nuxt-production
-description: |
-  Nuxt 4 production optimization: hydration, performance, testing with Vitest,
-  deployment to Cloudflare/Vercel/Netlify, and v4 migration.
+description: >-
+  |
+    Nuxt 4 production optimization: hydration, performance, testing with Vitest,
+    deployment to Cloudflare/Vercel/Netlify, and v4 migration.
 
-  Use when: debugging hydration mismatches, optimizing performance and Core Web Vitals,
-  writing tests with Vitest, deploying to Cloudflare Pages/Workers/Vercel/Netlify,
-  or migrating from Nuxt 3 to Nuxt 4.
+    Use when: debugging hydration mismatches, optimizing performance and Core Web Vitals,
+    writing tests with Vitest, deploying to Cloudflare Pages/Workers/Vercel/Netlify,
+    or migrating from Nuxt 3 to Nuxt 4.
 
-  Keywords: hydration, hydration mismatch, ClientOnly, SSR, performance,
-  lazy loading, lazy hydration, Vitest, testing, deployment, Cloudflare Pages,
-  Cloudflare Workers, Vercel, Netlify, NuxtHub, migration, Nuxt 3 to Nuxt 4
+    Keywords: hydration, hydration mismatch, ClientOnly, SSR, performance,
+    lazy loading, lazy hydration, Vitest, testing, deployment, Cloudflare Pages,
+    Cloudflare Workers, Vercel, Netlify, NuxtHub, migration, Nuxt 3 to Nuxt 4
 license: MIT
 metadata:
   version: 4.0.0

--- a/plugins/nuxt-v4/skills/nuxt-server/SKILL.md
+++ b/plugins/nuxt-v4/skills/nuxt-server/SKILL.md
@@ -1,17 +1,6 @@
 ---
 name: nuxt-server
-description: >-
-  |
-    Nuxt 4 server-side development with Nitro: API routes, server middleware,
-    database integration, and backend patterns.
-
-    Use when: creating server API routes, implementing server middleware,
-    integrating databases (D1, PostgreSQL, Drizzle), handling file uploads,
-    implementing WebSockets, or building backend logic with Nitro.
-
-    Keywords: server routes, API routes, Nitro, defineEventHandler,
-    getRouterParam, getQuery, readBody, setCookie, createError,
-    server middleware, D1, Drizzle, PostgreSQL, WebSocket, file upload
+description: "| Nuxt 4 server-side development with Nitro: API routes, server middleware, database integration, and backend patterns. Use when: creating server API routes, implementing server middleware, integrating databases (D1, PostgreSQL, Drizzle), handling file uploads, implementing WebSockets, or building backend logic with Nitro."
 license: MIT
 metadata:
   version: 4.0.0
@@ -20,8 +9,23 @@ metadata:
   framework: Nuxt
   framework-version: 4.x
   last-verified: 2025-12-28
+  keywords:
+    - server routes
+    - API routes
+    - Nitro
+    - defineEventHandler
+    - getRouterParam
+    - getQuery
+    - readBody
+    - setCookie
+    - createError
+    - server middleware
+    - D1
+    - Drizzle
+    - PostgreSQL
+    - WebSocket
+    - file upload
 ---
-
 # Nuxt 4 Server Development
 
 Server routes, API patterns, and backend development with Nitro.

--- a/plugins/nuxt-v4/skills/nuxt-server/SKILL.md
+++ b/plugins/nuxt-v4/skills/nuxt-server/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: nuxt-server
-description: |
-  Nuxt 4 server-side development with Nitro: API routes, server middleware,
-  database integration, and backend patterns.
+description: >-
+  |
+    Nuxt 4 server-side development with Nitro: API routes, server middleware,
+    database integration, and backend patterns.
 
-  Use when: creating server API routes, implementing server middleware,
-  integrating databases (D1, PostgreSQL, Drizzle), handling file uploads,
-  implementing WebSockets, or building backend logic with Nitro.
+    Use when: creating server API routes, implementing server middleware,
+    integrating databases (D1, PostgreSQL, Drizzle), handling file uploads,
+    implementing WebSockets, or building backend logic with Nitro.
 
-  Keywords: server routes, API routes, Nitro, defineEventHandler,
-  getRouterParam, getQuery, readBody, setCookie, createError,
-  server middleware, D1, Drizzle, PostgreSQL, WebSocket, file upload
+    Keywords: server routes, API routes, Nitro, defineEventHandler,
+    getRouterParam, getQuery, readBody, setCookie, createError,
+    server middleware, D1, Drizzle, PostgreSQL, WebSocket, file upload
 license: MIT
 metadata:
   version: 4.0.0

--- a/plugins/nuxt-v5/.claude-plugin/plugin.json
+++ b/plugins/nuxt-v5/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-v5",
   "description": "Comprehensive Nuxt 5 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 5 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 4, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-v5/skills/nuxt-production/SKILL.md
+++ b/plugins/nuxt-v5/skills/nuxt-production/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: nuxt-production
-description: |
-  Nuxt 5 production optimization: hydration, performance, testing with Vitest,
-  deployment to Cloudflare/Vercel/Netlify, and migration from Nuxt 4.
+description: >-
+  |
+    Nuxt 5 production optimization: hydration, performance, testing with Vitest,
+    deployment to Cloudflare/Vercel/Netlify, and migration from Nuxt 4.
 
-  Use when: debugging hydration mismatches, optimizing performance and Core Web Vitals,
-  writing tests with Vitest, deploying to Cloudflare Pages/Workers/Vercel/Netlify,
-  or migrating from Nuxt 4 to Nuxt 5.
+    Use when: debugging hydration mismatches, optimizing performance and Core Web Vitals,
+    writing tests with Vitest, deploying to Cloudflare Pages/Workers/Vercel/Netlify,
+    or migrating from Nuxt 4 to Nuxt 5.
 
-  Keywords: hydration, hydration mismatch, ClientOnly, SSR, performance,
-  lazy loading, lazy hydration, Vitest, testing, deployment, Cloudflare Pages,
-  Cloudflare Workers, Vercel, Netlify, NuxtHub, migration, Nuxt 4 to Nuxt 5,
-  Rolldown, Vite 8, Nitro v3, comment placeholder
+    Keywords: hydration, hydration mismatch, ClientOnly, SSR, performance,
+    lazy loading, lazy hydration, Vitest, testing, deployment, Cloudflare Pages,
+    Cloudflare Workers, Vercel, Netlify, NuxtHub, migration, Nuxt 4 to Nuxt 5,
+    Rolldown, Vite 8, Nitro v3, comment placeholder
 license: MIT
 metadata:
   version: 5.0.0

--- a/plugins/nuxt-v5/skills/nuxt-production/SKILL.md
+++ b/plugins/nuxt-v5/skills/nuxt-production/SKILL.md
@@ -1,18 +1,6 @@
 ---
 name: nuxt-production
-description: >-
-  |
-    Nuxt 5 production optimization: hydration, performance, testing with Vitest,
-    deployment to Cloudflare/Vercel/Netlify, and migration from Nuxt 4.
-
-    Use when: debugging hydration mismatches, optimizing performance and Core Web Vitals,
-    writing tests with Vitest, deploying to Cloudflare Pages/Workers/Vercel/Netlify,
-    or migrating from Nuxt 4 to Nuxt 5.
-
-    Keywords: hydration, hydration mismatch, ClientOnly, SSR, performance,
-    lazy loading, lazy hydration, Vitest, testing, deployment, Cloudflare Pages,
-    Cloudflare Workers, Vercel, Netlify, NuxtHub, migration, Nuxt 4 to Nuxt 5,
-    Rolldown, Vite 8, Nitro v3, comment placeholder
+description: "| Nuxt 5 production optimization: hydration, performance, testing with Vitest, deployment to Cloudflare/Vercel/Netlify, and migration from Nuxt 4. Use when: debugging hydration mismatches, optimizing performance and Core Web Vitals, writing tests with Vitest, deploying to Cloudflare Pages/Workers/Vercel/Netlify, or migrating from Nuxt 4 to Nuxt 5."
 license: MIT
 metadata:
   version: 5.0.0
@@ -21,8 +9,29 @@ metadata:
   framework: Nuxt
   framework-version: 5.x
   last-verified: 2026-03-30
+  keywords:
+    - hydration
+    - hydration mismatch
+    - ClientOnly
+    - SSR
+    - performance
+    - lazy loading
+    - lazy hydration
+    - Vitest
+    - testing
+    - deployment
+    - Cloudflare Pages
+    - Cloudflare Workers
+    - Vercel
+    - Netlify
+    - NuxtHub
+    - migration
+    - Nuxt 4 to Nuxt 5
+    - Rolldown
+    - Vite 8
+    - Nitro v3
+    - comment placeholder
 ---
-
 # Nuxt 5 Production Guide
 
 Hydration, performance, testing, deployment, and migration patterns.

--- a/plugins/oauth-implementation/.claude-plugin/plugin.json
+++ b/plugins/oauth-implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oauth-implementation",
   "description": "OAuth 2.0 and OpenID Connect authentication with secure flows. Use for third-party integrations, SSO systems, token-based API access, or encountering authorization code flow, PKCE, token refresh, scope management errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/openai-agents/.claude-plugin/plugin.json
+++ b/plugins/openai-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-agents",
   "description": "OpenAI Agents SDK for JavaScript/TypeScript (text + voice agents). Use for multi-agent workflows, tools, guardrails, or encountering Zod errors, MCP failures, infinite loops, tool call issues.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/openai-agents/skills/openai-agents/SKILL.md
+++ b/plugins/openai-agents/skills/openai-agents/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: openai-agents
-description: >-
-  OpenAI Agents SDK for JavaScript/TypeScript (text + voice agents). Use for multi-agent workflows, tools, guardrails, or encountering Zod errors, MCP failures, infinite loops, tool call issues.
-
-    Keywords: OpenAI Agents SDK, @openai/agents, @openai/agents-realtime, openai agents javascript, openai agents typescript, text agents, voice agents, realtime agents, multi-agent workflows, agent handoffs, agent tools, zod schemas agents, structured outputs agents, agent streaming, agent guardrails, input guardrails, output guardrails, human-in-the-loop, cloudflare workers agents, nextjs openai agents, react openai agents, hono agents, agent debugging, Zod schema type error, MCP tracing failure, agent infinite loop, tool call failures, schema mismatch agents
+description: "OpenAI Agents SDK for JavaScript/TypeScript (text + voice agents). Use for multi-agent workflows, tools, guardrails, or encountering Zod errors, MCP failures, infinite loops, tool call issues."
 license: MIT
 metadata:
   packages:
@@ -15,8 +12,36 @@ metadata:
   production_tested: true
   token_savings: "~60%"
   errors_prevented: 9
+  keywords:
+    - OpenAI Agents SDK
+    - "@openai/agents"
+    - "@openai/agents-realtime"
+    - openai agents javascript
+    - openai agents typescript
+    - text agents
+    - voice agents
+    - realtime agents
+    - multi-agent workflows
+    - agent handoffs
+    - agent tools
+    - zod schemas agents
+    - structured outputs agents
+    - agent streaming
+    - agent guardrails
+    - input guardrails
+    - output guardrails
+    - human-in-the-loop
+    - cloudflare workers agents
+    - nextjs openai agents
+    - react openai agents
+    - hono agents
+    - agent debugging
+    - Zod schema type error
+    - MCP tracing failure
+    - agent infinite loop
+    - tool call failures
+    - schema mismatch agents
 ---
-
 # OpenAI Agents SDK Skill
 
 Complete skill for building AI applications with OpenAI Agents SDK (JavaScript/TypeScript), covering text agents, realtime voice agents, multi-agent workflows, and production deployment patterns.

--- a/plugins/openai-agents/skills/openai-agents/SKILL.md
+++ b/plugins/openai-agents/skills/openai-agents/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: openai-agents
-description: OpenAI Agents SDK for JavaScript/TypeScript (text + voice agents). Use for multi-agent workflows, tools, guardrails, or encountering Zod errors, MCP failures, infinite loops, tool call issues.
+description: >-
+  OpenAI Agents SDK for JavaScript/TypeScript (text + voice agents). Use for multi-agent workflows, tools, guardrails, or encountering Zod errors, MCP failures, infinite loops, tool call issues.
 
-  Keywords: OpenAI Agents SDK, @openai/agents, @openai/agents-realtime, openai agents javascript, openai agents typescript, text agents, voice agents, realtime agents, multi-agent workflows, agent handoffs, agent tools, zod schemas agents, structured outputs agents, agent streaming, agent guardrails, input guardrails, output guardrails, human-in-the-loop, cloudflare workers agents, nextjs openai agents, react openai agents, hono agents, agent debugging, Zod schema type error, MCP tracing failure, agent infinite loop, tool call failures, schema mismatch agents
+    Keywords: OpenAI Agents SDK, @openai/agents, @openai/agents-realtime, openai agents javascript, openai agents typescript, text agents, voice agents, realtime agents, multi-agent workflows, agent handoffs, agent tools, zod schemas agents, structured outputs agents, agent streaming, agent guardrails, input guardrails, output guardrails, human-in-the-loop, cloudflare workers agents, nextjs openai agents, react openai agents, hono agents, agent debugging, Zod schema type error, MCP tracing failure, agent infinite loop, tool call failures, schema mismatch agents
 license: MIT
 metadata:
   packages:

--- a/plugins/openai-api/.claude-plugin/plugin.json
+++ b/plugins/openai-api/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-api",
   "description": "Complete guide for OpenAI APIs: Chat Completions (GPT-5.2, GPT-4o), Embeddings, Images (GPT-Image-1.5), Audio (Whisper + TTS + Transcribe), Moderation. Includes Node.js SDK and fetch approaches.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/openai-api/skills/openai-api/SKILL.md
+++ b/plugins/openai-api/skills/openai-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openai-api
-description: Complete guide for OpenAI APIs: Chat Completions (GPT-5.2, GPT-4o), Embeddings, Images (GPT-Image-1.5), Audio (Whisper + TTS + Transcribe), Moderation. Includes Node.js SDK and fetch approaches.
+description: "Complete guide for OpenAI APIs: Chat Completions (GPT-5.2, GPT-4o), Embeddings, Images (GPT-Image-1.5), Audio (Whisper + TTS + Transcribe), Moderation. Includes Node.js SDK and fetch approaches."
 license: MIT
 ---
 

--- a/plugins/openai-assistants/.claude-plugin/plugin.json
+++ b/plugins/openai-assistants/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-assistants",
   "description": "OpenAI Assistants API v2 for stateful chatbots with Code Interpreter, File Search, RAG. Use for threads, vector stores, or encountering active run errors, indexing delays. ⚠️ Sunset August 26, 2026.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/openai-assistants/skills/openai-assistants/SKILL.md
+++ b/plugins/openai-assistants/skills/openai-assistants/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: openai-assistants
-description: OpenAI Assistants API v2 for stateful chatbots with Code Interpreter, File Search, RAG. Use for threads, vector stores, or encountering active run errors, indexing delays. ⚠️ Sunset August 26, 2026.
+description: >-
+  OpenAI Assistants API v2 for stateful chatbots with Code Interpreter, File Search, RAG. Use for threads, vector stores, or encountering active run errors, indexing delays. ⚠️ Sunset August 26, 2026.
 
-  Keywords: openai assistants, assistants api, openai threads, openai runs, code interpreter assistant,
-  file search openai, vector store openai, openai rag, assistant streaming, thread persistence,
-  stateful chatbot, thread already has active run, run status polling, vector store error
+    Keywords: openai assistants, assistants api, openai threads, openai runs, code interpreter assistant,
+    file search openai, vector store openai, openai rag, assistant streaming, thread persistence,
+    stateful chatbot, thread already has active run, run status polling, vector store error
 license: MIT
 metadata:
   version: "2.0.0"

--- a/plugins/openai-assistants/skills/openai-assistants/SKILL.md
+++ b/plugins/openai-assistants/skills/openai-assistants/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: openai-assistants
-description: >-
-  OpenAI Assistants API v2 for stateful chatbots with Code Interpreter, File Search, RAG. Use for threads, vector stores, or encountering active run errors, indexing delays. ⚠️ Sunset August 26, 2026.
-
-    Keywords: openai assistants, assistants api, openai threads, openai runs, code interpreter assistant,
-    file search openai, vector store openai, openai rag, assistant streaming, thread persistence,
-    stateful chatbot, thread already has active run, run status polling, vector store error
+description: "OpenAI Assistants API v2 for stateful chatbots with Code Interpreter, File Search, RAG. Use for threads, vector stores, or encountering active run errors, indexing delays. ⚠️ Sunset August 26, 2026."
 license: MIT
 metadata:
   version: "2.0.0"
@@ -19,8 +14,22 @@ metadata:
   errors_prevented: 15
   templates_included: 8
   references_included: 8
+  keywords:
+    - openai assistants
+    - assistants api
+    - openai threads
+    - openai runs
+    - code interpreter assistant
+    - file search openai
+    - vector store openai
+    - openai rag
+    - assistant streaming
+    - thread persistence
+    - stateful chatbot
+    - thread already has active run
+    - run status polling
+    - vector store error
 ---
-
 # OpenAI Assistants API v2
 
 **Status**: Production Ready (Deprecated H1 2026) | **Package**: openai@6.9.1

--- a/plugins/openai-responses/.claude-plugin/plugin.json
+++ b/plugins/openai-responses/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-responses",
   "description": "OpenAI Responses API for stateful agentic applications with reasoning preservation. Use for MCP integration, built-in tools, background processing, or migrating from Chat Completions.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/openai-responses/skills/openai-responses/SKILL.md
+++ b/plugins/openai-responses/skills/openai-responses/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: openai-responses
-description: OpenAI Responses API for stateful agentic applications with reasoning preservation. Use for MCP integration, built-in tools, background processing, or migrating from Chat Completions.
+description: >-
+  OpenAI Responses API for stateful agentic applications with reasoning preservation. Use for MCP integration, built-in tools, background processing, or migrating from Chat Completions.
 
-  Keywords: responses api, openai responses, stateful openai, openai mcp, code interpreter openai, file search openai, web search openai, image generation openai, reasoning preservation, agentic workflows, conversation state, background mode, chat completions migration, gpt-5, polymorphic outputs
+    Keywords: responses api, openai responses, stateful openai, openai mcp, code interpreter openai, file search openai, web search openai, image generation openai, reasoning preservation, agentic workflows, conversation state, background mode, chat completions migration, gpt-5, polymorphic outputs
 license: MIT
 metadata:
   version: "2.0.0"

--- a/plugins/openai-responses/skills/openai-responses/SKILL.md
+++ b/plugins/openai-responses/skills/openai-responses/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: openai-responses
-description: >-
-  OpenAI Responses API for stateful agentic applications with reasoning preservation. Use for MCP integration, built-in tools, background processing, or migrating from Chat Completions.
-
-    Keywords: responses api, openai responses, stateful openai, openai mcp, code interpreter openai, file search openai, web search openai, image generation openai, reasoning preservation, agentic workflows, conversation state, background mode, chat completions migration, gpt-5, polymorphic outputs
+description: "OpenAI Responses API for stateful agentic applications with reasoning preservation. Use for MCP integration, built-in tools, background processing, or migrating from Chat Completions."
 license: MIT
 metadata:
   version: "2.0.0"
@@ -12,8 +9,23 @@ metadata:
   sdk_version: "openai@5.19.1+"
   templates_included: 10
   references_included: 8
+  keywords:
+    - responses api
+    - openai responses
+    - stateful openai
+    - openai mcp
+    - code interpreter openai
+    - file search openai
+    - web search openai
+    - image generation openai
+    - reasoning preservation
+    - agentic workflows
+    - conversation state
+    - background mode
+    - chat completions migration
+    - gpt-5
+    - polymorphic outputs
 ---
-
 # OpenAI Responses API
 
 **Status**: Production Ready | **API Launch**: March 2025 | **SDK**: openai@5.19.1+

--- a/plugins/payment-gateway-integration/.claude-plugin/plugin.json
+++ b/plugins/payment-gateway-integration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "payment-gateway-integration",
   "description": "Integrates payment processing with Stripe, PayPal, or Square including subscriptions, webhooks, and PCI compliance. Use when implementing checkout flows, recurring billing, or handling refunds and disputes.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/pinia-colada/.claude-plugin/plugin.json
+++ b/plugins/pinia-colada/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pinia-colada",
   "description": "Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/pinia-colada/skills/pinia-colada/SKILL.md
+++ b/plugins/pinia-colada/skills/pinia-colada/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: pinia-colada
-description: >-
-  Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors.
-
-    Keywords: Pinia Colada, @pinia/colada, useQuery, useMutation, useQueryCache, data fetching, async state, Vue 3, Nuxt, Pinia, server state, caching, staleTime, gcTime, query invalidation, prefetching, optimistic updates, mutations, query keys, paginated queries, SSR, server-side rendering, Nuxt module, @pinia/colada-nuxt, query cache, auto-refetch, cache invalidation, request deduplication, loading states, error handling, onSettled, onSuccess, onError, defineColadaLoader
+description: "Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors."
 license: MIT
 metadata:
   version: "2.0.0"
@@ -15,8 +12,42 @@ metadata:
   token_savings: "~65%"
   errors_prevented: 12
   references_included: 4
+  keywords:
+    - Pinia Colada
+    - "@pinia/colada"
+    - useQuery
+    - useMutation
+    - useQueryCache
+    - data fetching
+    - async state
+    - Vue 3
+    - Nuxt
+    - Pinia
+    - server state
+    - caching
+    - staleTime
+    - gcTime
+    - query invalidation
+    - prefetching
+    - optimistic updates
+    - mutations
+    - query keys
+    - paginated queries
+    - SSR
+    - server-side rendering
+    - Nuxt module
+    - "@pinia/colada-nuxt"
+    - query cache
+    - auto-refetch
+    - cache invalidation
+    - request deduplication
+    - loading states
+    - error handling
+    - onSettled
+    - onSuccess
+    - onError
+    - defineColadaLoader
 ---
-
 # Pinia Colada - Smart Data Fetching for Vue
 
 **Status**: Production Ready ✅ | **Last Updated**: 2025-11-28

--- a/plugins/pinia-colada/skills/pinia-colada/SKILL.md
+++ b/plugins/pinia-colada/skills/pinia-colada/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: pinia-colada
-description: Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors.
+description: >-
+  Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors.
 
-  Keywords: Pinia Colada, @pinia/colada, useQuery, useMutation, useQueryCache, data fetching, async state, Vue 3, Nuxt, Pinia, server state, caching, staleTime, gcTime, query invalidation, prefetching, optimistic updates, mutations, query keys, paginated queries, SSR, server-side rendering, Nuxt module, @pinia/colada-nuxt, query cache, auto-refetch, cache invalidation, request deduplication, loading states, error handling, onSettled, onSuccess, onError, defineColadaLoader
+    Keywords: Pinia Colada, @pinia/colada, useQuery, useMutation, useQueryCache, data fetching, async state, Vue 3, Nuxt, Pinia, server state, caching, staleTime, gcTime, query invalidation, prefetching, optimistic updates, mutations, query keys, paginated queries, SSR, server-side rendering, Nuxt module, @pinia/colada-nuxt, query cache, auto-refetch, cache invalidation, request deduplication, loading states, error handling, onSettled, onSuccess, onError, defineColadaLoader
 license: MIT
 metadata:
   version: "2.0.0"

--- a/plugins/pinia-v3/.claude-plugin/plugin.json
+++ b/plugins/pinia-v3/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pinia-v3",
   "description": "Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/pinia-v3/skills/pinia-v3/SKILL.md
+++ b/plugins/pinia-v3/skills/pinia-v3/SKILL.md
@@ -1,12 +1,38 @@
 ---
 name: pinia-v3
-description: >-
-  Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors.
+description: "Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors."
 
-    Keywords: pinia, vue state management, pinia stores, defineStore, vue 3 state, state management, getters, actions, pinia plugins, pinia ssr, nuxt pinia, vuex migration, store composition, pinia testing, setup stores, option stores, storeToRefs, mapState, mapActions, state hydration, pinia nuxt module, createPinia, useStore, pinia devtools, pinia hmr, hot module replacement
+metadata:
+  keywords:
+    - pinia
+    - vue state management
+    - pinia stores
+    - defineStore
+    - vue 3 state
+    - state management
+    - getters
+    - actions
+    - pinia plugins
+    - pinia ssr
+    - nuxt pinia
+    - vuex migration
+    - store composition
+    - pinia testing
+    - setup stores
+    - option stores
+    - storeToRefs
+    - mapState
+    - mapActions
+    - state hydration
+    - pinia nuxt module
+    - createPinia
+    - useStore
+    - pinia devtools
+    - pinia hmr
+    - hot module replacement
+
 license: MIT
 ---
-
 # Pinia v3 - Vue State Management
 
 **Status**: Production Ready ✅

--- a/plugins/pinia-v3/skills/pinia-v3/SKILL.md
+++ b/plugins/pinia-v3/skills/pinia-v3/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: pinia-v3
-description: Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors.
+description: >-
+  Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors.
 
-  Keywords: pinia, vue state management, pinia stores, defineStore, vue 3 state, state management, getters, actions, pinia plugins, pinia ssr, nuxt pinia, vuex migration, store composition, pinia testing, setup stores, option stores, storeToRefs, mapState, mapActions, state hydration, pinia nuxt module, createPinia, useStore, pinia devtools, pinia hmr, hot module replacement
+    Keywords: pinia, vue state management, pinia stores, defineStore, vue 3 state, state management, getters, actions, pinia plugins, pinia ssr, nuxt pinia, vuex migration, store composition, pinia testing, setup stores, option stores, storeToRefs, mapState, mapActions, state hydration, pinia nuxt module, createPinia, useStore, pinia devtools, pinia hmr, hot module replacement
 license: MIT
 ---
 

--- a/plugins/plan-interview/.claude-plugin/plugin.json
+++ b/plugins/plan-interview/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-interview",
   "description": "Adaptive interview-driven spec generation with quality review. Automatically adjusts depth based on plan complexity.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/playwright/.claude-plugin/plugin.json
+++ b/plugins/playwright/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright",
   "description": "Browser automation and E2E testing with Playwright. Auto-detects dev servers, writes clean test scripts. Test pages, fill forms, take screenshots, check responsive design, validate UX, test login flows, check links, automate any browser task. Use for cross-browser testing, visual regression, API testing, component testing in TypeScript/JavaScript and Python projects.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/progressive-web-app/.claude-plugin/plugin.json
+++ b/plugins/progressive-web-app/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "progressive-web-app",
   "description": "Builds Progressive Web Apps with service workers, web manifest, offline support, and installation prompts. Use when creating installable web experiences, implementing offline functionality, or adding push notifications to web apps.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/push-notification-setup/.claude-plugin/plugin.json
+++ b/plugins/push-notification-setup/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "push-notification-setup",
   "description": "Implements push notifications across iOS, Android, and web using Firebase Cloud Messaging and native services. Use when adding notification capabilities, handling background messages, or setting up notification channels.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-best-practices/.claude-plugin/plugin.json
+++ b/plugins/react-best-practices/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-best-practices",
   "description": "React and Next.js performance optimization guidelines from Vercel Engineering. Use when writing/reviewing/refactoring React code for optimal performance. Covers async patterns, bundle optimization, server/client components, re-render optimization.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-composition-patterns/.claude-plugin/plugin.json
+++ b/plugins/react-composition-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-composition-patterns",
   "description": "React composition patterns from Vercel Engineering. Use when building scalable components, avoiding boolean prop proliferation, implementing compound components, or managing component state. Covers architecture, state management, and implementation patterns.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-hook-form-zod/.claude-plugin/plugin.json
+++ b/plugins/react-hook-form-zod/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-hook-form-zod",
   "description": "Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-hook-form-zod/skills/react-hook-form-zod/SKILL.md
+++ b/plugins/react-hook-form-zod/skills/react-hook-form-zod/SKILL.md
@@ -1,13 +1,40 @@
 ---
 name: react-hook-form-zod
-description: >-
-  Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems.
+description: "Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems."
 
-    Keywords: react-hook-form, useForm, zod validation, zodResolver, @hookform/resolvers, form schema, register, handleSubmit, formState, useFieldArray, useWatch, useController, Controller, shadcn form, Field component, client server validation, nested validation, array field validation, dynamic fields, multi-step form, async validation, zod refine, z.infer, form error handling, uncontrolled to controlled, resolver not found, schema validation error
+
+metadata:
+  keywords:
+    - react-hook-form
+    - useForm
+    - zod validation
+    - zodResolver
+    - "@hookform/resolvers"
+    - form schema
+    - register
+    - handleSubmit
+    - formState
+    - useFieldArray
+    - useWatch
+    - useController
+    - Controller
+    - shadcn form
+    - Field component
+    - client server validation
+    - nested validation
+    - array field validation
+    - dynamic fields
+    - multi-step form
+    - async validation
+    - zod refine
+    - z.infer
+    - form error handling
+    - uncontrolled to controlled
+    - resolver not found
+    - schema validation error
 
 license: MIT
 ---
-
 # React Hook Form + Zod Validation
 
 **Status**: Production Ready ✅

--- a/plugins/react-hook-form-zod/skills/react-hook-form-zod/SKILL.md
+++ b/plugins/react-hook-form-zod/skills/react-hook-form-zod/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: react-hook-form-zod
-description: Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems.
+description: >-
+  Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems.
 
-  Keywords: react-hook-form, useForm, zod validation, zodResolver, @hookform/resolvers, form schema, register, handleSubmit, formState, useFieldArray, useWatch, useController, Controller, shadcn form, Field component, client server validation, nested validation, array field validation, dynamic fields, multi-step form, async validation, zod refine, z.infer, form error handling, uncontrolled to controlled, resolver not found, schema validation error
+    Keywords: react-hook-form, useForm, zod validation, zodResolver, @hookform/resolvers, form schema, register, handleSubmit, formState, useFieldArray, useWatch, useController, Controller, shadcn form, Field component, client server validation, nested validation, array field validation, dynamic fields, multi-step form, async validation, zod refine, z.infer, form error handling, uncontrolled to controlled, resolver not found, schema validation error
 
 license: MIT
 ---

--- a/plugins/react-native-skills/.claude-plugin/plugin.json
+++ b/plugins/react-native-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-skills",
   "description": "React Native and Expo best practices for building performant mobile apps. Use when building React Native components, optimizing list performance, implementing animations, or working with native modules.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/recommendation-engine/.claude-plugin/plugin.json
+++ b/plugins/recommendation-engine/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "recommendation-engine",
   "description": "Build recommendation systems with collaborative filtering, matrix factorization, hybrid approaches. Use for product recommendations, personalization, or encountering cold start, sparsity, quality evaluation issues.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/recommendation-system/.claude-plugin/plugin.json
+++ b/plugins/recommendation-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "recommendation-system",
   "description": "Deploy production recommendation systems with feature stores, caching, A/B testing. Use for personalization APIs, low latency serving, or encountering cache invalidation, experiment tracking, quality monitoring issues.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/responsive-web-design/.claude-plugin/plugin.json
+++ b/plugins/responsive-web-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "responsive-web-design",
   "description": "Builds adaptive web interfaces using Flexbox, CSS Grid, and media queries with a mobile-first approach. Use when creating multi-device layouts, implementing flexible UI systems, or ensuring cross-browser compatibility.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/rest-api-design/.claude-plugin/plugin.json
+++ b/plugins/rest-api-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rest-api-design",
   "description": "Designs RESTful APIs with proper resource naming, HTTP methods, status codes, and response formats. Use when building new APIs, establishing API conventions, or designing developer-friendly interfaces.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/root-cause-tracing/.claude-plugin/plugin.json
+++ b/plugins/root-cause-tracing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "root-cause-tracing",
   "description": "Systematically trace bugs backward through call stack to find original trigger. Use when errors occur deep in execution and you need to trace back to find the original trigger.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/security-headers-configuration/.claude-plugin/plugin.json
+++ b/plugins/security-headers-configuration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "security-headers-configuration",
   "description": "Configures HTTP security headers to protect against XSS, clickjacking, and MIME sniffing attacks. Use when hardening web applications, passing security audits, or implementing Content Security Policy.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/seo-keyword-cluster-builder/.claude-plugin/plugin.json
+++ b/plugins/seo-keyword-cluster-builder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seo-keyword-cluster-builder",
   "description": "Groups related keywords into topic clusters and creates content hub architecture recommendations with internal linking strategies. Use when planning content strategy, organizing keyword research, or building pillar page structures.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/seo-optimizer/.claude-plugin/plugin.json
+++ b/plugins/seo-optimizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seo-optimizer",
   "description": "SEO optimization with keyword analysis, readability assessment, technical validation, content quality. Use for search rankings, blog posts, content audits, or encountering keyword density, readability scores, meta tags, schema markup errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/sequential-thinking/.claude-plugin/plugin.json
+++ b/plugins/sequential-thinking/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sequential-thinking",
   "description": "Systematic step-by-step reasoning with revision and branching. Use for complex problems, multi-stage analysis, design planning, problem decomposition, or encountering unclear scope, alternative approaches needed, revision requirements.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/session-management/.claude-plugin/plugin.json
+++ b/plugins/session-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "session-management",
   "description": "Implements secure session management with JWT tokens, Redis storage, refresh flows, and proper cookie configuration. Use when building authentication systems, managing user sessions, or implementing secure logout functionality.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/shadcn-vue/.claude-plugin/plugin.json
+++ b/plugins/shadcn-vue/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shadcn-vue",
   "description": "shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/shadcn-vue/skills/shadcn-vue/SKILL.md
+++ b/plugins/shadcn-vue/skills/shadcn-vue/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: shadcn-vue
-description: shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors.
+description: >-
+  shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors.
 
-  Keywords: shadcn-vue, shadcn vue, Reka UI, radix-vue, Vue components, Nuxt components, Tailwind CSS, accessible components, headless ui, Auto Form, Zod validation, TanStack Table, data tables, Unovis charts, dark mode, useColorMode, components.json, bunx shadcn-vue, vueuse, composables, Vue 3, Nuxt 3, TypeScript, accessibility, ARIA, component library, UI components, form builder, schema validation
+    Keywords: shadcn-vue, shadcn vue, Reka UI, radix-vue, Vue components, Nuxt components, Tailwind CSS, accessible components, headless ui, Auto Form, Zod validation, TanStack Table, data tables, Unovis charts, dark mode, useColorMode, components.json, bunx shadcn-vue, vueuse, composables, Vue 3, Nuxt 3, TypeScript, accessibility, ARIA, component library, UI components, form builder, schema validation
 license: MIT
 ---
 

--- a/plugins/shadcn-vue/skills/shadcn-vue/SKILL.md
+++ b/plugins/shadcn-vue/skills/shadcn-vue/SKILL.md
@@ -1,12 +1,41 @@
 ---
 name: shadcn-vue
-description: >-
-  shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors.
+description: "shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors."
 
-    Keywords: shadcn-vue, shadcn vue, Reka UI, radix-vue, Vue components, Nuxt components, Tailwind CSS, accessible components, headless ui, Auto Form, Zod validation, TanStack Table, data tables, Unovis charts, dark mode, useColorMode, components.json, bunx shadcn-vue, vueuse, composables, Vue 3, Nuxt 3, TypeScript, accessibility, ARIA, component library, UI components, form builder, schema validation
+metadata:
+  keywords:
+    - shadcn-vue
+    - shadcn vue
+    - Reka UI
+    - radix-vue
+    - Vue components
+    - Nuxt components
+    - Tailwind CSS
+    - accessible components
+    - headless ui
+    - Auto Form
+    - Zod validation
+    - TanStack Table
+    - data tables
+    - Unovis charts
+    - dark mode
+    - useColorMode
+    - components.json
+    - bunx shadcn-vue
+    - vueuse
+    - composables
+    - Vue 3
+    - Nuxt 3
+    - TypeScript
+    - accessibility
+    - ARIA
+    - component library
+    - UI components
+    - form builder
+    - schema validation
+
 license: MIT
 ---
-
 # shadcn-vue Production Stack
 
 **Production-tested**: Vue/Nuxt applications with accessible, customizable components

--- a/plugins/sql-query-optimization/.claude-plugin/plugin.json
+++ b/plugins/sql-query-optimization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sql-query-optimization",
   "description": "SQL query optimization for PostgreSQL/MySQL with indexing, EXPLAIN analysis. Use for slow queries, N+1 problems, missing indexes, or encountering sequential scans, OFFSET pagination, temp table spills, inefficient JOINs.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/sql-query-optimization/skills/sql-query-optimization/SKILL.md
+++ b/plugins/sql-query-optimization/skills/sql-query-optimization/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: sql-query-optimization
-description: SQL query optimization for PostgreSQL/MySQL with indexing, EXPLAIN analysis. Use for slow queries, N+1 problems, missing indexes, or encountering sequential scans, OFFSET pagination, temp table spills, inefficient JOINs.
+description: >-
+  SQL query optimization for PostgreSQL/MySQL with indexing, EXPLAIN analysis. Use for slow queries, N+1 problems, missing indexes, or encountering sequential scans, OFFSET pagination, temp table spills, inefficient JOINs.
 
-  Keywords: sql optimization, query performance, database indexes, explain analyze, slow queries, n+1 problem,
-  query plan, index strategy, composite index, covering index, postgresql performance, mysql optimization,
-  query rewriting, prepared statements, connection pooling, sequential scan, missing index, SELECT *,
-  LIMIT optimization, subquery performance, pagination, cursor based pagination, batch operations,
-  pg_stat_statements, full-text search, bitmap scan, index only scan, query tuning, database performance,
-  cache hit ratio, work_mem, shared_buffers, database monitoring
+    Keywords: sql optimization, query performance, database indexes, explain analyze, slow queries, n+1 problem,
+    query plan, index strategy, composite index, covering index, postgresql performance, mysql optimization,
+    query rewriting, prepared statements, connection pooling, sequential scan, missing index, SELECT *,
+    LIMIT optimization, subquery performance, pagination, cursor based pagination, batch operations,
+    pg_stat_statements, full-text search, bitmap scan, index only scan, query tuning, database performance,
+    cache hit ratio, work_mem, shared_buffers, database monitoring
 license: MIT
 ---
 

--- a/plugins/sql-query-optimization/skills/sql-query-optimization/SKILL.md
+++ b/plugins/sql-query-optimization/skills/sql-query-optimization/SKILL.md
@@ -1,17 +1,45 @@
 ---
 name: sql-query-optimization
-description: >-
-  SQL query optimization for PostgreSQL/MySQL with indexing, EXPLAIN analysis. Use for slow queries, N+1 problems, missing indexes, or encountering sequential scans, OFFSET pagination, temp table spills, inefficient JOINs.
+description: "SQL query optimization for PostgreSQL/MySQL with indexing, EXPLAIN analysis. Use for slow queries, N+1 problems, missing indexes, or encountering sequential scans, OFFSET pagination, temp table spills, inefficient JOINs."
 
-    Keywords: sql optimization, query performance, database indexes, explain analyze, slow queries, n+1 problem,
-    query plan, index strategy, composite index, covering index, postgresql performance, mysql optimization,
-    query rewriting, prepared statements, connection pooling, sequential scan, missing index, SELECT *,
-    LIMIT optimization, subquery performance, pagination, cursor based pagination, batch operations,
-    pg_stat_statements, full-text search, bitmap scan, index only scan, query tuning, database performance,
-    cache hit ratio, work_mem, shared_buffers, database monitoring
+metadata:
+  keywords:
+    - sql optimization
+    - query performance
+    - database indexes
+    - explain analyze
+    - slow queries
+    - n+1 problem
+    - query plan
+    - index strategy
+    - composite index
+    - covering index
+    - postgresql performance
+    - mysql optimization
+    - query rewriting
+    - prepared statements
+    - connection pooling
+    - sequential scan
+    - missing index
+    - SELECT *
+    - LIMIT optimization
+    - subquery performance
+    - pagination
+    - cursor based pagination
+    - batch operations
+    - pg_stat_statements
+    - full-text search
+    - bitmap scan
+    - index only scan
+    - query tuning
+    - database performance
+    - cache hit ratio
+    - work_mem
+    - shared_buffers
+    - database monitoring
+
 license: MIT
 ---
-
 # SQL Query Optimization
 
 **Status**: Production Ready ✅

--- a/plugins/supabase-postgres-best-practices/.claude-plugin/plugin.json
+++ b/plugins/supabase-postgres-best-practices/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "supabase-postgres-best-practices",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Postgres performance optimization and best practices from Supabase. 30 rules across 8 categories prioritized by impact.",
   "author": {
     "name": "Supabase",

--- a/plugins/sveltia-cms/.claude-plugin/plugin.json
+++ b/plugins/sveltia-cms/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sveltia-cms",
   "description": "Sveltia CMS Git-backed content management (Decap/Netlify CMS successor). 5x smaller bundle (300 KB), GraphQL performance, solves 260+ issues. Use for static sites (Hugo, Jekyll, 11ty, Gatsby, Astro, Next.js), blogs, docs, i18n, or encountering OAuth errors, TOML/YAML issues, CORS problems, content listing errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/swift-best-practices/.claude-plugin/plugin.json
+++ b/plugins/swift-best-practices/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swift-best-practices",
   "description": "This skill should be used when writing or reviewing Swift code for iOS or macOS projects. Apply modern Swift 6+ best practices, concurrency patterns, API design guidelines, and migration strategies. Covers async/await, actors, MainActor, Sendable, typed throws, and Swift 6 breaking changes.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/swift-best-practices/skills/swift-best-practices/SKILL.md
+++ b/plugins/swift-best-practices/skills/swift-best-practices/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: swift-best-practices
-description: |
-  This skill should be used when writing or reviewing Swift code for iOS or macOS projects. Apply modern Swift 6+ best practices, concurrency patterns, API design guidelines, and migration strategies. Covers async/await, actors, MainActor, Sendable, typed throws, and Swift 6 breaking changes.
+description: >-
+  |
+    This skill should be used when writing or reviewing Swift code for iOS or macOS projects. Apply modern Swift 6+ best practices, concurrency patterns, API design guidelines, and migration strategies. Covers async/await, actors, MainActor, Sendable, typed throws, and Swift 6 breaking changes.
 
-  Keywords: concurrency, async-await, actors, Sendable, typed-throws, Swift-6, migration, data-races, MainActor, nonisolated, isolated, iOS, macOS, SwiftUI, Combine, Swift-concurrency, actor-isolation, strict-concurrency, Swift-migration, modern-Swift, Swift-evolution, code-review, Swift-patterns, Apple-platforms, Xcode, iOS-development, macOS-development
+    Keywords: concurrency, async-await, actors, Sendable, typed-throws, Swift-6, migration, data-races, MainActor, nonisolated, isolated, iOS, macOS, SwiftUI, Combine, Swift-concurrency, actor-isolation, strict-concurrency, Swift-migration, modern-Swift, Swift-evolution, code-review, Swift-patterns, Apple-platforms, Xcode, iOS-development, macOS-development
 license: MIT
 allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
 metadata:

--- a/plugins/swift-best-practices/skills/swift-best-practices/SKILL.md
+++ b/plugins/swift-best-practices/skills/swift-best-practices/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: swift-best-practices
-description: >-
-  |
-    This skill should be used when writing or reviewing Swift code for iOS or macOS projects. Apply modern Swift 6+ best practices, concurrency patterns, API design guidelines, and migration strategies. Covers async/await, actors, MainActor, Sendable, typed throws, and Swift 6 breaking changes.
-
-    Keywords: concurrency, async-await, actors, Sendable, typed-throws, Swift-6, migration, data-races, MainActor, nonisolated, isolated, iOS, macOS, SwiftUI, Combine, Swift-concurrency, actor-isolation, strict-concurrency, Swift-migration, modern-Swift, Swift-evolution, code-review, Swift-patterns, Apple-platforms, Xcode, iOS-development, macOS-development
+description: "| This skill should be used when writing or reviewing Swift code for iOS or macOS projects. Apply modern Swift 6+ best practices, concurrency patterns, API design guidelines, and migration strategies. Covers async/await, actors, MainActor, Sendable, typed throws, and Swift 6 breaking changes."
 license: MIT
 allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
 metadata:
@@ -15,8 +11,35 @@ metadata:
   companion_mcp: "swiftlens"
   mcp_install: "uvx swiftlens"
   references_source: "sammcj/agentic-coding (Apache 2.0)"
+  keywords:
+    - concurrency
+    - async-await
+    - actors
+    - Sendable
+    - typed-throws
+    - Swift-6
+    - migration
+    - data-races
+    - MainActor
+    - nonisolated
+    - isolated
+    - iOS
+    - macOS
+    - SwiftUI
+    - Combine
+    - Swift-concurrency
+    - actor-isolation
+    - strict-concurrency
+    - Swift-migration
+    - modern-Swift
+    - Swift-evolution
+    - code-review
+    - Swift-patterns
+    - Apple-platforms
+    - Xcode
+    - iOS-development
+    - macOS-development
 ---
-
 # Swift Best Practices Skill
 
 ## Overview

--- a/plugins/swift-settingskit/.claude-plugin/plugin.json
+++ b/plugins/swift-settingskit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swift-settingskit",
   "description": "SettingsKit for SwiftUI settings interfaces (iOS, macOS, watchOS, tvOS, visionOS). Use for settings/preferences screens, searchable settings, nested navigation, @Observable/@Bindable state, or encountering settings update errors, navigation state issues.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/swift-settingskit/skills/swift-settingskit/SKILL.md
+++ b/plugins/swift-settingskit/skills/swift-settingskit/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: swift-settingskit
-description: SettingsKit for SwiftUI settings interfaces (iOS, macOS, watchOS, tvOS, visionOS). Use for settings/preferences screens, searchable settings, nested navigation, @Observable/@Bindable state, or encountering settings update errors, navigation state issues.
+description: >-
+  SettingsKit for SwiftUI settings interfaces (iOS, macOS, watchOS, tvOS, visionOS). Use for settings/preferences screens, searchable settings, nested navigation, @Observable/@Bindable state, or encountering settings update errors, navigation state issues.
 
-  Keywords: SettingsKit, SwiftUI settings, settings interface, preferences UI, searchable settings, settings navigation, SettingsContainer, SettingsGroup, SettingsItem, CustomSettingsGroup, settings tags, settings search, Observable settings, Bindable settings, iOS 17, macOS 14, Swift 6, settings style, sidebar settings, declarative settings, settings hierarchy
+    Keywords: SettingsKit, SwiftUI settings, settings interface, preferences UI, searchable settings, settings navigation, SettingsContainer, SettingsGroup, SettingsItem, CustomSettingsGroup, settings tags, settings search, Observable settings, Bindable settings, iOS 17, macOS 14, Swift 6, settings style, sidebar settings, declarative settings, settings hierarchy
 license: MIT
 ---
 

--- a/plugins/swift-settingskit/skills/swift-settingskit/SKILL.md
+++ b/plugins/swift-settingskit/skills/swift-settingskit/SKILL.md
@@ -1,12 +1,33 @@
 ---
 name: swift-settingskit
-description: >-
-  SettingsKit for SwiftUI settings interfaces (iOS, macOS, watchOS, tvOS, visionOS). Use for settings/preferences screens, searchable settings, nested navigation, @Observable/@Bindable state, or encountering settings update errors, navigation state issues.
+description: "SettingsKit for SwiftUI settings interfaces (iOS, macOS, watchOS, tvOS, visionOS). Use for settings/preferences screens, searchable settings, nested navigation, @Observable/@Bindable state, or encountering settings update errors, navigation state issues."
 
-    Keywords: SettingsKit, SwiftUI settings, settings interface, preferences UI, searchable settings, settings navigation, SettingsContainer, SettingsGroup, SettingsItem, CustomSettingsGroup, settings tags, settings search, Observable settings, Bindable settings, iOS 17, macOS 14, Swift 6, settings style, sidebar settings, declarative settings, settings hierarchy
+metadata:
+  keywords:
+    - SettingsKit
+    - SwiftUI settings
+    - settings interface
+    - preferences UI
+    - searchable settings
+    - settings navigation
+    - SettingsContainer
+    - SettingsGroup
+    - SettingsItem
+    - CustomSettingsGroup
+    - settings tags
+    - settings search
+    - Observable settings
+    - Bindable settings
+    - iOS 17
+    - macOS 14
+    - Swift 6
+    - settings style
+    - sidebar settings
+    - declarative settings
+    - settings hierarchy
+
 license: MIT
 ---
-
 # Swift SettingsKit
 
 **Status**: Production Ready ✅

--- a/plugins/systematic-debugging/.claude-plugin/plugin.json
+++ b/plugins/systematic-debugging/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "systematic-debugging",
   "description": "Four-phase debugging framework that ensures root cause investigation before attempting fixes. Never jump to solutions. Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tailwind-v4-shadcn/.claude-plugin/plugin.json
+++ b/plugins/tailwind-v4-shadcn/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tailwind-v4-shadcn",
   "description": "Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React. Use when: initializing React projects with Tailwind v4, setting up shadcn/ui, implementing dark mode, debugging CSS variable issues, fixing theme switching, migrating from Tailwind v3, or encountering color/theming problems. Covers: @theme inline pattern, CSS variable architecture, dark mode with ThemeProvider, component composition, vite.config setup, common v4 gotchas, and production-tested patterns.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tailwind-v4-shadcn/skills/tailwind-v4-shadcn/SKILL.md
+++ b/plugins/tailwind-v4-shadcn/skills/tailwind-v4-shadcn/SKILL.md
@@ -1,21 +1,22 @@
 ---
 name: tailwind-v4-shadcn
-description: |
-  Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React.
+description: >-
+  |
+    Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React.
 
-  Use when: initializing React projects with Tailwind v4, setting up shadcn/ui,
-  implementing dark mode, debugging CSS variable issues, fixing theme switching,
-  migrating from Tailwind v3, or encountering color/theming problems.
+    Use when: initializing React projects with Tailwind v4, setting up shadcn/ui,
+    implementing dark mode, debugging CSS variable issues, fixing theme switching,
+    migrating from Tailwind v3, or encountering color/theming problems.
 
-  Covers: @theme inline pattern, CSS variable architecture, dark mode with
-  ThemeProvider, component composition, vite.config setup, common v4 gotchas,
-  and production-tested patterns.
+    Covers: @theme inline pattern, CSS variable architecture, dark mode with
+    ThemeProvider, component composition, vite.config setup, common v4 gotchas,
+    and production-tested patterns.
 
-  Keywords: Tailwind v4, shadcn/ui, @tailwindcss/vite, @theme inline, dark mode,
-  CSS variables, hsl() wrapper, components.json, React theming, theme switching,
-  colors not working, variables broken, theme not applying, @plugin directive,
-  typography plugin, forms plugin, prose class, @tailwindcss/typography,
-  @tailwindcss/forms
+    Keywords: Tailwind v4, shadcn/ui, @tailwindcss/vite, @theme inline, dark mode,
+    CSS variables, hsl() wrapper, components.json, React theming, theme switching,
+    colors not working, variables broken, theme not applying, @plugin directive,
+    typography plugin, forms plugin, prose class, @tailwindcss/typography,
+    @tailwindcss/forms
 license: MIT
 ---
 

--- a/plugins/tailwind-v4-shadcn/skills/tailwind-v4-shadcn/SKILL.md
+++ b/plugins/tailwind-v4-shadcn/skills/tailwind-v4-shadcn/SKILL.md
@@ -1,25 +1,31 @@
 ---
 name: tailwind-v4-shadcn
-description: >-
-  |
-    Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React.
+description: "| Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React. Use when: initializing React projects with Tailwind v4, setting up shadcn/ui, implementing dark mode, debugging CSS variable issues, fixing theme switching, migrating from Tailwind v3, or encountering color/theming problems. Covers: @theme inline pattern, CSS variable architecture, dark mode with ThemeProvider, component composition, vite.config setup, common v4 gotchas, and production-tested patterns."
 
-    Use when: initializing React projects with Tailwind v4, setting up shadcn/ui,
-    implementing dark mode, debugging CSS variable issues, fixing theme switching,
-    migrating from Tailwind v3, or encountering color/theming problems.
+metadata:
+  keywords:
+    - Tailwind v4
+    - shadcn/ui
+    - "@tailwindcss/vite"
+    - "@theme inline"
+    - dark mode
+    - CSS variables
+    - hsl() wrapper
+    - components.json
+    - React theming
+    - theme switching
+    - colors not working
+    - variables broken
+    - theme not applying
+    - "@plugin directive"
+    - typography plugin
+    - forms plugin
+    - prose class
+    - "@tailwindcss/typography"
+    - "@tailwindcss/forms"
 
-    Covers: @theme inline pattern, CSS variable architecture, dark mode with
-    ThemeProvider, component composition, vite.config setup, common v4 gotchas,
-    and production-tested patterns.
-
-    Keywords: Tailwind v4, shadcn/ui, @tailwindcss/vite, @theme inline, dark mode,
-    CSS variables, hsl() wrapper, components.json, React theming, theme switching,
-    colors not working, variables broken, theme not applying, @plugin directive,
-    typography plugin, forms plugin, prose class, @tailwindcss/typography,
-    @tailwindcss/forms
 license: MIT
 ---
-
 # Tailwind v4 + shadcn/ui Production Stack
 
 **Production-tested**: WordPress Auditor (https://wordpress-auditor.webfonts.workers.dev)

--- a/plugins/tanstack-ai/.claude-plugin/plugin.json
+++ b/plugins/tanstack-ai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-ai",
   "description": "TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and tool definitions.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-ai/skills/tanstack-ai/SKILL.md
+++ b/plugins/tanstack-ai/skills/tanstack-ai/SKILL.md
@@ -1,12 +1,39 @@
 ---
 name: tanstack-ai
-description: >-
-  TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and tool definitions.
+description: "TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and tool definitions."
 
-    Keywords: TanStack AI, @tanstack/ai, @tanstack/ai-react, @tanstack/ai-client, @tanstack/ai-solid, @tanstack/ai-openai, @tanstack/ai-anthropic, @tanstack/ai-gemini, @tanstack/ai-ollama, toolDefinition, client tools, server tools, tool approval, agent loop, streaming, SSE, connection adapters, multimodal, type-safe models, TanStack Start, Next.js API, toStreamResponse, fetchServerSentEvents, chat, useChat, ChatClient, needsApproval
+metadata:
+  keywords:
+    - TanStack AI
+    - "@tanstack/ai"
+    - "@tanstack/ai-react"
+    - "@tanstack/ai-client"
+    - "@tanstack/ai-solid"
+    - "@tanstack/ai-openai"
+    - "@tanstack/ai-anthropic"
+    - "@tanstack/ai-gemini"
+    - "@tanstack/ai-ollama"
+    - toolDefinition
+    - client tools
+    - server tools
+    - tool approval
+    - agent loop
+    - streaming
+    - SSE
+    - connection adapters
+    - multimodal
+    - type-safe models
+    - TanStack Start
+    - Next.js API
+    - toStreamResponse
+    - fetchServerSentEvents
+    - chat
+    - useChat
+    - ChatClient
+    - needsApproval
+
 license: MIT
 ---
-
 # TanStack AI (Provider-Agnostic LLM SDK)
 
 **Status**: Production Ready ✅  

--- a/plugins/tanstack-ai/skills/tanstack-ai/SKILL.md
+++ b/plugins/tanstack-ai/skills/tanstack-ai/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: tanstack-ai
-description: TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and tool definitions.
+description: >-
+  TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and tool definitions.
 
-  Keywords: TanStack AI, @tanstack/ai, @tanstack/ai-react, @tanstack/ai-client, @tanstack/ai-solid, @tanstack/ai-openai, @tanstack/ai-anthropic, @tanstack/ai-gemini, @tanstack/ai-ollama, toolDefinition, client tools, server tools, tool approval, agent loop, streaming, SSE, connection adapters, multimodal, type-safe models, TanStack Start, Next.js API, toStreamResponse, fetchServerSentEvents, chat, useChat, ChatClient, needsApproval
+    Keywords: TanStack AI, @tanstack/ai, @tanstack/ai-react, @tanstack/ai-client, @tanstack/ai-solid, @tanstack/ai-openai, @tanstack/ai-anthropic, @tanstack/ai-gemini, @tanstack/ai-ollama, toolDefinition, client tools, server tools, tool approval, agent loop, streaming, SSE, connection adapters, multimodal, type-safe models, TanStack Start, Next.js API, toStreamResponse, fetchServerSentEvents, chat, useChat, ChatClient, needsApproval
 license: MIT
 ---
 

--- a/plugins/tanstack-query/.claude-plugin/plugin.json
+++ b/plugins/tanstack-query/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-query",
   "description": "TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-query/skills/tanstack-query/SKILL.md
+++ b/plugins/tanstack-query/skills/tanstack-query/SKILL.md
@@ -1,12 +1,48 @@
 ---
 name: tanstack-query
-description: >-
-  TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors.
+description: "TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors."
 
-    Keywords: TanStack Query, React Query, useQuery, useMutation, useInfiniteQuery, useSuspenseQuery, QueryClient, QueryClientProvider, data fetching, server state, caching, staleTime, gcTime, query invalidation, prefetching, optimistic updates, mutations, query keys, query functions, error boundaries, suspense, React Query DevTools, v5 migration, v4 to v5, request waterfalls, background refetching, cacheTime renamed, loading status renamed, pending status, initialPageParam required, keepPreviousData removed, placeholderData, query callbacks removed, onSuccess removed, onError removed, object syntax required
+metadata:
+  keywords:
+    - TanStack Query
+    - React Query
+    - useQuery
+    - useMutation
+    - useInfiniteQuery
+    - useSuspenseQuery
+    - QueryClient
+    - QueryClientProvider
+    - data fetching
+    - server state
+    - caching
+    - staleTime
+    - gcTime
+    - query invalidation
+    - prefetching
+    - optimistic updates
+    - mutations
+    - query keys
+    - query functions
+    - error boundaries
+    - suspense
+    - React Query DevTools
+    - v5 migration
+    - v4 to v5
+    - request waterfalls
+    - background refetching
+    - cacheTime renamed
+    - loading status renamed
+    - pending status
+    - initialPageParam required
+    - keepPreviousData removed
+    - placeholderData
+    - query callbacks removed
+    - onSuccess removed
+    - onError removed
+    - object syntax required
+
 license: MIT
 ---
-
 # TanStack Query (React Query) v5
 
 **Status**: Production Ready ✅

--- a/plugins/tanstack-query/skills/tanstack-query/SKILL.md
+++ b/plugins/tanstack-query/skills/tanstack-query/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: tanstack-query
-description: TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors.
+description: >-
+  TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors.
 
-  Keywords: TanStack Query, React Query, useQuery, useMutation, useInfiniteQuery, useSuspenseQuery, QueryClient, QueryClientProvider, data fetching, server state, caching, staleTime, gcTime, query invalidation, prefetching, optimistic updates, mutations, query keys, query functions, error boundaries, suspense, React Query DevTools, v5 migration, v4 to v5, request waterfalls, background refetching, cacheTime renamed, loading status renamed, pending status, initialPageParam required, keepPreviousData removed, placeholderData, query callbacks removed, onSuccess removed, onError removed, object syntax required
+    Keywords: TanStack Query, React Query, useQuery, useMutation, useInfiniteQuery, useSuspenseQuery, QueryClient, QueryClientProvider, data fetching, server state, caching, staleTime, gcTime, query invalidation, prefetching, optimistic updates, mutations, query keys, query functions, error boundaries, suspense, React Query DevTools, v5 migration, v4 to v5, request waterfalls, background refetching, cacheTime renamed, loading status renamed, pending status, initialPageParam required, keepPreviousData removed, placeholderData, query callbacks removed, onSuccess removed, onError removed, object syntax required
 license: MIT
 ---
 

--- a/plugins/tanstack-router/.claude-plugin/plugin.json
+++ b/plugins/tanstack-router/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-router",
   "description": "TanStack Router type-safe file-based routing for React. Use for SPAs, TanStack Query integration, Cloudflare Workers, or encountering devtools, type safety, loader, Vite bundling errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-start/.claude-plugin/plugin.json
+++ b/plugins/tanstack-start/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-start",
   "description": "TanStack Start (RC) full-stack React with server functions, SSR, Cloudflare Workers. Use for Next.js migration, edge rendering, or encountering hydration, auth, data pattern errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-start/skills/tanstack-start/SKILL.md
+++ b/plugins/tanstack-start/skills/tanstack-start/SKILL.md
@@ -18,10 +18,10 @@ metadata:
     - static prerender
     - server functions
     - server routes
-  - cloudflare workers
-  - edge rendering
-  - hydration errors
-  - next.js migration
+    - cloudflare workers
+    - edge rendering
+    - hydration errors
+    - next.js migration
 ---
 
 # TanStack Start (React) — RC-Ready Playbook

--- a/plugins/tanstack-table/.claude-plugin/plugin.json
+++ b/plugins/tanstack-table/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-table",
   "description": "TanStack Table v8 headless data tables with server-side features for Cloudflare Workers + D1. Use for pagination, filtering, sorting, virtualization, or encountering state management, TanStack Query coordination, URL sync errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/technical-specification/.claude-plugin/plugin.json
+++ b/plugins/technical-specification/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "technical-specification",
   "description": "Creates detailed technical specifications for software projects covering requirements, architecture, APIs, and testing strategies. Use when planning features, documenting system design, or creating architecture decision records.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/test-quality-analysis/.claude-plugin/plugin.json
+++ b/plugins/test-quality-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "test-quality-analysis",
   "description": "Detect test smells, overmocking, flaky tests, and coverage issues. Analyze test effectiveness, maintainability, and reliability. Use when reviewing tests or improving test quality.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/thesys-generative-ui/.claude-plugin/plugin.json
+++ b/plugins/thesys-generative-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thesys-generative-ui",
   "description": "AI-powered generative UI with Thesys - create React components from natural language.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/thesys-generative-ui/skills/thesys-generative-ui/SKILL.md
+++ b/plugins/thesys-generative-ui/skills/thesys-generative-ui/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: thesys-generative-ui
-description: >
-  Generate, modify, and style React components from natural language using the
-  Thesys SDK. Guides schema-driven UI generation, theme customisation, tool
-  calling integration, and deployment to Vite, Next.js, or Cloudflare Workers.
-  Use when the user says "generate UI", "create a component", "build an
-  interface", "Thesys", "generative UI", or asks to turn a description into a
-  React component.
+description: >-
+  >
+    Generate, modify, and style React components from natural language using the
+    Thesys SDK. Guides schema-driven UI generation, theme customisation, tool
+    calling integration, and deployment to Vite, Next.js, or Cloudflare Workers.
+    Use when the user says "generate UI", "create a component", "build an
+    interface", "Thesys", "generative UI", or asks to turn a description into a
+    React component.
 license: MIT
 ---
 

--- a/plugins/threejs/.claude-plugin/plugin.json
+++ b/plugins/threejs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "threejs",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Comprehensive Three.js skills for building 3D web experiences",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/turborepo/.claude-plugin/plugin.json
+++ b/plugins/turborepo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "turborepo",
   "description": "Turborepo high-performance monorepo build system. Use for monorepo setup, build optimization, task pipelines, caching strategies, or multi-package orchestration.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/turborepo/skills/turborepo/SKILL.md
+++ b/plugins/turborepo/skills/turborepo/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: turborepo
-description: |
-  Turborepo monorepo build system guidance. Triggers on: turbo.json, task pipelines,
-  dependsOn, caching, remote cache, the "turbo" CLI, --filter, --affected, CI optimization, environment
-  variables, internal packages, monorepo structure/best practices, and boundaries.
+description: >-
+  |
+    Turborepo monorepo build system guidance. Triggers on: turbo.json, task pipelines,
+    dependsOn, caching, remote cache, the "turbo" CLI, --filter, --affected, CI optimization, environment
+    variables, internal packages, monorepo structure/best practices, and boundaries.
 
-  Use when user: configures tasks/workflows/pipelines, creates packages, sets up
-  monorepo, shares code between apps, runs changed/affected packages, debugs cache,
-  or has apps/packages directories.
+    Use when user: configures tasks/workflows/pipelines, creates packages, sets up
+    monorepo, shares code between apps, runs changed/affected packages, debugs cache,
+    or has apps/packages directories.
 metadata:
   version: 2.8.3-canary.4
 license: MIT

--- a/plugins/typescript-mcp/.claude-plugin/plugin.json
+++ b/plugins/typescript-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-mcp",
   "description": "MCP servers with TypeScript on Cloudflare Workers using @modelcontextprotocol/sdk. Use for API integrations, stateless tools, edge deployments, or encountering export syntax, schema validation, memory leak, CORS, auth errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/typescript-mcp/skills/typescript-mcp/SKILL.md
+++ b/plugins/typescript-mcp/skills/typescript-mcp/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: typescript-mcp
-description: >-
-  MCP servers with TypeScript on Cloudflare Workers using @modelcontextprotocol/sdk. Use for API integrations, stateless tools, edge deployments, or encountering export syntax, schema validation, memory leak, CORS, auth errors.
-
-    Keywords: mcp, model context protocol, typescript mcp, cloudflare workers mcp, mcp server, mcp tools, mcp resources, mcp sdk, @modelcontextprotocol/sdk, hono mcp, streamablehttpservertransport, mcp authentication, mcp cloudflare, edge mcp server, serverless mcp, typescript mcp server, mcp api, llm tools, ai tools, cloudflare d1 mcp, cloudflare kv mcp, mcp testing, mcp deployment, wrangler mcp, export syntax error, schema validation error, memory leak mcp, cors mcp, rate limiting mcp
+description: "MCP servers with TypeScript on Cloudflare Workers using @modelcontextprotocol/sdk. Use for API integrations, stateless tools, edge deployments, or encountering export syntax, schema validation, memory leak, CORS, auth errors."
 license: MIT
 metadata:
   version: 2.0.0
@@ -14,9 +11,38 @@ metadata:
   platform: cloudflare-workers
   production_tested: true
   errors_prevented: 13
+  keywords:
+    - mcp
+    - model context protocol
+    - typescript mcp
+    - cloudflare workers mcp
+    - mcp server
+    - mcp tools
+    - mcp resources
+    - mcp sdk
+    - "@modelcontextprotocol/sdk"
+    - hono mcp
+    - streamablehttpservertransport
+    - mcp authentication
+    - mcp cloudflare
+    - edge mcp server
+    - serverless mcp
+    - typescript mcp server
+    - mcp api
+    - llm tools
+    - ai tools
+    - cloudflare d1 mcp
+    - cloudflare kv mcp
+    - mcp testing
+    - mcp deployment
+    - wrangler mcp
+    - export syntax error
+    - schema validation error
+    - memory leak mcp
+    - cors mcp
+    - rate limiting mcp
 allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
 ---
-
 # TypeScript MCP Server on Cloudflare Workers
 
 Build production-ready Model Context Protocol (MCP) servers using TypeScript and deploy them on Cloudflare Workers. This skill covers the official `@modelcontextprotocol/sdk`, HTTP transport setup, authentication patterns, Cloudflare service integrations, and comprehensive error prevention.

--- a/plugins/typescript-mcp/skills/typescript-mcp/SKILL.md
+++ b/plugins/typescript-mcp/skills/typescript-mcp/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: typescript-mcp
-description: MCP servers with TypeScript on Cloudflare Workers using @modelcontextprotocol/sdk. Use for API integrations, stateless tools, edge deployments, or encountering export syntax, schema validation, memory leak, CORS, auth errors.
+description: >-
+  MCP servers with TypeScript on Cloudflare Workers using @modelcontextprotocol/sdk. Use for API integrations, stateless tools, edge deployments, or encountering export syntax, schema validation, memory leak, CORS, auth errors.
 
-  Keywords: mcp, model context protocol, typescript mcp, cloudflare workers mcp, mcp server, mcp tools, mcp resources, mcp sdk, @modelcontextprotocol/sdk, hono mcp, streamablehttpservertransport, mcp authentication, mcp cloudflare, edge mcp server, serverless mcp, typescript mcp server, mcp api, llm tools, ai tools, cloudflare d1 mcp, cloudflare kv mcp, mcp testing, mcp deployment, wrangler mcp, export syntax error, schema validation error, memory leak mcp, cors mcp, rate limiting mcp
+    Keywords: mcp, model context protocol, typescript mcp, cloudflare workers mcp, mcp server, mcp tools, mcp resources, mcp sdk, @modelcontextprotocol/sdk, hono mcp, streamablehttpservertransport, mcp authentication, mcp cloudflare, edge mcp server, serverless mcp, typescript mcp server, mcp api, llm tools, ai tools, cloudflare d1 mcp, cloudflare kv mcp, mcp testing, mcp deployment, wrangler mcp, export syntax error, schema validation error, memory leak mcp, cors mcp, rate limiting mcp
 license: MIT
 metadata:
   version: 2.0.0

--- a/plugins/ultracite/.claude-plugin/plugin.json
+++ b/plugins/ultracite/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultracite",
   "description": "Ultracite multi-provider linting/formatting (Biome, ESLint, Oxlint). Use for v6/v7 setup, provider selection, Git hooks, MCP integration, AI hooks, migrations, or encountering configuration, type-aware linting, monorepo errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/vercel-blob/.claude-plugin/plugin.json
+++ b/plugins/vercel-blob/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vercel-blob",
   "description": "Vercel Blob object storage with CDN for Next.js. Use for file uploads (images, PDFs, videos), presigned URLs, user-generated content, file management, or encountering BLOB_READ_WRITE_TOKEN errors, file size limits, client upload token errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/vercel-blob/skills/vercel-blob/SKILL.md
+++ b/plugins/vercel-blob/skills/vercel-blob/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: vercel-blob
-description: Vercel Blob object storage with CDN for Next.js. Use for file uploads (images, PDFs, videos), presigned URLs, user-generated content, file management, or encountering BLOB_READ_WRITE_TOKEN errors, file size limits, client upload token errors.
+description: >-
+  Vercel Blob object storage with CDN for Next.js. Use for file uploads (images, PDFs, videos), presigned URLs, user-generated content, file management, or encountering BLOB_READ_WRITE_TOKEN errors, file size limits, client upload token errors.
 
-  Keywords: vercel blob, @vercel/blob, vercel storage, vercel file upload, vercel cdn, blob storage vercel, client upload vercel, presigned url vercel, file upload nextjs, image upload vercel, pdf upload, video upload, user uploads, multipart upload, streaming upload, blob cdn, vercel assets, file download
+    Keywords: vercel blob, @vercel/blob, vercel storage, vercel file upload, vercel cdn, blob storage vercel, client upload vercel, presigned url vercel, file upload nextjs, image upload vercel, pdf upload, video upload, user uploads, multipart upload, streaming upload, blob cdn, vercel assets, file download
 license: MIT
 ---
 

--- a/plugins/vercel-blob/skills/vercel-blob/SKILL.md
+++ b/plugins/vercel-blob/skills/vercel-blob/SKILL.md
@@ -1,12 +1,30 @@
 ---
 name: vercel-blob
-description: >-
-  Vercel Blob object storage with CDN for Next.js. Use for file uploads (images, PDFs, videos), presigned URLs, user-generated content, file management, or encountering BLOB_READ_WRITE_TOKEN errors, file size limits, client upload token errors.
+description: "Vercel Blob object storage with CDN for Next.js. Use for file uploads (images, PDFs, videos), presigned URLs, user-generated content, file management, or encountering BLOB_READ_WRITE_TOKEN errors, file size limits, client upload token errors."
 
-    Keywords: vercel blob, @vercel/blob, vercel storage, vercel file upload, vercel cdn, blob storage vercel, client upload vercel, presigned url vercel, file upload nextjs, image upload vercel, pdf upload, video upload, user uploads, multipart upload, streaming upload, blob cdn, vercel assets, file download
+metadata:
+  keywords:
+    - vercel blob
+    - "@vercel/blob"
+    - vercel storage
+    - vercel file upload
+    - vercel cdn
+    - blob storage vercel
+    - client upload vercel
+    - presigned url vercel
+    - file upload nextjs
+    - image upload vercel
+    - pdf upload
+    - video upload
+    - user uploads
+    - multipart upload
+    - streaming upload
+    - blob cdn
+    - vercel assets
+    - file download
+
 license: MIT
 ---
-
 # Vercel Blob (Object Storage)
 
 **Status**: Production Ready

--- a/plugins/vercel-kv/.claude-plugin/plugin.json
+++ b/plugins/vercel-kv/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vercel-kv",
   "description": "Vercel KV (Redis-compatible key-value storage via Upstash). Use for Next.js caching, sessions, rate limiting, TTL data storage, or encountering KV_REST_API_URL errors, rate limit issues, JSON serialization errors. Provides strong consistency vs eventual consistency.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/vercel-kv/skills/vercel-kv/SKILL.md
+++ b/plugins/vercel-kv/skills/vercel-kv/SKILL.md
@@ -1,12 +1,32 @@
 ---
 name: vercel-kv
-description: >-
-  Vercel KV (Redis-compatible key-value storage via Upstash). Use for Next.js caching, sessions, rate limiting, TTL data storage, or encountering KV_REST_API_URL errors, rate limit issues, JSON serialization errors. Provides strong consistency vs eventual consistency.
+description: "Vercel KV (Redis-compatible key-value storage via Upstash). Use for Next.js caching, sessions, rate limiting, TTL data storage, or encountering KV_REST_API_URL errors, rate limit issues, JSON serialization errors. Provides strong consistency vs eventual consistency."
 
-    Keywords: vercel kv, @vercel/kv, vercel redis, upstash vercel, kv vercel, redis vercel edge, key-value vercel, vercel cache, vercel sessions, vercel rate limit, redis upstash, kv storage, edge kv, serverless redis, vercel ttl, vercel expire, kv typescript, next.js kv, server actions kv, edge runtime kv
+metadata:
+  keywords:
+    - vercel kv
+    - "@vercel/kv"
+    - vercel redis
+    - upstash vercel
+    - kv vercel
+    - redis vercel edge
+    - key-value vercel
+    - vercel cache
+    - vercel sessions
+    - vercel rate limit
+    - redis upstash
+    - kv storage
+    - edge kv
+    - serverless redis
+    - vercel ttl
+    - vercel expire
+    - kv typescript
+    - next.js kv
+    - server actions kv
+    - edge runtime kv
+
 license: MIT
 ---
-
 # Vercel KV (Redis-Compatible Storage)
 
 **Status**: Production Ready

--- a/plugins/vercel-kv/skills/vercel-kv/SKILL.md
+++ b/plugins/vercel-kv/skills/vercel-kv/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: vercel-kv
-description: Vercel KV (Redis-compatible key-value storage via Upstash). Use for Next.js caching, sessions, rate limiting, TTL data storage, or encountering KV_REST_API_URL errors, rate limit issues, JSON serialization errors. Provides strong consistency vs eventual consistency.
+description: >-
+  Vercel KV (Redis-compatible key-value storage via Upstash). Use for Next.js caching, sessions, rate limiting, TTL data storage, or encountering KV_REST_API_URL errors, rate limit issues, JSON serialization errors. Provides strong consistency vs eventual consistency.
 
-  Keywords: vercel kv, @vercel/kv, vercel redis, upstash vercel, kv vercel, redis vercel edge, key-value vercel, vercel cache, vercel sessions, vercel rate limit, redis upstash, kv storage, edge kv, serverless redis, vercel ttl, vercel expire, kv typescript, next.js kv, server actions kv, edge runtime kv
+    Keywords: vercel kv, @vercel/kv, vercel redis, upstash vercel, kv vercel, redis vercel edge, key-value vercel, vercel cache, vercel sessions, vercel rate limit, redis upstash, kv storage, edge kv, serverless redis, vercel ttl, vercel expire, kv typescript, next.js kv, server actions kv, edge runtime kv
 license: MIT
 ---
 

--- a/plugins/verification-before-completion/.claude-plugin/plugin.json
+++ b/plugins/verification-before-completion/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "verification-before-completion",
   "description": "Run verification commands and confirm output before claiming success. Use when about to claim work is complete, fixed, or passing, before committing or creating PRs.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/vitest-testing/.claude-plugin/plugin.json
+++ b/plugins/vitest-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vitest-testing",
   "description": "Modern TypeScript/JavaScript testing with Vitest. Fast unit and integration tests, native ESM support, Vite-powered HMR, and comprehensive mocking. Use for testing TS/JS projects.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/vulnerability-scanning/.claude-plugin/plugin.json
+++ b/plugins/vulnerability-scanning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vulnerability-scanning",
   "description": "Implements automated security scanning for dependencies, code, and containers using tools like Trivy, Snyk, and npm audit. Use when setting up CI/CD security gates, conducting pre-deployment audits, or meeting compliance requirements.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/web-performance-audit/.claude-plugin/plugin.json
+++ b/plugins/web-performance-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "web-performance-audit",
   "description": "Web performance audits with Core Web Vitals, bottleneck identification, optimization recommendations. Use for page load times, performance reviews, UX optimization, or encountering LCP, FID, CLS issues, resource blocking, render delays.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/web-performance-optimization/.claude-plugin/plugin.json
+++ b/plugins/web-performance-optimization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "web-performance-optimization",
   "description": "Optimizes web application performance through code splitting, lazy loading, caching strategies, and Core Web Vitals monitoring. Use when improving page load times, implementing service workers, or reducing bundle sizes.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/websocket-implementation/.claude-plugin/plugin.json
+++ b/plugins/websocket-implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "websocket-implementation",
   "description": "Implements real-time WebSocket communication with connection management, room-based messaging, and horizontal scaling. Use when building chat systems, live notifications, collaborative tools, or real-time dashboards.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-backend-dev/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-backend-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-backend-dev",
   "description": "Add or modify WooCommerce backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code in WooCommerce projects.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-code-review/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-code-review",
   "description": "Review WooCommerce code changes for coding standards compliance. Use when reviewing code locally, performing automated PR reviews, or checking code quality in WooCommerce projects.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-copy-guidelines/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-copy-guidelines/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-copy-guidelines",
   "description": "Guidelines for UI text and copy in WooCommerce. Use when writing user-facing text, labels, buttons, messages, or documentation in WooCommerce projects.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-dev-cycle/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-dev-cycle/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-dev-cycle",
   "description": "Run tests, linting, and quality checks for WooCommerce development. Use when running tests, fixing code style, or following the development workflow in WooCommerce projects.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/wordpress-plugin-core/.claude-plugin/plugin.json
+++ b/plugins/wordpress-plugin-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wordpress-plugin-core",
   "description": "WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/wordpress-plugin-core/skills/wordpress-plugin-core/SKILL.md
+++ b/plugins/wordpress-plugin-core/skills/wordpress-plugin-core/SKILL.md
@@ -1,12 +1,34 @@
 ---
 name: wordpress-plugin-core
-description: >-
-  WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors.
+description: "WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors."
 
-    Keywords: wordpress plugin development, wordpress security, wordpress hooks, wordpress filters, wordpress database, wpdb prepare, sanitize_text_field, esc_html, wp_nonce, custom post type, register_post_type, settings api, rest api, admin-ajax, wordpress sql injection, wordpress xss, wordpress csrf, plugin header, activation hook, deactivation hook, wordpress coding standards, wordpress plugin architecture
+metadata:
+  keywords:
+    - wordpress plugin development
+    - wordpress security
+    - wordpress hooks
+    - wordpress filters
+    - wordpress database
+    - wpdb prepare
+    - sanitize_text_field
+    - esc_html
+    - wp_nonce
+    - custom post type
+    - register_post_type
+    - settings api
+    - rest api
+    - admin-ajax
+    - wordpress sql injection
+    - wordpress xss
+    - wordpress csrf
+    - plugin header
+    - activation hook
+    - deactivation hook
+    - wordpress coding standards
+    - wordpress plugin architecture
+
 license: MIT
 ---
-
 # WordPress Plugin Development (Core)
 
 **Status**: Production Ready

--- a/plugins/wordpress-plugin-core/skills/wordpress-plugin-core/SKILL.md
+++ b/plugins/wordpress-plugin-core/skills/wordpress-plugin-core/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: wordpress-plugin-core
-description: WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors.
+description: >-
+  WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors.
 
-  Keywords: wordpress plugin development, wordpress security, wordpress hooks, wordpress filters, wordpress database, wpdb prepare, sanitize_text_field, esc_html, wp_nonce, custom post type, register_post_type, settings api, rest api, admin-ajax, wordpress sql injection, wordpress xss, wordpress csrf, plugin header, activation hook, deactivation hook, wordpress coding standards, wordpress plugin architecture
+    Keywords: wordpress plugin development, wordpress security, wordpress hooks, wordpress filters, wordpress database, wpdb prepare, sanitize_text_field, esc_html, wp_nonce, custom post type, register_post_type, settings api, rest api, admin-ajax, wordpress sql injection, wordpress xss, wordpress csrf, plugin header, activation hook, deactivation hook, wordpress coding standards, wordpress plugin architecture
 license: MIT
 ---
 

--- a/plugins/xss-prevention/.claude-plugin/plugin.json
+++ b/plugins/xss-prevention/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xss-prevention",
   "description": "Prevents Cross-Site Scripting attacks through input sanitization, output encoding, and Content Security Policy. Use when handling user-generated content, implementing rich text editors, or securing web applications.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/xss-prevention/skills/xss-prevention/SKILL.md
+++ b/plugins/xss-prevention/skills/xss-prevention/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: xss-prevention
-description: XSS attack prevention with input sanitization, output encoding, Content Security Policy. Use for user-generated content, rich text editors, web application security, or encountering stored XSS, reflected XSS, DOM manipulation, script injection errors.
+description: >-
+  XSS attack prevention with input sanitization, output encoding, Content Security Policy. Use for user-generated content, rich text editors, web application security, or encountering stored XSS, reflected XSS, DOM manipulation, script injection errors.
 
-  Keywords: sanitization, HTML-encoding, DOMPurify, CSP, Content-Security-Policy, rich-text-editor, user-input, escaping, innerHTML, DOM-manipulation, stored-XSS, reflected-XSS, input-validation, output-encoding, trusted-types, XSS-attacks, web-security, user-generated-content, secure-coding, script-injection, DOM-based-XSS
+    Keywords: sanitization, HTML-encoding, DOMPurify, CSP, Content-Security-Policy, rich-text-editor, user-input, escaping, innerHTML, DOM-manipulation, stored-XSS, reflected-XSS, input-validation, output-encoding, trusted-types, XSS-attacks, web-security, user-generated-content, secure-coding, script-injection, DOM-based-XSS
 license: MIT
 ---
 

--- a/plugins/xss-prevention/skills/xss-prevention/SKILL.md
+++ b/plugins/xss-prevention/skills/xss-prevention/SKILL.md
@@ -1,12 +1,33 @@
 ---
 name: xss-prevention
-description: >-
-  XSS attack prevention with input sanitization, output encoding, Content Security Policy. Use for user-generated content, rich text editors, web application security, or encountering stored XSS, reflected XSS, DOM manipulation, script injection errors.
+description: "XSS attack prevention with input sanitization, output encoding, Content Security Policy. Use for user-generated content, rich text editors, web application security, or encountering stored XSS, reflected XSS, DOM manipulation, script injection errors."
 
-    Keywords: sanitization, HTML-encoding, DOMPurify, CSP, Content-Security-Policy, rich-text-editor, user-input, escaping, innerHTML, DOM-manipulation, stored-XSS, reflected-XSS, input-validation, output-encoding, trusted-types, XSS-attacks, web-security, user-generated-content, secure-coding, script-injection, DOM-based-XSS
+metadata:
+  keywords:
+    - sanitization
+    - HTML-encoding
+    - DOMPurify
+    - CSP
+    - Content-Security-Policy
+    - rich-text-editor
+    - user-input
+    - escaping
+    - innerHTML
+    - DOM-manipulation
+    - stored-XSS
+    - reflected-XSS
+    - input-validation
+    - output-encoding
+    - trusted-types
+    - XSS-attacks
+    - web-security
+    - user-generated-content
+    - secure-coding
+    - script-injection
+    - DOM-based-XSS
+
 license: MIT
 ---
-
 # XSS Prevention
 
 ## Overview

--- a/plugins/zod/.claude-plugin/plugin.json
+++ b/plugins/zod/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zod",
   "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies (2kb gzipped).",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/zustand-state-management/.claude-plugin/plugin.json
+++ b/plugins/zustand-state-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zustand-state-management",
   "description": "Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loops.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/zustand-state-management/skills/zustand-state-management/SKILL.md
+++ b/plugins/zustand-state-management/skills/zustand-state-management/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: zustand-state-management
-description: Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loops.
+description: >-
+  Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loops.
 
-  Keywords: zustand, state management, React state, TypeScript state, persist middleware,
-  devtools, slices pattern, global state, React hooks, create store, useBoundStore,
-  StateCreator, hydration error, text content mismatch, infinite render, localStorage,
-  sessionStorage, immer middleware, shallow equality, selector pattern, zustand v5
+    Keywords: zustand, state management, React state, TypeScript state, persist middleware,
+    devtools, slices pattern, global state, React hooks, create store, useBoundStore,
+    StateCreator, hydration error, text content mismatch, infinite render, localStorage,
+    sessionStorage, immer middleware, shallow equality, selector pattern, zustand v5
 license: MIT
 ---
 

--- a/plugins/zustand-state-management/skills/zustand-state-management/SKILL.md
+++ b/plugins/zustand-state-management/skills/zustand-state-management/SKILL.md
@@ -1,15 +1,33 @@
 ---
 name: zustand-state-management
-description: >-
-  Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loops.
+description: "Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loops."
 
-    Keywords: zustand, state management, React state, TypeScript state, persist middleware,
-    devtools, slices pattern, global state, React hooks, create store, useBoundStore,
-    StateCreator, hydration error, text content mismatch, infinite render, localStorage,
-    sessionStorage, immer middleware, shallow equality, selector pattern, zustand v5
+metadata:
+  keywords:
+    - zustand
+    - state management
+    - React state
+    - TypeScript state
+    - persist middleware
+    - devtools
+    - slices pattern
+    - global state
+    - React hooks
+    - create store
+    - useBoundStore
+    - StateCreator
+    - hydration error
+    - text content mismatch
+    - infinite render
+    - localStorage
+    - sessionStorage
+    - immer middleware
+    - shallow equality
+    - selector pattern
+    - zustand v5
+
 license: MIT
 ---
-
 # Zustand State Management
 
 **Status**: Production Ready ✅

--- a/scripts/extract-keywords.rb
+++ b/scripts/extract-keywords.rb
@@ -1,0 +1,175 @@
+#!/usr/bin/env ruby
+#
+# Extract embedded Keywords from description into metadata.keywords YAML list.
+#
+# Usage:
+#   ruby scripts/extract-keywords.rb              # Apply changes
+#   ruby scripts/extract-keywords.rb --dry-run    # Preview only
+
+require 'yaml'
+require 'date'
+
+REPO_ROOT = File.expand_path('..', __dir__)
+PLUGINS_DIR = File.join(REPO_ROOT, 'plugins')
+DRY_RUN = ARGV.include?('--dry-run')
+
+def find_skill_files(dir)
+  results = []
+  Dir.entries(dir).each do |entry|
+    next if entry.start_with?('.')
+    full = File.join(dir, entry)
+    if File.directory?(full)
+      results.concat(find_skill_files(full))
+    elsif entry == 'SKILL.md'
+      results << full
+    end
+  end
+  results.sort
+end
+
+def quote_yaml_value(str)
+  if str.include?(':') || str.include?('"') || str.include?('#') || str.include?("'")
+    '"' + str.gsub('\\', '\\\\\\\\').gsub('"', '\\"') + '"'
+  else
+    '"' + str + '"'
+  end
+end
+
+def quote_keyword(kw)
+  if kw.start_with?('@', '`') || kw.include?(':') || kw.include?('#') || kw.include?('"')
+    '"' + kw.gsub('"', '\\"') + '"'
+  else
+    kw
+  end
+end
+
+def process_file(file_path)
+  content = File.read(file_path)
+
+  unless content.start_with?("---\n")
+    return nil
+  end
+
+  end_match = content.index("\n---\n", 4)
+  return nil unless end_match
+
+  fm_raw = content[4...end_match]
+  fm_end = end_match + 5
+
+  # Match the description: >- block
+  desc_match = fm_raw.match(/^description: >-\n((?:  .*\n|\n)+)/)
+  return nil unless desc_match
+
+  desc_block = desc_match[1]
+
+  # Find Keywords within the description block
+  kw_pos = desc_block.index(/^(?: {2,4})Keywords:/)
+  return nil unless kw_pos
+
+  # Split into prose (before Keywords) and keywords section
+  prose_part = desc_block[0...kw_pos]
+  kw_part = desc_block[kw_pos..]
+
+  # Extract prose text
+  prose = prose_part.lines.map(&:strip).reject(&:empty?).join(' ')
+  return nil if prose.empty?
+
+  # Extract keywords
+  full_kw = kw_part.lines.map { |l| l.strip.sub(/^Keywords:\s*/, '') }.join(' ').gsub(/\s+/, ' ').strip
+  keywords = full_kw.split(',').map(&:strip).reject(&:empty?)
+  return nil if keywords.empty?
+
+  # Quote the description
+  desc_value = quote_yaml_value(prose)
+
+  # Quote keywords that need it
+  quoted_keywords = keywords.map { |k| quote_keyword(k) }
+
+  # Build the replacement frontmatter
+  # Step 1: Replace description block
+  old_desc_block = desc_match[0].rstrip + "\n"
+  new_desc_line = "description: #{desc_value}\n"
+
+  fm_after_desc = fm_raw.sub(old_desc_block, new_desc_line)
+  # Clean up double blank lines
+  fm_after_desc = fm_after_desc.gsub(/\n{3,}/, "\n\n")
+
+  # Step 2: Add keywords to metadata
+  lines = fm_after_desc.lines.map(&:chomp)
+
+  # Build the keyword YAML block
+  kw_yaml = ["  keywords:"] + quoted_keywords.map { |k| "    - #{k}" }
+
+  meta_line_idx = lines.index { |l| l == "metadata:" }
+
+  if meta_line_idx
+    # Find last child of metadata block
+    last_child_idx = meta_line_idx
+    (meta_line_idx + 1...lines.length).each do |j|
+      if lines[j].start_with?('  ') && lines[j].strip != ''
+        last_child_idx = j
+      elsif lines[j].strip == ''
+        # blank line - might be within metadata, keep looking
+        next
+      else
+        break
+      end
+    end
+
+    # Insert after last child, with a blank line between if needed
+    kw_yaml.each_with_index do |line, offset|
+      lines.insert(last_child_idx + 1 + offset, line)
+    end
+  else
+    # No metadata section - create one
+    # Find insertion point (before license or allowed-tools)
+    insert_idx = lines.index { |l| l =~ /^(license:|allowed-tools:)/ }
+    insert_idx ||= lines.length
+
+    meta_block = ["metadata:"] + kw_yaml
+
+    # Insert with blank lines around
+    lines.insert(insert_idx, "")
+    meta_block.each_with_index do |line, offset|
+      lines.insert(insert_idx + 1 + offset, line)
+    end
+    lines.insert(insert_idx + 1 + meta_block.length, "")
+  end
+
+  new_fm = lines.join("\n")
+
+  # Verify valid YAML
+  begin
+    YAML.safe_load(new_fm, permitted_classes: [Date, Time])
+  rescue => e
+    $stderr.puts "  Error: Invalid YAML for #{file_path.sub("#{REPO_ROOT}/", '')}: #{e.message}"
+    return nil
+  end
+
+  new_content = "---\n#{new_fm}\n---#{content[fm_end..]}"
+  { new_content: new_content, keywords: keywords, prose: prose }
+end
+
+files = find_skill_files(PLUGINS_DIR)
+modified = 0
+
+files.each do |file|
+  result = process_file(file)
+  next unless result
+
+  modified += 1
+  rel = file.sub("#{REPO_ROOT}/", '')
+
+  if DRY_RUN
+    puts "[DRY RUN] #{rel}"
+    puts "  Keywords: #{result[:keywords].length}"
+    puts "  Description: #{result[:prose][0..80]}..."
+  else
+    new_c = result[:new_content]
+    File.write(file, new_c)
+    puts "Fixed: #{rel} (#{result[:keywords].length} keywords)"
+  end
+end
+
+puts
+puts "#{DRY_RUN ? '[DRY RUN] ' : ''}Modified: #{modified} file(s)"

--- a/scripts/fix-frontmatter.mjs
+++ b/scripts/fix-frontmatter.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * Fix broken YAML frontmatter in SKILL.md files.
+ *
+ * Pattern A: Multiline description with indented "Keywords:" (the YAML parser
+ *            sees the indented "Keywords:" as a new mapping key, causing failure).
+ *            Fix: use >- folded block scalar for the description value, with
+ *            all content properly indented by 2+ spaces.
+ *            Also handles single-line descriptions containing colons (wrap in quotes).
+ *
+ * Pattern B: Inconsistent list indentation in metadata.keywords (tanstack-start).
+ *            Fix: normalize all list items to use the same indentation.
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const REPO_ROOT = '/Users/eddie/github-repos/claude-skills';
+const PLUGINS_DIR = join(REPO_ROOT, 'plugins');
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function findSkillFiles(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) results.push(...findSkillFiles(full));
+    else if (entry.name === 'SKILL.md') results.push(full);
+  }
+  return results;
+}
+
+/** Return the raw frontmatter string (between the --- delimiters) or null. */
+function extractFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  return match ? { raw: match[1], end: match[0].length } : null;
+}
+
+// ── Pattern A fix ────────────────────────────────────────────────────────────
+
+/**
+ * A YAML key at the top level of the frontmatter starts at column 0 (no indent)
+ * and matches the pattern: `word:` or `word-with-hyphens:`
+ *
+ * A continuation line for a description value is any line that does NOT match
+ * that top-level key pattern.
+ */
+function isTopLevelKey(line) {
+  // Match YAML keys at column 0: "key: value" or "key:" (no value on same line)
+  return /^[a-z][a-z0-9-]*:(\s|$)/.test(line);
+}
+
+function fixDescriptionBlock(lines) {
+  const out = [];
+  let i = 0;
+  let changed = false;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const m = line.match(/^description:\s*(.*)/);
+
+    if (m) {
+      const firstValue = m[1]; // text after "description: "
+
+      // Gather continuation lines: everything that is NOT a top-level key
+      const continuations = [];
+      let j = i + 1;
+      while (j < lines.length) {
+        const next = lines[j];
+        if (isTopLevelKey(next)) {
+          break; // new key → stop
+        }
+        continuations.push(next);
+        j++;
+      }
+
+      if (continuations.length > 0) {
+        // ── multiline description → use >- folded block scalar ──
+        // All content after >- must be indented by ≥2 spaces
+        out.push('description: >-');
+
+        // First value line: indent by 2
+        if (firstValue.trim() !== '') {
+          out.push('  ' + firstValue);
+        }
+
+        for (const cl of continuations) {
+          if (cl.trim() === '') {
+            // Blank line: keep as-is (YAML folds these)
+            out.push('');
+          } else {
+            // Content line: add 2-space indent if not already indented enough
+            // Original lines like "  Keywords: ..." become "    Keywords: ..."
+            if (/^\s{2}/.test(cl)) {
+              out.push('  ' + cl); // add 2 more spaces to existing 2-space indent
+            } else if (/^\s/.test(cl)) {
+              out.push(cl); // already indented enough
+            } else {
+              out.push('  ' + cl); // no indent, add 2 spaces
+            }
+          }
+        }
+        changed = true;
+        i = j;
+        continue;
+      }
+
+      // ── single-line with unquoted colon → wrap in double quotes ──
+      if (firstValue.includes(':') && !/^['"]/.test(firstValue)) {
+        const escaped = firstValue.replace(/"/g, '\\"');
+        out.push(`description: "${escaped}"`);
+        changed = true;
+        i++;
+        continue;
+      }
+    }
+
+    out.push(line);
+    i++;
+  }
+
+  return { lines: out, changed };
+}
+
+// ── Pattern B fix ────────────────────────────────────────────────────────────
+
+/**
+ * Inside a YAML list, if some items are indented differently, normalise every
+ * item in that list to the indentation of the *first* item.
+ */
+function fixListIndentation(lines) {
+  const out = [];
+  let i = 0;
+  let changed = false;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const listMatch = line.match(/^(\s+)-\s/);
+
+    if (listMatch) {
+      const blockIndent = listMatch[1]; // indentation of first item
+      const block = [line];
+      let j = i + 1;
+
+      while (j < lines.length) {
+        const next = lines[j];
+        if (next.trim() === '') {
+          block.push(next);
+          j++;
+          continue;
+        }
+        if (next.match(/^\s+-\s/)) {
+          block.push(next);
+          j++;
+          continue;
+        }
+        break;
+      }
+
+      // Normalise every list item to blockIndent
+      const normalised = block.map(l => {
+        if (l.trim() === '') return l;
+        const itemMatch = l.match(/^(\s+)(-\s.*)$/);
+        if (!itemMatch) return l;
+        if (itemMatch[1] !== blockIndent) {
+          changed = true;
+          return blockIndent + itemMatch[2];
+        }
+        return l;
+      });
+
+      out.push(...normalised);
+      i = j;
+      continue;
+    }
+
+    out.push(line);
+    i++;
+  }
+
+  return { lines: out, changed };
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+const files = findSkillFiles(PLUGINS_DIR);
+let fixedCount = 0;
+const fixedNames = [];
+
+for (const file of files) {
+  const content = readFileSync(file, 'utf8');
+  const fm = extractFrontmatter(content);
+  if (!fm) continue;
+
+  const fmLines = fm.raw.split('\n');
+
+  // Apply both fixes in sequence
+  const step1 = fixDescriptionBlock(fmLines);
+  const step2 = fixListIndentation(step1.lines);
+
+  if (step1.changed || step2.changed) {
+    const newContent = '---\n' + step2.lines.join('\n') + '\n---' + content.slice(fm.end);
+    writeFileSync(file, newContent, 'utf8');
+    fixedCount++;
+    fixedNames.push(relative(REPO_ROOT, file));
+  }
+}
+
+console.log(`Fixed ${fixedCount} file(s):`);
+for (const name of fixedNames) console.log(`  ${name}`);

--- a/scripts/generate-marketplace.sh
+++ b/scripts/generate-marketplace.sh
@@ -70,7 +70,7 @@ cat > "$MARKETPLACE_JSON" << 'EOF_HEADER'
   },
   "metadata": {
     "description": "Production-tested skills for Claude Code - Cloudflare, AI, React, Tailwind v4, and modern web development",
-    "version": "3.0.0",
+    "version": "3.3.0",
     "homepage": "https://github.com/secondsky/claude-skills"
   },
   "plugins": [

--- a/scripts/validate-frontmatter.sh
+++ b/scripts/validate-frontmatter.sh
@@ -7,6 +7,7 @@
 #   https://github.com/agentskills/agentskills/tree/main/skills-ref
 #
 # Checks:
+#   - YAML parseability (uses Ruby's YAML parser to catch syntax errors)
 #   - Frontmatter delimiters (--- ... ---)
 #   - Required fields: name, description
 #   - name: lowercase, <= 64 chars, no leading/trailing/consecutive hyphens, [a-z0-9-] only
@@ -81,6 +82,21 @@ validate_skill() {
 
   local errors=""
   local warnings=""
+
+  # --- YAML parseability check (catches malformed YAML that grep/awk would miss) ---
+  local yaml_error=""
+  yaml_error=$(ruby -r yaml -r date -e "
+    content = ARGF.read
+    fm_match = content.match(/^---\n(.*?)\n---/m)
+    if fm_match
+      YAML.safe_load(fm_match[1], [Date, Time])
+    else
+      exit 1
+    end
+  " < "$skill_file" 2>&1) || {
+    errors="${errors}  YAML frontmatter failed to parse: ${yaml_error}\n"
+    errors="${errors}  At runtime this skill loads with empty metadata (all frontmatter fields silently dropped).\n"
+  }
 
   # --- Required fields ---
   if ! echo "$frontmatter" | grep -q "^name:"; then

--- a/scripts/validate-frontmatter.sh
+++ b/scripts/validate-frontmatter.sh
@@ -89,7 +89,7 @@ validate_skill() {
     content = ARGF.read
     fm_match = content.match(/^---\n(.*?)\n---/m)
     if fm_match
-      YAML.safe_load(fm_match[1], [Date, Time])
+      YAML.safe_load(fm_match[1], permitted_classes: [Date, Time])
     else
       exit 1
     end


### PR DESCRIPTION
## Summary

- Extract embedded `Keywords:` lists from `description: >-` folded block scalars into proper `metadata.keywords` YAML lists across 67 SKILL.md files
- Add `scripts/extract-keywords.rb` for reproducible keyword extraction (supports `--dry-run`)
- Add CI guardrail in `validate-frontmatter.yml` to prevent Keywords from appearing in description fields on PRs

Relates to #60 / #61 — this repo already fixed the YAML parse errors in commit `852a9f78`, but the structural issue of keywords crammed into description values remained.

## What changed

**67 SKILL.md files:** Moved keyword lists from inside `description: >-` blocks into `metadata.keywords` YAML lists. Descriptions now contain only the concise "Use when..." prose.

**Before:**
```yaml
description: >-
  Short use-when prose.

    Keywords: kw1, kw2, kw3, ...
```

**After:**
```yaml
description: "Short use-when prose."
metadata:
  keywords:
    - kw1
    - kw2
    - kw3
```

**New files:**
- `scripts/extract-keywords.rb` — keyword extraction script with `--dry-run` support

**CI update:**
- Added "Check no Keywords in description" step to `.github/workflows/validate-frontmatter.yml` (runs on PRs only)

## Verification

- `./scripts/validate-frontmatter.sh` — 211/211 pass, 0 failures
- 91 files now have `metadata.keywords` (67 newly extracted + 24 pre-existing)
- 0 files have Keywords in description fields
- Pre-push hook validated all changed skills

## Test plan

- [x] `./scripts/validate-frontmatter.sh` passes (211/211)
- [x] `ruby scripts/extract-keywords.rb --dry-run` reports 0 remaining (already applied)
- [x] CI guardrail will catch any new PRs that embed Keywords in description
- [x] Spot-checked `nextjs`, `cloudflare-d1`, `elevenlabs-agents`, `tanstack-query`, `cloudflare-zero-trust-access`