### PR TITLE
feat: add supply chain security (Socket CLI) and Secure Installation to 31 skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
     {
       "name": "access-control-rbac",
       "source": "./plugins/access-control-rbac",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Role-based access control (RBAC) with permissions and policies. Use for admin dashboards, enterprise access, multi-tenant apps, fine-grained authorization, or encountering permission hierarchies, role inheritance, policy conflicts.",
       "keywords": ["access-control-rbac","access","control","rbac","security","vulnerability","protection","authorization"],
       "category": "security"
@@ -23,7 +23,7 @@
     {
       "name": "aceternity-ui",
       "source": "./plugins/aceternity-ui",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "100+ animated React components (Aceternity UI) for Next.js with Tailwind. Use for hero sections, parallax, 3D effects, or encountering animation, shadcn CLI integration errors.",
       "keywords": ["aceternity-ui","aceternity","frontend","components","cli"],
       "category": "frontend"
@@ -32,7 +32,7 @@
     {
       "name": "ai-elements-chatbot",
       "source": "./plugins/ai-elements-chatbot",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "shadcn/ui AI chat components for conversational interfaces. Use for streaming chat, tool/function displays, reasoning visualization, or encountering Next.js App Router setup, Tailwind v4 integration, AI SDK v5 migration errors.",
       "keywords": ["ai-elements-chatbot","elements","chatbot","machine-learning","llm","artificial-intelligence","migration"],
       "category": "ai"
@@ -41,7 +41,7 @@
     {
       "name": "ai-sdk-core",
       "source": "./plugins/ai-sdk-core",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Vercel AI SDK v5 for backend AI (text generation, structured output, tools, agents). Multi-provider. Use for server-side AI or encountering AI_APICallError, AI_NoObjectGeneratedError, streaming failures.",
       "keywords": ["ai-sdk-core","sdk","core","machine-learning","llm","artificial-intelligence"],
       "category": "ai"
@@ -50,7 +50,7 @@
     {
       "name": "ai-sdk-ui",
       "source": "./plugins/ai-sdk-ui",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Vercel AI SDK v5 React hooks (useChat, useCompletion, useObject) for AI chat interfaces. Use for React/Next.js AI apps or encountering parse stream errors, no response, streaming issues.",
       "keywords": ["ai-sdk-ui","sdk","machine-learning","llm","artificial-intelligence"],
       "category": "ai"
@@ -59,7 +59,7 @@
     {
       "name": "api-authentication",
       "source": "./plugins/api-authentication",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Secure API authentication with JWT, OAuth 2.0, API keys. Use for authentication systems, third-party integrations, service-to-service communication, or encountering token management, security headers, auth flow errors.",
       "keywords": ["api-authentication","api","authentication","authorization","login","security","session","jwt"],
       "category": "auth"
@@ -68,7 +68,7 @@
     {
       "name": "api-changelog-versioning",
       "source": "./plugins/api-changelog-versioning",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Creates comprehensive API changelogs documenting breaking changes, deprecations, and migration strategies for API consumers. Use when managing API versions, communicating breaking changes, or creating upgrade guides.",
       "keywords": ["api-changelog-versioning","api","changelog","versioning","rest","graphql","endpoints","http","migration"],
       "category": "api"
@@ -77,7 +77,7 @@
     {
       "name": "api-contract-testing",
       "source": "./plugins/api-contract-testing",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Verifies API contracts between services using consumer-driven contracts, schema validation, and tools like Pact. Use when testing microservices communication, preventing breaking changes, or validating OpenAPI specifications.",
       "keywords": ["api-contract-testing","api","contract","testing","rest","graphql","endpoints","http","openapi","validation"],
       "category": "api"
@@ -86,7 +86,7 @@
     {
       "name": "api-design-principles",
       "source": "./plugins/api-design-principles",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewing API specifications, or establishing API design standards.",
       "keywords": ["api-design-principles","api","design","principles","rest","graphql","endpoints","http","scalable","maintainable"],
       "category": "api"
@@ -95,7 +95,7 @@
     {
       "name": "api-error-handling",
       "source": "./plugins/api-error-handling",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Implements standardized API error responses with proper status codes, logging, and user-friendly messages. Use when building production APIs, implementing error recovery patterns, or integrating error monitoring services.",
       "keywords": ["api-error-handling","api","error","handling","rest","graphql","endpoints","http"],
       "category": "api"
@@ -104,7 +104,7 @@
     {
       "name": "api-filtering-sorting",
       "source": "./plugins/api-filtering-sorting",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Builds flexible API filtering and sorting systems with query parameter parsing, validation, and security. Use when implementing search endpoints, building data grids, or creating dynamic query APIs.",
       "keywords": ["api-filtering-sorting","api","filtering","sorting","rest","graphql","endpoints","http","validation"],
       "category": "api"
@@ -113,7 +113,7 @@
     {
       "name": "api-gateway-configuration",
       "source": "./plugins/api-gateway-configuration",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Configures API gateways for routing, authentication, rate limiting, and request transformation in microservice architectures. Use when setting up Kong, Nginx, AWS API Gateway, or Traefik for centralized API management.",
       "keywords": ["api-gateway-configuration","api","gateway","configuration","rest","graphql","endpoints","http","aws","authentication"],
       "category": "api"
@@ -122,7 +122,7 @@
     {
       "name": "api-pagination",
       "source": "./plugins/api-pagination",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Implements efficient API pagination using offset, cursor, and keyset strategies for large datasets. Use when building paginated endpoints, implementing infinite scroll, or optimizing database queries for collections.",
       "keywords": ["api-pagination","api","pagination","rest","graphql","endpoints","http"],
       "category": "api"
@@ -131,7 +131,7 @@
     {
       "name": "api-rate-limiting",
       "source": "./plugins/api-rate-limiting",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Implements API rate limiting using token bucket, sliding window, and Redis-based algorithms to protect against abuse. Use when securing public APIs, implementing tiered access, or preventing denial-of-service attacks.",
       "keywords": ["api-rate-limiting","api","rate","limiting","rest","graphql","endpoints","http"],
       "category": "api"
@@ -140,7 +140,7 @@
     {
       "name": "api-reference-documentation",
       "source": "./plugins/api-reference-documentation",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Creates professional API documentation using OpenAPI specifications with endpoints, authentication, and interactive examples. Use when documenting REST APIs, creating SDK references, or building developer portals.",
       "keywords": ["api-reference-documentation","api","reference","documentation","rest","graphql","endpoints","http","openapi","authentication"],
       "category": "api"
@@ -149,7 +149,7 @@
     {
       "name": "api-response-optimization",
       "source": "./plugins/api-response-optimization",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Optimizes API performance through payload reduction, caching strategies, and compression techniques. Use when improving API response times, reducing bandwidth usage, or implementing efficient caching.",
       "keywords": ["api-response-optimization","api","response","optimization","rest","graphql","endpoints","http","caching"],
       "category": "api"
@@ -158,7 +158,7 @@
     {
       "name": "api-security-hardening",
       "source": "./plugins/api-security-hardening",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "REST API security hardening with authentication, rate limiting, input validation, security headers. Use for production APIs, security audits, defense-in-depth, or encountering vulnerabilities, injection attacks, CORS issues.",
       "keywords": ["api-security-hardening","api","security","hardening","rest","graphql","endpoints","http","cors","authentication","validation"],
       "category": "api"
@@ -167,7 +167,7 @@
     {
       "name": "api-testing",
       "source": "./plugins/api-testing",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "HTTP API testing for TypeScript (Supertest) and Python (httpx, pytest). Test REST APIs, GraphQL, request/response validation, authentication, and error handling.",
       "keywords": ["api-testing","api","testing","rest","graphql","endpoints","http","authentication","validation"],
       "category": "api"
@@ -176,7 +176,7 @@
     {
       "name": "api-versioning-strategy",
       "source": "./plugins/api-versioning-strategy",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Implements API versioning using URL paths, headers, or query parameters with backward compatibility and deprecation strategies. Use when managing multiple API versions, planning breaking changes, or designing migration paths.",
       "keywords": ["api-versioning-strategy","api","versioning","strategy","rest","graphql","endpoints","http","url","migration"],
       "category": "api"
@@ -185,7 +185,7 @@
     {
       "name": "app-store-deployment",
       "source": "./plugins/app-store-deployment",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Publishes mobile applications to iOS App Store and Google Play with code signing, versioning, and CI/CD automation. Use when preparing app releases, configuring signing certificates, or setting up automated deployment pipelines.",
       "keywords": ["app-store-deployment","app","store","mobile","native"],
       "category": "mobile"
@@ -194,7 +194,7 @@
     {
       "name": "architecture-patterns",
       "source": "./plugins/architecture-patterns",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Implement proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design. Use when architecting complex backend systems or refactoring existing applications for better maintainability.",
       "keywords": ["architecture-patterns","architecture","patterns","microservices","refactoring"],
       "category": "architecture"
@@ -203,7 +203,7 @@
     {
       "name": "auto-animate",
       "source": "./plugins/auto-animate",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity.",
       "keywords": ["auto-animate","auto","animate","frontend","components","ssr","autoanimate"],
       "category": "frontend"
@@ -212,7 +212,7 @@
     {
       "name": "base-ui-react",
       "source": "./plugins/base-ui-react",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues.",
       "keywords": ["base-ui-react","base","react","frontend","components","mui","migration"],
       "category": "frontend"
@@ -221,7 +221,7 @@
     {
       "name": "better-auth",
       "source": "./plugins/better-auth",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Skill for integrating Better Auth - comprehensive TypeScript authentication framework for Cloudflare D1, Next.js, Nuxt, and 15+ frameworks. Use when adding auth, encountering D1 adapter errors, or implementing OAuth/2FA/RBAC features.",
       "keywords": ["better-auth","better","auth","authentication","authorization","login","security","session","rbac"],
       "category": "auth"
@@ -230,7 +230,7 @@
     {
       "name": "better-chatbot",
       "source": "./plugins/better-chatbot",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "better-chatbot project conventions and standards. Use for contributing code, following three-tier tool system (MCP/Workflow/Default), or encountering server action validators, repository patterns, component design errors.",
       "keywords": ["better-chatbot","better","chatbot","tooling","workflow","mcp"],
       "category": "tooling"
@@ -239,7 +239,7 @@
     {
       "name": "better-chatbot-patterns",
       "source": "./plugins/better-chatbot-patterns",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Reusable better-chatbot patterns for custom deployments. Use for server action validators, tool abstraction, multi-AI providers, or encountering auth validation, FormData parsing, workflow execution errors.",
       "keywords": ["better-chatbot-patterns","better","chatbot","patterns","tooling","workflow","formdata","validation"],
       "category": "tooling"
@@ -248,7 +248,7 @@
     {
       "name": "bun",
       "source": "./plugins/bun",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Comprehensive Bun runtime toolkit covering runtime, package manager, bundler, testing, HTTP servers, WebSockets, databases, framework integrations (Hono, Next.js, Nuxt, TanStack Start, SvelteKit), deployment, and Node.js compatibility.",
       "keywords": ["bun","tooling","workflow","http","sveltekit","tanstack","websockets"],
       "category": "tooling"
@@ -257,7 +257,7 @@
     {
       "name": "chrome-devtools",
       "source": "./plugins/chrome-devtools",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Browser automation with Puppeteer CLI scripts. Use for screenshots, performance analysis, network monitoring, web scraping, form automation, or encountering JavaScript debugging, browser automation errors.",
       "keywords": ["chrome-devtools","chrome","devtools","tooling","workflow","cli"],
       "category": "tooling"
@@ -266,7 +266,7 @@
     {
       "name": "claude-agent-sdk",
       "source": "./plugins/claude-agent-sdk",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Anthropic Claude Agent SDK for autonomous agents and multi-step workflows. Use for subagents, tool orchestration, MCP servers, or encountering CLI not found, context length exceeded errors.",
       "keywords": ["claude-agent-sdk","claude","agent","sdk","machine-learning","llm","artificial-intelligence","cli","mcp"],
       "category": "ai"
@@ -275,7 +275,7 @@
     {
       "name": "claude-api",
       "source": "./plugins/claude-api",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Anthropic Messages API (Claude API) for integrations, streaming, prompt caching, tool use, vision. Use for chatbots, assistants, or encountering rate limits, 429 errors.",
       "keywords": ["claude-api","claude","api","machine-learning","llm","artificial-intelligence","caching"],
       "category": "ai"
@@ -284,7 +284,7 @@
     {
       "name": "claude-code-bash-patterns",
       "source": "./plugins/claude-code-bash-patterns",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Claude Code Bash tool patterns with hooks, automation, git workflows. Use for PreToolUse hooks, command chaining, CLI orchestration, custom commands, or encountering bash permissions, command failures, security guards, hook configurations.",
       "keywords": ["claude-code-bash-patterns","claude","code","bash","patterns","tooling","workflow","cli","pretooluse"],
       "category": "tooling"
@@ -293,7 +293,7 @@
     {
       "name": "claude-hook-writer",
       "source": "./plugins/claude-hook-writer",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Expert guidance for writing secure, reliable, and performant Claude Code hooks - validates design decisions, enforces best practices, and prevents common pitfalls. Use when creating, reviewing, or debugging Claude Code hooks.",
       "keywords": ["claude-hook-writer","claude","hook","writer","tooling","workflow"],
       "category": "tooling"
@@ -302,7 +302,7 @@
     {
       "name": "cloudflare-agents",
       "source": "./plugins/cloudflare-agents",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Build AI agents on Cloudflare Workers with MCP integration, tool use, and LLM providers.",
       "keywords": ["cloudflare-agents","cloudflare","agents","workers","edge","wrangler","llm","mcp"],
       "category": "cloudflare"
@@ -311,7 +311,7 @@
     {
       "name": "cloudflare-browser-rendering",
       "source": "./plugins/cloudflare-browser-rendering",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded.",
       "keywords": ["cloudflare-browser-rendering","cloudflare","browser","rendering","workers","edge","wrangler"],
       "category": "cloudflare"
@@ -320,7 +320,7 @@
     {
       "name": "cloudflare-cron-triggers",
       "source": "./plugins/cloudflare-cron-triggers",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors.",
       "keywords": ["cloudflare-cron-triggers","cloudflare","cron","triggers","workers","edge","wrangler"],
       "category": "cloudflare"
@@ -329,7 +329,7 @@
     {
       "name": "cloudflare-d1",
       "source": "./plugins/cloudflare-d1",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors.",
       "keywords": ["cloudflare-d1","cloudflare","workers","edge","wrangler","migration"],
       "category": "cloudflare"
@@ -338,7 +338,7 @@
     {
       "name": "cloudflare-durable-objects",
       "source": "./plugins/cloudflare-durable-objects",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors.",
       "keywords": ["cloudflare-durable-objects","cloudflare","durable","objects","workers","edge","wrangler","websocket","migration","real-time"],
       "category": "cloudflare"
@@ -347,7 +347,7 @@
     {
       "name": "cloudflare-email-routing",
       "source": "./plugins/cloudflare-email-routing",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues.",
       "keywords": ["cloudflare-email-routing","cloudflare","email","routing","workers","edge","wrangler","spf"],
       "category": "cloudflare"
@@ -356,7 +356,7 @@
     {
       "name": "cloudflare-hyperdrive",
       "source": "./plugins/cloudflare-hyperdrive",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused.",
       "keywords": ["cloudflare-hyperdrive","cloudflare","hyperdrive","workers","edge","wrangler","tls","mysql","postgresql","caching"],
       "category": "cloudflare"
@@ -365,7 +365,7 @@
     {
       "name": "cloudflare-images",
       "source": "./plugins/cloudflare-images",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "This skill should be used when the user asks to \"upload images to Cloudflare\", \"implement direct creator upload\", \"configure image transformations\", \"optimize WebP/AVIF\", \"create image variants\", \"generate signed URLs\", \"add image watermarks\", \"integrate with Next.js/Remix\", \"configure webhooks\", \"debug CORS errors\", \"troubleshoot error 5408/9401-9413\", or \"build responsive images with Cloudflare Images API\".",
       "keywords": ["cloudflare-images","cloudflare","images","workers","edge","wrangler","avif","cors","webp","webhooks"],
       "category": "cloudflare"
@@ -374,7 +374,7 @@
     {
       "name": "cloudflare-kv",
       "source": "./plugins/cloudflare-kv",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues.",
       "keywords": ["cloudflare-kv","cloudflare","workers","edge","wrangler","ttl","caching"],
       "category": "cloudflare"
@@ -383,7 +383,7 @@
     {
       "name": "cloudflare-manager",
       "source": "./plugins/cloudflare-manager",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Comprehensive Cloudflare account management for deploying Workers, KV Storage, R2, Pages, DNS, and Routes. Use when deploying cloudflare services, managing worker containers, configuring KV/R2 storage, or setting up DNS/routing. Requires CLOUDFLARE_API_KEY in .env and Bun runtime with dependencies installed.",
       "keywords": ["cloudflare-manager","cloudflare","manager","workers","edge","wrangler","dns"],
       "category": "cloudflare"
@@ -392,7 +392,7 @@
     {
       "name": "cloudflare-mcp-server",
       "source": "./plugins/cloudflare-mcp-server",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Build MCP (Model Context Protocol) servers on Cloudflare Workers with tools, resources, and prompts.",
       "keywords": ["cloudflare-mcp-server","cloudflare","mcp","server","workers","edge","wrangler"],
       "category": "cloudflare"
@@ -401,7 +401,7 @@
     {
       "name": "cloudflare-nextjs",
       "source": "./plugins/cloudflare-nextjs",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Deploy Next.js to Cloudflare Workers via OpenNext adapter. Use for SSR, ISR, App/Pages Router, or encountering worker size limits, runtime compatibility, connection scoping errors.",
       "keywords": ["cloudflare-nextjs","cloudflare","nextjs","workers","edge","wrangler","isr","ssr","opennext"],
       "category": "cloudflare"
@@ -410,7 +410,7 @@
     {
       "name": "cloudflare-queues",
       "source": "./plugins/cloudflare-queues",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "This skill should be used when the user asks to \"set up Cloudflare Queues\", \"create a message queue\", \"implement queue consumer\", \"process background jobs\", \"configure queue retry logic\", \"publish messages to queue\", \"implement dead letter queue\", or encountering \"queue timeout\", \"message retry\", \"throughput exceeded\", \"queue backlog\" errors.",
       "keywords": ["cloudflare-queues","cloudflare","queues","workers","edge","wrangler"],
       "category": "cloudflare"
@@ -419,7 +419,7 @@
     {
       "name": "cloudflare-r2",
       "source": "./plugins/cloudflare-r2",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Cloudflare R2 S3-compatible object storage with SQL, Iceberg, event notifications, and automation. Use for buckets, uploads, CORS, presigned URLs, large files, S3 migration, analytics, or encountering R2_ERROR, CORS failures, multipart issues.",
       "keywords": ["cloudflare-r2","cloudflare","workers","edge","wrangler","cors","sql","migration"],
       "category": "cloudflare"
@@ -428,7 +428,7 @@
     {
       "name": "cloudflare-sandbox",
       "source": "./plugins/cloudflare-sandbox",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations.",
       "keywords": ["cloudflare-sandbox","cloudflare","sandbox","workers","edge","wrangler"],
       "category": "cloudflare"
@@ -437,7 +437,7 @@
     {
       "name": "cloudflare-turnstile",
       "source": "./plugins/cloudflare-turnstile",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Cloudflare Turnstile CAPTCHA-alternative bot protection. Use for forms, login security, API protection, or encountering CSP errors, token validation failures, error codes 100*/300*/600*.",
       "keywords": ["cloudflare-turnstile","cloudflare","turnstile","workers","edge","wrangler","captcha","csp","validation"],
       "category": "cloudflare"
@@ -446,7 +446,7 @@
     {
       "name": "cloudflare-vectorize",
       "source": "./plugins/cloudflare-vectorize",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors.",
       "keywords": ["cloudflare-vectorize","cloudflare","vectorize","workers","edge","wrangler","rag"],
       "category": "cloudflare"
@@ -455,7 +455,7 @@
     {
       "name": "cloudflare-workers",
       "source": "./plugins/cloudflare-workers",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Comprehensive Cloudflare Workers platform guide covering runtime APIs, testing (Vitest), CI/CD, observability, framework integration, performance, security, and migration. Use for Workers development, deployment, debugging, or optimization.",
       "keywords": ["cloudflare-workers","cloudflare","workers","edge","wrangler","migration"],
       "category": "cloudflare"
@@ -464,7 +464,7 @@
     {
       "name": "cloudflare-workers-ai",
       "source": "./plugins/cloudflare-workers-ai",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors.",
       "keywords": ["cloudflare-workers-ai","cloudflare","workers","edge","wrangler","gpu"],
       "category": "cloudflare"
@@ -473,7 +473,7 @@
     {
       "name": "cloudflare-workflows",
       "source": "./plugins/cloudflare-workflows",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors.",
       "keywords": ["cloudflare-workflows","cloudflare","workflows","workers","edge","wrangler","nonretryableerror"],
       "category": "cloudflare"
@@ -482,7 +482,7 @@
     {
       "name": "cloudflare-zero-trust-access",
       "source": "./plugins/cloudflare-zero-trust-access",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers.",
       "keywords": ["cloudflare-zero-trust-access","cloudflare","zero","trust","access","workers","edge","wrangler","cors","jwt","authentication","validation"],
       "category": "cloudflare"
@@ -491,7 +491,7 @@
     {
       "name": "code-review",
       "source": "./plugins/code-review",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Code review practices with technical rigor and verification gates. Use for receiving feedback, requesting code-reviewer subagent reviews, or preventing false completion claims in pull requests.",
       "keywords": ["code-review","code","review","tooling","workflow"],
       "category": "tooling"
@@ -500,7 +500,7 @@
     {
       "name": "content-collections",
       "source": "./plugins/content-collections",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Content Collections TypeScript-first build tool for Markdown/MDX content. Use for blogs, docs, content sites with Vite + React, MDX components, type-safe Zod schemas, Contentlayer migration, or encountering TypeScript import errors, path alias issues, collection validation errors.",
       "keywords": ["content-collections","content","collections","cms","management","publishing","mdx","validation","migration"],
       "category": "cms"
@@ -509,7 +509,7 @@
     {
       "name": "csrf-protection",
       "source": "./plugins/csrf-protection",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Implements CSRF protection using synchronizer tokens, double-submit cookies, and SameSite attributes. Use when securing web forms, protecting state-changing endpoints, or implementing defense-in-depth authentication.",
       "keywords": ["csrf-protection","csrf","protection","security","vulnerability","xss","samesite","authentication"],
       "category": "security"
@@ -518,7 +518,7 @@
     {
       "name": "database-schema-design",
       "source": "./plugins/database-schema-design",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Database schema design for PostgreSQL/MySQL with normalization, relationships, constraints. Use for new databases, schema reviews, migrations, or encountering missing PKs/FKs, wrong data types, premature denormalization, EAV anti-pattern.",
       "keywords": ["database-schema-design","database","schema","design","orm","sql","query","migrations","eav","mysql","postgresql","migration"],
       "category": "database"
@@ -527,7 +527,7 @@
     {
       "name": "database-sharding",
       "source": "./plugins/database-sharding",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Database sharding for PostgreSQL/MySQL with hash/range/directory strategies. Use for horizontal scaling, multi-tenant isolation, billions of records, or encountering wrong shard keys, hotspots, cross-shard transactions, rebalancing issues.",
       "keywords": ["database-sharding","database","sharding","orm","sql","query","migrations","mysql","postgresql"],
       "category": "database"
@@ -536,7 +536,7 @@
     {
       "name": "defense-in-depth-validation",
       "source": "./plugins/defense-in-depth-validation",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Validate at every layer data passes through to make bugs impossible. Use when invalid data causes failures deep in execution, requiring validation at multiple system layers.",
       "keywords": ["defense-in-depth-validation","defense","depth","validation","security","vulnerability","protection","csrf","xss"],
       "category": "security"
@@ -545,16 +545,16 @@
     {
       "name": "dependency-upgrade",
       "source": "./plugins/dependency-upgrade",
-      "version": "3.3.0",
-      "description": "Secure dependency upgrades with supply chain protection, cooldown periods, post-install script hardening, lockfile validation, and staged rollout across npm, Bun, pnpm, and Yarn. Use when upgrading dependencies, configuring security policies, or preventing supply chain attacks.",
-      "keywords": ["dependency-upgrade","dependency","upgrade","tooling","workflow","validation"],
+      "version": "3.3.1",
+      "description": "Secure dependency upgrades with supply chain protection, cooldowns, staged rollout, and Socket CLI integration. Use when upgrading deps, configuring security policies, or preventing supply chain attacks.",
+      "keywords": ["dependency-upgrade","dependency","upgrade","tooling","workflow","cli"],
       "category": "tooling"
     }
 ,
     {
       "name": "design-review",
       "source": "./plugins/design-review",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states.",
       "keywords": ["design-review","design","review","interface","user-experience","wcag"],
       "category": "design"
@@ -563,7 +563,7 @@
     {
       "name": "design-system-creation",
       "source": "./plugins/design-system-creation",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency.",
       "keywords": ["design-system-creation","design","system","creation","interface","user-experience"],
       "category": "design"
@@ -572,7 +572,7 @@
     {
       "name": "drizzle-orm-d1",
       "source": "./plugins/drizzle-orm-d1",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transaction errors, foreign key constraint failures, or schema inference issues.",
       "keywords": ["drizzle-orm-d1","drizzle","orm","database","sql","query","migrations","migration"],
       "category": "database"
@@ -581,7 +581,7 @@
     {
       "name": "elevenlabs-agents",
       "source": "./plugins/elevenlabs-agents",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "ElevenLabs Agents Platform for AI voice agents (React/JS/Native/Swift). Use for voice AI, RAG, tools, or encountering package deprecation, audio cutoff, CSP violations, webhook auth failures.",
       "keywords": ["elevenlabs-agents","elevenlabs","agents","machine-learning","llm","artificial-intelligence","csp","rag"],
       "category": "ai"
@@ -590,7 +590,7 @@
     {
       "name": "fastmcp",
       "source": "./plugins/fastmcp",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "FastMCP Python framework for MCP servers with tools, resources, storage backends (memory/disk/Redis/DynamoDB). Use for Claude tool exposure, OAuth Proxy, cloud deployment, or encountering storage, lifespan, middleware, circular import, async errors.",
       "keywords": ["fastmcp","tooling","workflow","mcp","dynamodb","async"],
       "category": "tooling"
@@ -599,7 +599,7 @@
     {
       "name": "feature-dev",
       "source": "./plugins/feature-dev",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Automate 7-phase feature development with specialized agents (code-explorer, code-architect, code-reviewer). Use for multi-file features, architectural decisions, or encountering ambiguous requirements, integration patterns, design approach errors.",
       "keywords": ["feature-dev","feature","dev","tooling","workflow"],
       "category": "tooling"
@@ -608,7 +608,7 @@
     {
       "name": "firecrawl-scraper",
       "source": "./plugins/firecrawl-scraper",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors.",
       "keywords": ["firecrawl-scraper","firecrawl","scraper","web","performance","pwa","llm"],
       "category": "web"
@@ -617,7 +617,7 @@
     {
       "name": "frontend-design",
       "source": "./plugins/frontend-design",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.",
       "keywords": ["frontend-design","frontend","design","tooling","workflow"],
       "category": "tooling"
@@ -626,7 +626,7 @@
     {
       "name": "gemini-cli",
       "source": "./plugins/gemini-cli",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool.",
       "keywords": ["gemini-cli","gemini","cli","machine-learning","llm","artificial-intelligence"],
       "category": "ai"
@@ -635,7 +635,7 @@
     {
       "name": "github-project-automation",
       "source": "./plugins/github-project-automation",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors.",
       "keywords": ["github-project-automation","github","project","automation","tooling","workflow","yaml","codeql"],
       "category": "tooling"
@@ -644,7 +644,7 @@
     {
       "name": "google-gemini-api",
       "source": "./plugins/google-gemini-api",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Google Gemini API with @google/genai SDK. Use for multimodal AI, thinking mode, function calling, or encountering SDK deprecation warnings, context errors, multimodal format errors.",
       "keywords": ["google-gemini-api","google","gemini","api","machine-learning","llm","artificial-intelligence"],
       "category": "ai"
@@ -653,7 +653,7 @@
     {
       "name": "google-gemini-embeddings",
       "source": "./plugins/google-gemini-embeddings",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Google Gemini embeddings API (gemini-embedding-001) for RAG and semantic search. Use for vector search, Vectorize integration, or encountering dimension mismatches, rate limits, text truncation.",
       "keywords": ["google-gemini-embeddings","google","gemini","embeddings","machine-learning","llm","artificial-intelligence","rag"],
       "category": "ai"
@@ -662,7 +662,7 @@
     {
       "name": "google-gemini-file-search",
       "source": "./plugins/google-gemini-file-search",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Google Gemini File Search for managed RAG with 100+ file formats. Use for document Q&A, knowledge bases, or encountering immutability errors, quota issues, polling failures. Supports Gemini 3 Pro/Flash (Gemini 2.5 legacy).",
       "keywords": ["google-gemini-file-search","google","gemini","file","search","machine-learning","llm","artificial-intelligence","rag"],
       "category": "ai"
@@ -671,7 +671,7 @@
     {
       "name": "graphql-implementation",
       "source": "./plugins/graphql-implementation",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Builds GraphQL APIs with schema design, resolvers, error handling, and performance optimization using Apollo or Graphene. Use when creating flexible query APIs, migrating from REST, or implementing real-time subscriptions.",
       "keywords": ["graphql-implementation","graphql","implementation","rest","endpoints","http","real-time"],
       "category": "api"
@@ -680,7 +680,7 @@
     {
       "name": "health-check-endpoints",
       "source": "./plugins/health-check-endpoints",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Health check endpoints for liveness, readiness, dependency monitoring. Use for Kubernetes, load balancers, auto-scaling, or encountering probe failures, startup delays, dependency checks, timeout configuration errors.",
       "keywords": ["health-check-endpoints","health","check","endpoints","architecture","patterns","microservices"],
       "category": "architecture"
@@ -689,7 +689,7 @@
     {
       "name": "hono-routing",
       "source": "./plugins/hono-routing",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors.",
       "keywords": ["hono-routing","hono","routing","web","performance","pwa","rpc","validation"],
       "category": "web"
@@ -698,7 +698,7 @@
     {
       "name": "hugo",
       "source": "./plugins/hugo",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors.",
       "keywords": ["hugo","cms","content","management","publishing"],
       "category": "cms"
@@ -707,7 +707,7 @@
     {
       "name": "idempotency-handling",
       "source": "./plugins/idempotency-handling",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Idempotent API operations with idempotency keys, Redis caching, DB constraints. Use for payment systems, webhook retries, safe retries, or encountering duplicate processing, race conditions, key expiry errors.",
       "keywords": ["idempotency-handling","idempotency","handling","tooling","workflow","caching"],
       "category": "tooling"
@@ -716,7 +716,7 @@
     {
       "name": "image-optimization",
       "source": "./plugins/image-optimization",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Optimizes images for web performance using modern formats, responsive techniques, and lazy loading strategies. Use when improving page load times, implementing responsive images, or preparing assets for production deployment.",
       "keywords": ["image-optimization","image","optimization","web","performance","pwa"],
       "category": "web"
@@ -725,7 +725,7 @@
     {
       "name": "inspira-ui",
       "source": "./plugins/inspira-ui",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "120+ Vue/Nuxt animated components with TailwindCSS v4, motion-v, GSAP, Three.js. Use for hero sections, 3D effects, interactive backgrounds, or encountering setup, CSS variables, motion-v integration errors.",
       "keywords": ["inspira-ui","inspira","frontend","components","css","gsap","tailwindcss"],
       "category": "frontend"
@@ -734,7 +734,7 @@
     {
       "name": "interaction-design",
       "source": "./plugins/interaction-design",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Creates intuitive user experiences through feedback patterns, microinteractions, and accessible interaction design. Use when designing loading states, error handling UX, animation guidelines, or touch interactions.",
       "keywords": ["interaction-design","interaction","design","interface","user-experience"],
       "category": "design"
@@ -743,7 +743,7 @@
     {
       "name": "internationalization-i18n",
       "source": "./plugins/internationalization-i18n",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Implements multi-language support using i18next, gettext, or Intl API with translation workflows and RTL support. Use when building multilingual applications, handling date/currency formatting, or supporting right-to-left languages.",
       "keywords": ["internationalization-i18n","internationalization","i18n","web","rtl"],
       "category": "web"
@@ -752,7 +752,7 @@
     {
       "name": "jest-generator",
       "source": "./plugins/jest-generator",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Generate Jest unit tests for JavaScript/TypeScript with mocking, coverage. Use for JS/TS modules, React components, test generation, or encountering missing coverage, improper mocking, test structure errors.",
       "keywords": ["jest-generator","jest","generator","testing","tests","unit-tests","quality"],
       "category": "testing"
@@ -761,7 +761,7 @@
     {
       "name": "kpi-dashboard-design",
       "source": "./plugins/kpi-dashboard-design",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Designs effective KPI dashboards with proper metric selection, visual hierarchy, and data visualization best practices. Use when building executive dashboards, creating analytics views, or presenting business metrics.",
       "keywords": ["kpi-dashboard-design","kpi","dashboard","design","interface","user-experience"],
       "category": "design"
@@ -770,7 +770,7 @@
     {
       "name": "logging-best-practices",
       "source": "./plugins/logging-best-practices",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Structured logging with proper levels, context, PII handling, centralized aggregation. Use for application logging, log management integration, distributed tracing, or encountering log bloat, PII exposure, missing context errors.",
       "keywords": ["logging-best-practices","logging","best","practices","tooling","workflow","pii"],
       "category": "tooling"
@@ -779,7 +779,7 @@
     {
       "name": "maz-ui",
       "source": "./plugins/maz-ui",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Maz-UI v4 - Modern Vue & Nuxt component library with 50+ standalone components, composables, directives, theming, i18n, and SSR support.",
       "keywords": ["maz-ui","maz","tooling","workflow","ssr"],
       "category": "tooling"
@@ -788,7 +788,7 @@
     {
       "name": "mcp-dynamic-orchestrator",
       "source": "./plugins/mcp-dynamic-orchestrator",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets.",
       "keywords": ["mcp-dynamic-orchestrator","mcp","dynamic","orchestrator","tooling","workflow"],
       "category": "tooling"
@@ -797,7 +797,7 @@
     {
       "name": "mcp-management",
       "source": "./plugins/mcp-management",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Manage MCP servers - discover, analyze, execute tools/prompts/resources. Use for MCP integrations, capability discovery, tool filtering, programmatic execution, or encountering context bloat, server configuration, tool execution errors.",
       "keywords": ["mcp-management","mcp","management","tooling","workflow"],
       "category": "tooling"
@@ -806,7 +806,7 @@
     {
       "name": "microservices-patterns",
       "source": "./plugins/microservices-patterns",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Design microservices architectures with service boundaries, event-driven communication, and resilience patterns. Use when building distributed systems, decomposing monoliths, or implementing microservices.",
       "keywords": ["microservices-patterns","microservices","patterns","architecture"],
       "category": "architecture"
@@ -815,7 +815,7 @@
     {
       "name": "ml-model-training",
       "source": "./plugins/ml-model-training",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Train ML models with scikit-learn, PyTorch, TensorFlow. Use for classification/regression, neural networks, hyperparameter tuning, or encountering overfitting, underfitting, convergence issues.",
       "keywords": ["ml-model-training","model","training","machine-learning","artificial-intelligence","pytorch","tensorflow"],
       "category": "ai"
@@ -824,7 +824,7 @@
     {
       "name": "ml-pipeline-automation",
       "source": "./plugins/ml-pipeline-automation",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Automate ML workflows with Airflow, Kubeflow, MLflow. Use for reproducible pipelines, retraining schedules, MLOps, or encountering task failures, dependency errors, experiment tracking issues.",
       "keywords": ["ml-pipeline-automation","pipeline","automation","machine-learning","llm","artificial-intelligence"],
       "category": "ai"
@@ -833,7 +833,7 @@
     {
       "name": "mobile-app-debugging",
       "source": "./plugins/mobile-app-debugging",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Mobile app debugging for iOS, Android, cross-platform frameworks. Use for crashes, memory leaks, performance issues, network problems, or encountering Xcode instruments, Android Profiler, React Native debugger, native bridge errors.",
       "keywords": ["mobile-app-debugging","mobile","app","debugging","native"],
       "category": "mobile"
@@ -842,7 +842,7 @@
     {
       "name": "mobile-app-testing",
       "source": "./plugins/mobile-app-testing",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Mobile app testing with unit tests, UI automation, performance testing. Use for test infrastructure, E2E tests, testing standards, or encountering test framework setup, device farms, flaky tests, platform-specific test errors.",
       "keywords": ["mobile-app-testing","mobile","app","testing","native","e2e"],
       "category": "mobile"
@@ -851,7 +851,7 @@
     {
       "name": "mobile-first-design",
       "source": "./plugins/mobile-first-design",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Designs responsive interfaces starting from mobile screens with progressive enhancement for larger devices. Use when building responsive websites, optimizing for mobile users, or implementing adaptive layouts.",
       "keywords": ["mobile-first-design","mobile","first","design","responsive-design","media-queries","breakpoints"],
       "category": "mobile"
@@ -860,7 +860,7 @@
     {
       "name": "mobile-offline-support",
       "source": "./plugins/mobile-offline-support",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Offline-first mobile apps with local storage, sync queues, conflict resolution. Use for offline functionality, data sync, connectivity handling, or encountering sync conflicts, queue management, storage limits, network transition errors.",
       "keywords": ["mobile-offline-support","mobile","offline","support","native"],
       "category": "mobile"
@@ -869,7 +869,7 @@
     {
       "name": "model-deployment",
       "source": "./plugins/model-deployment",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Deploy ML models with FastAPI, Docker, Kubernetes. Use for serving predictions, containerization, monitoring, drift detection, or encountering latency issues, health check failures, version conflicts.",
       "keywords": ["model-deployment","model","machine-learning","llm","artificial-intelligence","fastapi"],
       "category": "ai"
@@ -878,7 +878,7 @@
     {
       "name": "motion",
       "source": "./plugins/motion",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Motion (Framer Motion) React animation library. Use for drag-and-drop, scroll animations, gestures, SVG morphing, or encountering bundle size, complex transitions, spring physics errors.",
       "keywords": ["motion","frontend","components","svg"],
       "category": "frontend"
@@ -887,7 +887,7 @@
     {
       "name": "multi-ai-consultant",
       "source": "./plugins/multi-ai-consultant",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Consult external AIs (Gemini 2.5 Pro, OpenAI Codex, Claude) for second opinions. Use for debugging failures, architectural decisions, security validation, or need fresh perspective with synthesis.",
       "keywords": ["multi-ai-consultant","multi","consultant","machine-learning","llm","artificial-intelligence","openai","validation"],
       "category": "ai"
@@ -896,7 +896,7 @@
     {
       "name": "mutation-testing",
       "source": "./plugins/mutation-testing",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.",
       "keywords": ["mutation-testing","mutation","testing","tests","unit-tests","quality"],
       "category": "testing"
@@ -905,7 +905,7 @@
     {
       "name": "nano-banana-prompts",
       "source": "./plugins/nano-banana-prompts",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Generate optimized prompts for Gemini 2.5 Flash Image (Nano Banana). Use for image generation, crafting photo prompts, art styles, or multi-turn editing workflows with best practices.",
       "keywords": ["nano-banana-prompts","nano","banana","prompts","tooling","workflow"],
       "category": "tooling"
@@ -914,7 +914,7 @@
     {
       "name": "neon-vercel-postgres",
       "source": "./plugins/neon-vercel-postgres",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Neon + Vercel serverless Postgres for edge and serverless environments. Use for Cloudflare Workers, Vercel Edge, Next.js apps with HTTP/WebSocket connections, database branching (git-like), Drizzle/Prisma ORM integration, migrations, PITR backups, or encountering connection pool exhausted errors, TCP connection issues, SSL config problems.",
       "keywords": ["neon-vercel-postgres","neon","vercel","postgres","database","orm","sql","query","migrations","http","pitr","ssl","tcp","websocket","migration","edge"],
       "category": "database"
@@ -923,7 +923,7 @@
     {
       "name": "nextjs",
       "source": "./plugins/nextjs",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors.",
       "keywords": ["nextjs","frontend","components","ssr","migration","async"],
       "category": "frontend"
@@ -932,7 +932,7 @@
     {
       "name": "nuxt-content",
       "source": "./plugins/nuxt-content",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Nuxt Content v3 Git-backed CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Vercel deployment, SQL storage, MDC components, content collections.",
       "keywords": ["nuxt-content","nuxt","content","frontend","components","cms","mdc","sql","validation"],
       "category": "frontend"
@@ -941,7 +941,7 @@
     {
       "name": "nuxt-seo",
       "source": "./plugins/nuxt-seo",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Comprehensive guide for all 8 Nuxt SEO modules plus Pro modules. Use when building SEO-optimized Nuxt applications, implementing robots.txt/sitemaps, generating OG images, adding Schema.org data, managing meta tags, checking links, or encountering sitemap, robots.txt, OG image, schema validation, meta tag, canonical URL, or i18n SEO errors.",
       "keywords": ["nuxt-seo","nuxt","seo","frontend","components","url","validation"],
       "category": "frontend"
@@ -950,7 +950,7 @@
     {
       "name": "nuxt-studio",
       "source": "./plugins/nuxt-studio",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Visual CMS for Nuxt Content with Cloudflare deployment. Use when setting up Nuxt Studio, configuring OAuth authentication, deploying to Cloudflare Pages/Workers with subdomain routing, or troubleshooting Studio integration.",
       "keywords": ["nuxt-studio","nuxt","studio","frontend","components","cms","authentication"],
       "category": "frontend"
@@ -959,7 +959,7 @@
     {
       "name": "nuxt-ui-v4",
       "source": "./plugins/nuxt-ui-v4",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Nuxt UI v4 with 125+ accessible components, Tailwind v4, Reka UI, AI chat integration with reasoning and tool calling. Use for dashboards, forms, overlays, editors, page layouts, or encountering theming, composable, TypeScript errors.",
       "keywords": ["nuxt-ui-v4","nuxt","frontend","components"],
       "category": "frontend"
@@ -968,7 +968,7 @@
     {
       "name": "nuxt-v4",
       "source": "./plugins/nuxt-v4",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Comprehensive Nuxt 4 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 4 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 3, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
       "keywords": ["nuxt-v4","nuxt","frontend","components","ssr","migration"],
       "category": "frontend"
@@ -977,7 +977,7 @@
     {
       "name": "nuxt-v5",
       "source": "./plugins/nuxt-v5",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Comprehensive Nuxt 5 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 5 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 4, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
       "keywords": ["nuxt-v5","nuxt","frontend","components","ssr","migration"],
       "category": "frontend"
@@ -986,7 +986,7 @@
     {
       "name": "oauth-implementation",
       "source": "./plugins/oauth-implementation",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "OAuth 2.0 and OpenID Connect authentication with secure flows. Use for third-party integrations, SSO systems, token-based API access, or encountering authorization code flow, PKCE, token refresh, scope management errors.",
       "keywords": ["oauth-implementation","oauth","implementation","authentication","authorization","login","security","session","pkce","sso","openid"],
       "category": "auth"
@@ -995,7 +995,7 @@
     {
       "name": "openai-agents",
       "source": "./plugins/openai-agents",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "OpenAI Agents SDK for JavaScript/TypeScript (text + voice agents). Use for multi-agent workflows, tools, guardrails, or encountering Zod errors, MCP failures, infinite loops, tool call issues.",
       "keywords": ["openai-agents","openai","agents","machine-learning","llm","artificial-intelligence","mcp"],
       "category": "ai"
@@ -1004,7 +1004,7 @@
     {
       "name": "openai-api",
       "source": "./plugins/openai-api",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Complete guide for OpenAI APIs: Chat Completions (GPT-5.2, GPT-4o), Embeddings, Images (GPT-Image-1.5), Audio (Whisper + TTS + Transcribe), Moderation. Includes Node.js SDK and fetch approaches.",
       "keywords": ["openai-api","openai","api","machine-learning","llm","artificial-intelligence","gpt","tts"],
       "category": "ai"
@@ -1013,7 +1013,7 @@
     {
       "name": "openai-assistants",
       "source": "./plugins/openai-assistants",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "OpenAI Assistants API v2 for stateful chatbots with Code Interpreter, File Search, RAG. Use for threads, vector stores, or encountering active run errors, indexing delays. ⚠️ Sunset August 26, 2026.",
       "keywords": ["openai-assistants","openai","assistants","machine-learning","llm","artificial-intelligence","rag"],
       "category": "ai"
@@ -1022,7 +1022,7 @@
     {
       "name": "openai-responses",
       "source": "./plugins/openai-responses",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "OpenAI Responses API for stateful agentic applications with reasoning preservation. Use for MCP integration, built-in tools, background processing, or migrating from Chat Completions.",
       "keywords": ["openai-responses","openai","responses","machine-learning","llm","artificial-intelligence","mcp"],
       "category": "ai"
@@ -1031,7 +1031,7 @@
     {
       "name": "payment-gateway-integration",
       "source": "./plugins/payment-gateway-integration",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Integrates payment processing with Stripe, PayPal, or Square including subscriptions, webhooks, and PCI compliance. Use when implementing checkout flows, recurring billing, or handling refunds and disputes.",
       "keywords": ["payment-gateway-integration","payment","gateway","integration","web","pci","paypal","webhooks"],
       "category": "web"
@@ -1040,7 +1040,7 @@
     {
       "name": "pinia-colada",
       "source": "./plugins/pinia-colada",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors.",
       "keywords": ["pinia-colada","pinia","colada","frontend","components","ssr","tanstack","migration","async"],
       "category": "frontend"
@@ -1049,7 +1049,7 @@
     {
       "name": "pinia-v3",
       "source": "./plugins/pinia-v3",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors.",
       "keywords": ["pinia-v3","pinia","frontend","components","ssr","migration"],
       "category": "frontend"
@@ -1058,7 +1058,7 @@
     {
       "name": "plan-interview",
       "source": "./plugins/plan-interview",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Adaptive interview-driven spec generation with quality review. Automatically adjusts depth based on plan complexity.",
       "keywords": ["plan-interview","plan","interview","tooling","workflow"],
       "category": "tooling"
@@ -1067,7 +1067,7 @@
     {
       "name": "playwright",
       "source": "./plugins/playwright",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Browser automation and E2E testing with Playwright. Auto-detects dev servers, writes clean test scripts. Test pages, fill forms, take screenshots, check responsive design, validate UX, test login flows, check links, automate any browser task. Use for cross-browser testing, visual regression, API testing, component testing in TypeScript/JavaScript and Python projects.",
       "keywords": ["playwright","tooling","workflow","e2e"],
       "category": "tooling"
@@ -1076,7 +1076,7 @@
     {
       "name": "progressive-web-app",
       "source": "./plugins/progressive-web-app",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Builds Progressive Web Apps with service workers, web manifest, offline support, and installation prompts. Use when creating installable web experiences, implementing offline functionality, or adding push notifications to web apps.",
       "keywords": ["progressive-web-app","progressive","web","app","performance","pwa"],
       "category": "web"
@@ -1085,7 +1085,7 @@
     {
       "name": "push-notification-setup",
       "source": "./plugins/push-notification-setup",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Implements push notifications across iOS, Android, and web using Firebase Cloud Messaging and native services. Use when adding notification capabilities, handling background messages, or setting up notification channels.",
       "keywords": ["push-notification-setup","push","notification","setup","web","performance","pwa"],
       "category": "web"
@@ -1094,7 +1094,7 @@
     {
       "name": "react-best-practices",
       "source": "./plugins/react-best-practices",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "React and Next.js performance optimization guidelines from Vercel Engineering. Use when writing/reviewing/refactoring React code for optimal performance. Covers async patterns, bundle optimization, server/client components, re-render optimization.",
       "keywords": ["react-best-practices","react","best","practices","frontend","components","refactoring","async"],
       "category": "frontend"
@@ -1103,7 +1103,7 @@
     {
       "name": "react-composition-patterns",
       "source": "./plugins/react-composition-patterns",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "React composition patterns from Vercel Engineering. Use when building scalable components, avoiding boolean prop proliferation, implementing compound components, or managing component state. Covers architecture, state management, and implementation patterns.",
       "keywords": ["react-composition-patterns","react","composition","patterns","frontend","components","scalable","implementation"],
       "category": "frontend"
@@ -1112,7 +1112,7 @@
     {
       "name": "react-hook-form-zod",
       "source": "./plugins/react-hook-form-zod",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems.",
       "keywords": ["react-hook-form-zod","react","hook","form","zod","frontend","components","validation"],
       "category": "frontend"
@@ -1121,7 +1121,7 @@
     {
       "name": "react-native-skills",
       "source": "./plugins/react-native-skills",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "React Native and Expo best practices for building performant mobile apps. Use when building React Native components, optimizing list performance, implementing animations, or working with native modules.",
       "keywords": ["react-native-skills","react","native","skills","frontend","components"],
       "category": "frontend"
@@ -1130,7 +1130,7 @@
     {
       "name": "recommendation-engine",
       "source": "./plugins/recommendation-engine",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Build recommendation systems with collaborative filtering, matrix factorization, hybrid approaches. Use for product recommendations, personalization, or encountering cold start, sparsity, quality evaluation issues.",
       "keywords": ["recommendation-engine","recommendation","engine","data","analytics","processing","sql","queries"],
       "category": "data"
@@ -1139,7 +1139,7 @@
     {
       "name": "recommendation-system",
       "source": "./plugins/recommendation-system",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Deploy production recommendation systems with feature stores, caching, A/B testing. Use for personalization APIs, low latency serving, or encountering cache invalidation, experiment tracking, quality monitoring issues.",
       "keywords": ["recommendation-system","recommendation","system","data","analytics","processing","sql","queries","caching"],
       "category": "data"
@@ -1148,7 +1148,7 @@
     {
       "name": "responsive-web-design",
       "source": "./plugins/responsive-web-design",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Builds adaptive web interfaces using Flexbox, CSS Grid, and media queries with a mobile-first approach. Use when creating multi-device layouts, implementing flexible UI systems, or ensuring cross-browser compatibility.",
       "keywords": ["responsive-web-design","responsive","web","design","performance","pwa","css"],
       "category": "web"
@@ -1157,7 +1157,7 @@
     {
       "name": "rest-api-design",
       "source": "./plugins/rest-api-design",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Designs RESTful APIs with proper resource naming, HTTP methods, status codes, and response formats. Use when building new APIs, establishing API conventions, or designing developer-friendly interfaces.",
       "keywords": ["rest-api-design","rest","api","design","graphql","endpoints","http"],
       "category": "api"
@@ -1166,7 +1166,7 @@
     {
       "name": "root-cause-tracing",
       "source": "./plugins/root-cause-tracing",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Systematically trace bugs backward through call stack to find original trigger. Use when errors occur deep in execution and you need to trace back to find the original trigger.",
       "keywords": ["root-cause-tracing","root","cause","tracing","tooling","workflow"],
       "category": "tooling"
@@ -1175,7 +1175,7 @@
     {
       "name": "security-headers-configuration",
       "source": "./plugins/security-headers-configuration",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Configures HTTP security headers to protect against XSS, clickjacking, and MIME sniffing attacks. Use when hardening web applications, passing security audits, or implementing Content Security Policy.",
       "keywords": ["security-headers-configuration","security","headers","configuration","vulnerability","protection","csrf","xss","http","mime"],
       "category": "security"
@@ -1184,7 +1184,7 @@
     {
       "name": "seo-keyword-cluster-builder",
       "source": "./plugins/seo-keyword-cluster-builder",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Groups related keywords into topic clusters and creates content hub architecture recommendations with internal linking strategies. Use when planning content strategy, organizing keyword research, or building pillar page structures.",
       "keywords": ["seo-keyword-cluster-builder","seo","keyword","cluster","builder","search","keywords","ranking"],
       "category": "seo"
@@ -1193,7 +1193,7 @@
     {
       "name": "seo-optimizer",
       "source": "./plugins/seo-optimizer",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "SEO optimization with keyword analysis, readability assessment, technical validation, content quality. Use for search rankings, blog posts, content audits, or encountering keyword density, readability scores, meta tags, schema markup errors.",
       "keywords": ["seo-optimizer","seo","optimizer","search","keywords","ranking","validation"],
       "category": "seo"
@@ -1202,7 +1202,7 @@
     {
       "name": "sequential-thinking",
       "source": "./plugins/sequential-thinking",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Systematic step-by-step reasoning with revision and branching. Use for complex problems, multi-stage analysis, design planning, problem decomposition, or encountering unclear scope, alternative approaches needed, revision requirements.",
       "keywords": ["sequential-thinking","sequential","thinking","tooling","workflow"],
       "category": "tooling"
@@ -1211,7 +1211,7 @@
     {
       "name": "session-management",
       "source": "./plugins/session-management",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Implements secure session management with JWT tokens, Redis storage, refresh flows, and proper cookie configuration. Use when building authentication systems, managing user sessions, or implementing secure logout functionality.",
       "keywords": ["session-management","session","management","authentication","authorization","login","security","jwt"],
       "category": "auth"
@@ -1220,7 +1220,7 @@
     {
       "name": "shadcn-vue",
       "source": "./plugins/shadcn-vue",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors.",
       "keywords": ["shadcn-vue","shadcn","vue","frontend","components"],
       "category": "frontend"
@@ -1229,7 +1229,7 @@
     {
       "name": "sql-query-optimization",
       "source": "./plugins/sql-query-optimization",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "SQL query optimization for PostgreSQL/MySQL with indexing, EXPLAIN analysis. Use for slow queries, N+1 problems, missing indexes, or encountering sequential scans, OFFSET pagination, temp table spills, inefficient JOINs.",
       "keywords": ["sql-query-optimization","sql","query","optimization","data","analytics","processing","queries","explain","offset","mysql","postgresql"],
       "category": "data"
@@ -1238,7 +1238,7 @@
     {
       "name": "supabase-postgres-best-practices",
       "source": "./plugins/supabase-postgres-best-practices",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Postgres performance optimization and best practices from Supabase. 30 rules across 8 categories prioritized by impact.",
       "keywords": ["supabase-postgres-best-practices","supabase","postgres","best","practices","tooling","workflow"],
       "category": "tooling"
@@ -1247,7 +1247,7 @@
     {
       "name": "sveltia-cms",
       "source": "./plugins/sveltia-cms",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Sveltia CMS Git-backed content management (Decap/Netlify CMS successor). 5x smaller bundle (300 KB), GraphQL performance, solves 260+ issues. Use for static sites (Hugo, Jekyll, 11ty, Gatsby, Astro, Next.js), blogs, docs, i18n, or encountering OAuth errors, TOML/YAML issues, CORS problems, content listing errors.",
       "keywords": ["sveltia-cms","sveltia","cms","content","management","publishing","cors","toml","yaml","graphql"],
       "category": "cms"
@@ -1256,7 +1256,7 @@
     {
       "name": "swift-best-practices",
       "source": "./plugins/swift-best-practices",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "This skill should be used when writing or reviewing Swift code for iOS or macOS projects. Apply modern Swift 6+ best practices, concurrency patterns, API design guidelines, and migration strategies. Covers async/await, actors, MainActor, Sendable, typed throws, and Swift 6 breaking changes.",
       "keywords": ["swift-best-practices","swift","best","practices","mobile","native","mainactor","migration","async"],
       "category": "mobile"
@@ -1265,7 +1265,7 @@
     {
       "name": "swift-settingskit",
       "source": "./plugins/swift-settingskit",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "SettingsKit for SwiftUI settings interfaces (iOS, macOS, watchOS, tvOS, visionOS). Use for settings/preferences screens, searchable settings, nested navigation, @Observable/@Bindable state, or encountering settings update errors, navigation state issues.",
       "keywords": ["swift-settingskit","swift","settingskit","mobile","native","swiftui"],
       "category": "mobile"
@@ -1274,7 +1274,7 @@
     {
       "name": "systematic-debugging",
       "source": "./plugins/systematic-debugging",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Four-phase debugging framework that ensures root cause investigation before attempting fixes. Never jump to solutions. Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes.",
       "keywords": ["systematic-debugging","systematic","debugging","tooling","workflow"],
       "category": "tooling"
@@ -1283,7 +1283,7 @@
     {
       "name": "tailwind-v4-shadcn",
       "source": "./plugins/tailwind-v4-shadcn",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React. Use when: initializing React projects with Tailwind v4, setting up shadcn/ui, implementing dark mode, debugging CSS variable issues, fixing theme switching, migrating from Tailwind v3, or encountering color/theming problems. Covers: @theme inline pattern, CSS variable architecture, dark mode with ThemeProvider, component composition, vite.config setup, common v4 gotchas, and production-tested patterns.",
       "keywords": ["tailwind-v4-shadcn","tailwind","shadcn","frontend","components","css","themeprovider"],
       "category": "frontend"
@@ -1292,7 +1292,7 @@
     {
       "name": "tanstack-ai",
       "source": "./plugins/tanstack-ai",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and tool definitions.",
       "keywords": ["tanstack-ai","tanstack","machine-learning","llm","artificial-intelligence","chatclient","openai"],
       "category": "ai"
@@ -1301,7 +1301,7 @@
     {
       "name": "tanstack-query",
       "source": "./plugins/tanstack-query",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors.",
       "keywords": ["tanstack-query","tanstack","query","frontend","components","migration","caching"],
       "category": "frontend"
@@ -1310,7 +1310,7 @@
     {
       "name": "tanstack-router",
       "source": "./plugins/tanstack-router",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "TanStack Router type-safe file-based routing for React. Use for SPAs, TanStack Query integration, Cloudflare Workers, or encountering devtools, type safety, loader, Vite bundling errors.",
       "keywords": ["tanstack-router","tanstack","router","frontend","components"],
       "category": "frontend"
@@ -1319,7 +1319,7 @@
     {
       "name": "tanstack-start",
       "source": "./plugins/tanstack-start",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "TanStack Start (RC) full-stack React with server functions, SSR, Cloudflare Workers. Use for Next.js migration, edge rendering, or encountering hydration, auth, data pattern errors.",
       "keywords": ["tanstack-start","tanstack","start","frontend","components","ssr","migration","edge"],
       "category": "frontend"
@@ -1328,7 +1328,7 @@
     {
       "name": "tanstack-table",
       "source": "./plugins/tanstack-table",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "TanStack Table v8 headless data tables with server-side features for Cloudflare Workers + D1. Use for pagination, filtering, sorting, virtualization, or encountering state management, TanStack Query coordination, URL sync errors.",
       "keywords": ["tanstack-table","tanstack","table","frontend","components","url"],
       "category": "frontend"
@@ -1337,7 +1337,7 @@
     {
       "name": "technical-specification",
       "source": "./plugins/technical-specification",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Creates detailed technical specifications for software projects covering requirements, architecture, APIs, and testing strategies. Use when planning features, documenting system design, or creating architecture decision records.",
       "keywords": ["technical-specification","technical","specification","documentation","docs","technical-writing","specs"],
       "category": "documentation"
@@ -1346,7 +1346,7 @@
     {
       "name": "test-quality-analysis",
       "source": "./plugins/test-quality-analysis",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Detect test smells, overmocking, flaky tests, and coverage issues. Analyze test effectiveness, maintainability, and reliability. Use when reviewing tests or improving test quality.",
       "keywords": ["test-quality-analysis","test","quality","analysis","testing","tests","unit-tests"],
       "category": "testing"
@@ -1355,7 +1355,7 @@
     {
       "name": "thesys-generative-ui",
       "source": "./plugins/thesys-generative-ui",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "AI-powered generative UI with Thesys - create React components from natural language.",
       "keywords": ["thesys-generative-ui","thesys","generative","machine-learning","llm","artificial-intelligence"],
       "category": "ai"
@@ -1364,7 +1364,7 @@
     {
       "name": "threejs",
       "source": "./plugins/threejs",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Comprehensive Three.js skills for building 3D web experiences",
       "keywords": ["threejs","tooling","workflow"],
       "category": "tooling"
@@ -1373,7 +1373,7 @@
     {
       "name": "turborepo",
       "source": "./plugins/turborepo",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Turborepo high-performance monorepo build system. Use for monorepo setup, build optimization, task pipelines, caching strategies, or multi-package orchestration.",
       "keywords": ["turborepo","tooling","workflow","caching"],
       "category": "tooling"
@@ -1382,7 +1382,7 @@
     {
       "name": "typescript-mcp",
       "source": "./plugins/typescript-mcp",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "MCP servers with TypeScript on Cloudflare Workers using @modelcontextprotocol/sdk. Use for API integrations, stateless tools, edge deployments, or encountering export syntax, schema validation, memory leak, CORS, auth errors.",
       "keywords": ["typescript-mcp","mcp","tooling","workflow","cors","validation","edge"],
       "category": "tooling"
@@ -1391,7 +1391,7 @@
     {
       "name": "ultracite",
       "source": "./plugins/ultracite",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Ultracite multi-provider linting/formatting (Biome, ESLint, Oxlint). Use for v6/v7 setup, provider selection, Git hooks, MCP integration, AI hooks, migrations, or encountering configuration, type-aware linting, monorepo errors.",
       "keywords": ["ultracite","frontend","components","mcp","migration"],
       "category": "frontend"
@@ -1400,7 +1400,7 @@
     {
       "name": "vercel-blob",
       "source": "./plugins/vercel-blob",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Vercel Blob object storage with CDN for Next.js. Use for file uploads (images, PDFs, videos), presigned URLs, user-generated content, file management, or encountering BLOB_READ_WRITE_TOKEN errors, file size limits, client upload token errors.",
       "keywords": ["vercel-blob","vercel","blob","database","orm","sql","query","migrations","cdn"],
       "category": "database"
@@ -1409,7 +1409,7 @@
     {
       "name": "vercel-kv",
       "source": "./plugins/vercel-kv",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Vercel KV (Redis-compatible key-value storage via Upstash). Use for Next.js caching, sessions, rate limiting, TTL data storage, or encountering KV_REST_API_URL errors, rate limit issues, JSON serialization errors. Provides strong consistency vs eventual consistency.",
       "keywords": ["vercel-kv","vercel","database","orm","sql","query","migrations","json","ttl","caching"],
       "category": "database"
@@ -1418,7 +1418,7 @@
     {
       "name": "verification-before-completion",
       "source": "./plugins/verification-before-completion",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Run verification commands and confirm output before claiming success. Use when about to claim work is complete, fixed, or passing, before committing or creating PRs.",
       "keywords": ["verification-before-completion","verification","before","completion","tooling","workflow"],
       "category": "tooling"
@@ -1427,7 +1427,7 @@
     {
       "name": "vitest-testing",
       "source": "./plugins/vitest-testing",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Modern TypeScript/JavaScript testing with Vitest. Fast unit and integration tests, native ESM support, Vite-powered HMR, and comprehensive mocking. Use for testing TS/JS projects.",
       "keywords": ["vitest-testing","vitest","testing","tests","unit-tests","quality","esm","hmr"],
       "category": "testing"
@@ -1436,7 +1436,7 @@
     {
       "name": "vulnerability-scanning",
       "source": "./plugins/vulnerability-scanning",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Implements automated security scanning for dependencies, code, and containers using tools like Trivy, Snyk, and npm audit. Use when setting up CI/CD security gates, conducting pre-deployment audits, or meeting compliance requirements.",
       "keywords": ["vulnerability-scanning","vulnerability","scanning","security","protection","csrf","xss"],
       "category": "security"
@@ -1445,7 +1445,7 @@
     {
       "name": "web-performance-audit",
       "source": "./plugins/web-performance-audit",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Web performance audits with Core Web Vitals, bottleneck identification, optimization recommendations. Use for page load times, performance reviews, UX optimization, or encountering LCP, FID, CLS issues, resource blocking, render delays.",
       "keywords": ["web-performance-audit","web","performance","audit","pwa","cls","fid","lcp"],
       "category": "web"
@@ -1454,7 +1454,7 @@
     {
       "name": "web-performance-optimization",
       "source": "./plugins/web-performance-optimization",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Optimizes web application performance through code splitting, lazy loading, caching strategies, and Core Web Vitals monitoring. Use when improving page load times, implementing service workers, or reducing bundle sizes.",
       "keywords": ["web-performance-optimization","web","performance","optimization","pwa","caching"],
       "category": "web"
@@ -1463,7 +1463,7 @@
     {
       "name": "websocket-implementation",
       "source": "./plugins/websocket-implementation",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Implements real-time WebSocket communication with connection management, room-based messaging, and horizontal scaling. Use when building chat systems, live notifications, collaborative tools, or real-time dashboards.",
       "keywords": ["websocket-implementation","websocket","implementation","http","real-time"],
       "category": "api"
@@ -1472,7 +1472,7 @@
     {
       "name": "woocommerce-backend-dev",
       "source": "./plugins/woocommerce-backend-dev",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Add or modify WooCommerce backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code in WooCommerce projects.",
       "keywords": ["woocommerce-backend-dev","woocommerce","backend","dev","wordpress","ecommerce","shop","php"],
       "category": "woocommerce"
@@ -1481,7 +1481,7 @@
     {
       "name": "woocommerce-code-review",
       "source": "./plugins/woocommerce-code-review",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Review WooCommerce code changes for coding standards compliance. Use when reviewing code locally, performing automated PR reviews, or checking code quality in WooCommerce projects.",
       "keywords": ["woocommerce-code-review","woocommerce","code","review","wordpress","ecommerce","shop"],
       "category": "woocommerce"
@@ -1490,7 +1490,7 @@
     {
       "name": "woocommerce-copy-guidelines",
       "source": "./plugins/woocommerce-copy-guidelines",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Guidelines for UI text and copy in WooCommerce. Use when writing user-facing text, labels, buttons, messages, or documentation in WooCommerce projects.",
       "keywords": ["woocommerce-copy-guidelines","woocommerce","copy","guidelines","wordpress","ecommerce","shop"],
       "category": "woocommerce"
@@ -1499,7 +1499,7 @@
     {
       "name": "woocommerce-dev-cycle",
       "source": "./plugins/woocommerce-dev-cycle",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Run tests, linting, and quality checks for WooCommerce development. Use when running tests, fixing code style, or following the development workflow in WooCommerce projects.",
       "keywords": ["woocommerce-dev-cycle","woocommerce","dev","cycle","wordpress","ecommerce","shop"],
       "category": "woocommerce"
@@ -1508,7 +1508,7 @@
     {
       "name": "wordpress-plugin-core",
       "source": "./plugins/wordpress-plugin-core",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors.",
       "keywords": ["wordpress-plugin-core","wordpress","plugin","core","cms","content","management","publishing","csrf","rest","sql","xss"],
       "category": "cms"
@@ -1517,7 +1517,7 @@
     {
       "name": "xss-prevention",
       "source": "./plugins/xss-prevention",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Prevents Cross-Site Scripting attacks through input sanitization, output encoding, and Content Security Policy. Use when handling user-generated content, implementing rich text editors, or securing web applications.",
       "keywords": ["xss-prevention","xss","prevention","security","vulnerability","protection","csrf"],
       "category": "security"
@@ -1526,7 +1526,7 @@
     {
       "name": "zod",
       "source": "./plugins/zod",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies (2kb gzipped).",
       "keywords": ["zod","tooling","workflow","json","openapi","validation"],
       "category": "tooling"
@@ -1535,7 +1535,7 @@
     {
       "name": "zustand-state-management",
       "source": "./plugins/zustand-state-management",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "description": "Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loops.",
       "keywords": ["zustand-state-management","zustand","state","management","frontend","components","ssr","migration"],
       "category": "frontend"

--- a/.factory/settings.json
+++ b/.factory/settings.json
@@ -1,0 +1,15 @@
+{
+  "enabledPlugins": {
+    "core@factory-plugins": true,
+    "seo-optimizer@claude-skills": true,
+    "react-best-practices@claude-skills": true,
+    "react-hook-form-zod@claude-skills": true,
+    "seo-keyword-cluster-builder@claude-skills": true,
+    "react-composition-patterns@claude-skills": true,
+    "sql-query-optimization@claude-skills": true,
+    "security-headers-configuration@claude-skills": true,
+    "tanstack-table@claude-skills": true,
+    "web-performance-optimization@claude-skills": true,
+    "maz-ui@claude-skills": true
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -542,6 +542,17 @@ This script consolidates all plugin management into one command:
 - Before releasing/pushing changes
 - To sync version across all skills
 
+### ⚠️ Versioning: Global Only
+
+`sync-plugins.sh` uses a **single global version** for all 170 plugins. The version is read from `marketplace.json` → `.metadata.version` and stamped onto every `plugin.json` and marketplace entry. There is **no per-plugin versioning**.
+
+To bump version for any plugin change:
+1. Update `.metadata.version` in `.claude-plugin/marketplace.json`
+2. Run `./scripts/sync-plugins.sh`
+3. All plugins receive the same version — this is by design
+
+**Do NOT manually edit** `plugin.json` version or keywords — sync will overwrite them. Keywords are auto-generated from skill name, category, and description.
+
 ### Plugin.json Schema
 
 Each skill's plugin.json follows the [official Claude Code plugin schema](https://docs.claude.com/en/docs/claude-code/plugins-reference). Only `name` is required:

--- a/plugins/access-control-rbac/.claude-plugin/plugin.json
+++ b/plugins/access-control-rbac/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "access-control-rbac",
   "description": "Role-based access control (RBAC) with permissions and policies. Use for admin dashboards, enterprise access, multi-tenant apps, fine-grained authorization, or encountering permission hierarchies, role inheritance, policy conflicts.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/aceternity-ui/.claude-plugin/plugin.json
+++ b/plugins/aceternity-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aceternity-ui",
   "description": "100+ animated React components (Aceternity UI) for Next.js with Tailwind. Use for hero sections, parallax, 3D effects, or encountering animation, shadcn CLI integration errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/aceternity-ui/skills/aceternity-ui/SKILL.md
+++ b/plugins/aceternity-ui/skills/aceternity-ui/SKILL.md
@@ -169,6 +169,16 @@ export function cn(...inputs: ClassValue[]) {
 
 3. Copy component code from [ui.aceternity.com](https://ui.aceternity.com) to your project
 
+## Secure Installation
+
+This setup runs multiple remote code executions (`create-next-app`, `shadcn init`, `shadcn add`). Before installing, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Component Categories
 
 ### 1. Backgrounds & Effects (28 components)

--- a/plugins/ai-elements-chatbot/.claude-plugin/plugin.json
+++ b/plugins/ai-elements-chatbot/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-elements-chatbot",
   "description": "shadcn/ui AI chat components for conversational interfaces. Use for streaming chat, tool/function displays, reasoning visualization, or encountering Next.js App Router setup, Tailwind v4 integration, AI SDK v5 migration errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ai-sdk-core/.claude-plugin/plugin.json
+++ b/plugins/ai-sdk-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-sdk-core",
   "description": "Vercel AI SDK v5 for backend AI (text generation, structured output, tools, agents). Multi-provider. Use for server-side AI or encountering AI_APICallError, AI_NoObjectGeneratedError, streaming failures.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ai-sdk-core/skills/ai-sdk-core/SKILL.md
+++ b/plugins/ai-sdk-core/skills/ai-sdk-core/SKILL.md
@@ -122,6 +122,16 @@ console.log(result.object);
 // { name: "Alice", age: 28, skills: ["TypeScript", "React"] }
 ```
 
+## Secure Installation
+
+This installs 6+ AI provider packages simultaneously — a large dependency surface to audit. Before installing, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ---
 
 ## Core Functions

--- a/plugins/ai-sdk-ui/.claude-plugin/plugin.json
+++ b/plugins/ai-sdk-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-sdk-ui",
   "description": "Vercel AI SDK v5 React hooks (useChat, useCompletion, useObject) for AI chat interfaces. Use for React/Next.js AI apps or encountering parse stream errors, no response, streaming issues.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-authentication/.claude-plugin/plugin.json
+++ b/plugins/api-authentication/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-authentication",
   "description": "Secure API authentication with JWT, OAuth 2.0, API keys. Use for authentication systems, third-party integrations, service-to-service communication, or encountering token management, security headers, auth flow errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-changelog-versioning/.claude-plugin/plugin.json
+++ b/plugins/api-changelog-versioning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-changelog-versioning",
   "description": "Creates comprehensive API changelogs documenting breaking changes, deprecations, and migration strategies for API consumers. Use when managing API versions, communicating breaking changes, or creating upgrade guides.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-contract-testing/.claude-plugin/plugin.json
+++ b/plugins/api-contract-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-contract-testing",
   "description": "Verifies API contracts between services using consumer-driven contracts, schema validation, and tools like Pact. Use when testing microservices communication, preventing breaking changes, or validating OpenAPI specifications.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-design-principles/.claude-plugin/plugin.json
+++ b/plugins/api-design-principles/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-design-principles",
   "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewing API specifications, or establishing API design standards.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-error-handling/.claude-plugin/plugin.json
+++ b/plugins/api-error-handling/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-error-handling",
   "description": "Implements standardized API error responses with proper status codes, logging, and user-friendly messages. Use when building production APIs, implementing error recovery patterns, or integrating error monitoring services.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-filtering-sorting/.claude-plugin/plugin.json
+++ b/plugins/api-filtering-sorting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-filtering-sorting",
   "description": "Builds flexible API filtering and sorting systems with query parameter parsing, validation, and security. Use when implementing search endpoints, building data grids, or creating dynamic query APIs.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-gateway-configuration/.claude-plugin/plugin.json
+++ b/plugins/api-gateway-configuration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-gateway-configuration",
   "description": "Configures API gateways for routing, authentication, rate limiting, and request transformation in microservice architectures. Use when setting up Kong, Nginx, AWS API Gateway, or Traefik for centralized API management.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-pagination/.claude-plugin/plugin.json
+++ b/plugins/api-pagination/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-pagination",
   "description": "Implements efficient API pagination using offset, cursor, and keyset strategies for large datasets. Use when building paginated endpoints, implementing infinite scroll, or optimizing database queries for collections.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-rate-limiting/.claude-plugin/plugin.json
+++ b/plugins/api-rate-limiting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-rate-limiting",
   "description": "Implements API rate limiting using token bucket, sliding window, and Redis-based algorithms to protect against abuse. Use when securing public APIs, implementing tiered access, or preventing denial-of-service attacks.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-reference-documentation/.claude-plugin/plugin.json
+++ b/plugins/api-reference-documentation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-reference-documentation",
   "description": "Creates professional API documentation using OpenAPI specifications with endpoints, authentication, and interactive examples. Use when documenting REST APIs, creating SDK references, or building developer portals.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-response-optimization/.claude-plugin/plugin.json
+++ b/plugins/api-response-optimization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-response-optimization",
   "description": "Optimizes API performance through payload reduction, caching strategies, and compression techniques. Use when improving API response times, reducing bandwidth usage, or implementing efficient caching.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-security-hardening/.claude-plugin/plugin.json
+++ b/plugins/api-security-hardening/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-security-hardening",
   "description": "REST API security hardening with authentication, rate limiting, input validation, security headers. Use for production APIs, security audits, defense-in-depth, or encountering vulnerabilities, injection attacks, CORS issues.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-testing/.claude-plugin/plugin.json
+++ b/plugins/api-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-testing",
   "description": "HTTP API testing for TypeScript (Supertest) and Python (httpx, pytest). Test REST APIs, GraphQL, request/response validation, authentication, and error handling.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-versioning-strategy/.claude-plugin/plugin.json
+++ b/plugins/api-versioning-strategy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-versioning-strategy",
   "description": "Implements API versioning using URL paths, headers, or query parameters with backward compatibility and deprecation strategies. Use when managing multiple API versions, planning breaking changes, or designing migration paths.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/app-store-deployment/.claude-plugin/plugin.json
+++ b/plugins/app-store-deployment/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "app-store-deployment",
   "description": "Publishes mobile applications to iOS App Store and Google Play with code signing, versioning, and CI/CD automation. Use when preparing app releases, configuring signing certificates, or setting up automated deployment pipelines.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/architecture-patterns/.claude-plugin/plugin.json
+++ b/plugins/architecture-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "architecture-patterns",
   "description": "Implement proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design. Use when architecting complex backend systems or refactoring existing applications for better maintainability.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/auto-animate/.claude-plugin/plugin.json
+++ b/plugins/auto-animate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-animate",
   "description": "AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/base-ui-react/.claude-plugin/plugin.json
+++ b/plugins/base-ui-react/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "base-ui-react",
   "description": "MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/better-auth/.claude-plugin/plugin.json
+++ b/plugins/better-auth/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-auth",
   "description": "Skill for integrating Better Auth - comprehensive TypeScript authentication framework for Cloudflare D1, Next.js, Nuxt, and 15+ frameworks. Use when adding auth, encountering D1 adapter errors, or implementing OAuth/2FA/RBAC features.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/better-auth/skills/better-auth/SKILL.md
+++ b/plugins/better-auth/skills/better-auth/SKILL.md
@@ -763,6 +763,16 @@ This skill focuses on **Cloudflare Workers + D1**. better-auth also supports:
 
 ---
 
+## Secure Installation
+
+When installing authentication packages, follow supply chain security best practices — auth libraries are high-value targets for supply chain attacks:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Complete Setup Checklist
 
 - [ ] Verified ESM support (`"type": "module"` in package.json) - v1.4.0+ required

--- a/plugins/better-chatbot-patterns/.claude-plugin/plugin.json
+++ b/plugins/better-chatbot-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-chatbot-patterns",
   "description": "Reusable better-chatbot patterns for custom deployments. Use for server action validators, tool abstraction, multi-AI providers, or encountering auth validation, FormData parsing, workflow execution errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/better-chatbot/.claude-plugin/plugin.json
+++ b/plugins/better-chatbot/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-chatbot",
   "description": "better-chatbot project conventions and standards. Use for contributing code, following three-tier tool system (MCP/Workflow/Default), or encountering server action validators, repository patterns, component design errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/bun/.claude-plugin/plugin.json
+++ b/plugins/bun/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bun",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Comprehensive Bun runtime toolkit covering runtime, package manager, bundler, testing, HTTP servers, WebSockets, databases, framework integrations (Hono, Next.js, Nuxt, TanStack Start, SvelteKit), deployment, and Node.js compatibility.",
   "author": {
     "name": "Claude Skills",

--- a/plugins/bun/skills/bun-cloudflare-workers/SKILL.md
+++ b/plugins/bun/skills/bun-cloudflare-workers/SKILL.md
@@ -25,6 +25,16 @@ bun run dev
 bun run deploy
 ```
 
+## Secure Installation
+
+Scaffolding tools like `bunx create-cloudflare` download and execute remote code. Before running, follow supply chain security best practices:
+
+- **Block post-install scripts** — Bun disables them by default; allow specific packages via `trustedDependencies` in `package.json`
+- **Cooldown period** — Configure `minimumReleaseAge` in `bunfig.toml` to wait 7 days for new versions
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Project Setup
 
 ### package.json

--- a/plugins/bun/skills/bun-docker/SKILL.md
+++ b/plugins/bun/skills/bun-docker/SKILL.md
@@ -305,6 +305,16 @@ USER bun
 CMD ["bun", "run", "dist/index.js"]
 ```
 
+## Secure Installation
+
+When installing packages in Docker builds, follow supply chain security best practices:
+
+- **Block post-install scripts** — Bun disables them by default; allow specific packages via `trustedDependencies`
+- **Pin dependency versions** — Use exact versions in `package.json` for reproducible builds
+- **Audit before installing** — Run `socket package score npm <pkg>` to check packages before they reach your image
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Security Best Practices
 
 ```dockerfile

--- a/plugins/bun/skills/bun-nextjs/SKILL.md
+++ b/plugins/bun/skills/bun-nextjs/SKILL.md
@@ -30,6 +30,16 @@ bun run build
 bun run start
 ```
 
+## Secure Installation
+
+Scaffolding tools like `bunx create-next-app` download and execute remote code. Multiple install contexts (local, Docker) require pinning versions in both. Before running, follow supply chain security best practices:
+
+- **Block post-install scripts** — Bun disables them by default; allow specific packages via `trustedDependencies` in `package.json`
+- **Cooldown period** — Configure `minimumReleaseAge` in `bunfig.toml` to wait 7 days for new versions
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Project Setup
 
 ### package.json

--- a/plugins/bun/skills/bun-nuxt/SKILL.md
+++ b/plugins/bun/skills/bun-nuxt/SKILL.md
@@ -28,6 +28,16 @@ bun run build
 bun run preview
 ```
 
+## Secure Installation
+
+Scaffolding tools like `bunx nuxi init` download and execute remote code. Before running, follow supply chain security best practices:
+
+- **Block post-install scripts** — Bun disables them by default; allow specific packages via `trustedDependencies` in `package.json`
+- **Cooldown period** — Configure `minimumReleaseAge` in `bunfig.toml` to wait 7 days for new versions
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Project Setup
 
 ### package.json

--- a/plugins/bun/skills/bun-package-manager/SKILL.md
+++ b/plugins/bun/skills/bun-package-manager/SKILL.md
@@ -190,6 +190,16 @@ Isolated prevents "phantom dependencies" - packages can only access declared dep
 bun install --cpu=x64 --os=linux
 ```
 
+## Secure Installation
+
+When installing packages, follow supply chain security best practices:
+
+- **Block post-install scripts** — Bun disables them by default; allow specific packages via `trustedDependencies` in `package.json`
+- **Cooldown period** — Configure `minimumReleaseAge` in `bunfig.toml` to wait 7 days for new versions
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages before they reach your project
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Common Errors
 
 | Error | Cause | Fix |

--- a/plugins/bun/skills/bun-sveltekit/SKILL.md
+++ b/plugins/bun/skills/bun-sveltekit/SKILL.md
@@ -30,6 +30,16 @@ bun run build
 bun run preview
 ```
 
+## Secure Installation
+
+Scaffolding tools like `bunx sv create` download and execute remote code. Before running, follow supply chain security best practices:
+
+- **Block post-install scripts** — Bun disables them by default; allow specific packages via `trustedDependencies` in `package.json`
+- **Cooldown period** — Configure `minimumReleaseAge` in `bunfig.toml` to wait 7 days for new versions
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Project Setup
 
 ### package.json

--- a/plugins/bun/skills/bun-tanstack-start/SKILL.md
+++ b/plugins/bun/skills/bun-tanstack-start/SKILL.md
@@ -28,6 +28,16 @@ bun run build
 bun run start
 ```
 
+## Secure Installation
+
+Scaffolding tools like `bunx create-tanstack-start` download and execute remote code. Before running, follow supply chain security best practices:
+
+- **Block post-install scripts** — Bun disables them by default; allow specific packages via `trustedDependencies` in `package.json`
+- **Cooldown period** — Configure `minimumReleaseAge` in `bunfig.toml` to wait 7 days for new versions
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Project Setup
 
 ### package.json

--- a/plugins/chrome-devtools/.claude-plugin/plugin.json
+++ b/plugins/chrome-devtools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "chrome-devtools",
   "description": "Browser automation with Puppeteer CLI scripts. Use for screenshots, performance analysis, network monitoring, web scraping, form automation, or encountering JavaScript debugging, browser automation errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/claude-agent-sdk/.claude-plugin/plugin.json
+++ b/plugins/claude-agent-sdk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-agent-sdk",
   "description": "Anthropic Claude Agent SDK for autonomous agents and multi-step workflows. Use for subagents, tool orchestration, MCP servers, or encountering CLI not found, context length exceeded errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/claude-agent-sdk/skills/claude-agent-sdk/SKILL.md
+++ b/plugins/claude-agent-sdk/skills/claude-agent-sdk/SKILL.md
@@ -79,6 +79,16 @@ for await (const message of response) {
 
 ---
 
+## Secure Installation
+
+Agent SDK packages provide system-level capabilities — verify before installing to prevent unauthorized agent access. Follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## The Complete Claude Agent SDK Reference
 
 ## Table of Contents

--- a/plugins/claude-api/.claude-plugin/plugin.json
+++ b/plugins/claude-api/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-api",
   "description": "Anthropic Messages API (Claude API) for integrations, streaming, prompt caching, tool use, vision. Use for chatbots, assistants, or encountering rate limits, 429 errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/claude-code-bash-patterns/.claude-plugin/plugin.json
+++ b/plugins/claude-code-bash-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-bash-patterns",
   "description": "Claude Code Bash tool patterns with hooks, automation, git workflows. Use for PreToolUse hooks, command chaining, CLI orchestration, custom commands, or encountering bash permissions, command failures, security guards, hook configurations.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/claude-hook-writer/.claude-plugin/plugin.json
+++ b/plugins/claude-hook-writer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hook-writer",
   "description": "Expert guidance for writing secure, reliable, and performant Claude Code hooks - validates design decisions, enforces best practices, and prevents common pitfalls. Use when creating, reviewing, or debugging Claude Code hooks.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-agents/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-agents",
   "description": "Build AI agents on Cloudflare Workers with MCP integration, tool use, and LLM providers.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-browser-rendering/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-browser-rendering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-browser-rendering",
   "description": "Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-cron-triggers/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-cron-triggers/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-cron-triggers",
   "description": "Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-d1/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-d1/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-d1",
   "description": "Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-d1/skills/cloudflare-d1/SKILL.md
+++ b/plugins/cloudflare-d1/skills/cloudflare-d1/SKILL.md
@@ -614,6 +614,16 @@ D1 uses SQLite type affinity:
 
 ---
 
+## Secure Installation
+
+When installing D1 driver packages, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Official Documentation
 
 - **D1 Overview**: https://developers.cloudflare.com/d1/

--- a/plugins/cloudflare-durable-objects/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-durable-objects/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-durable-objects",
   "description": "Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-email-routing/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-email-routing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-email-routing",
   "description": "Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-hyperdrive/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-hyperdrive/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-hyperdrive",
   "description": "Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-images/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-images/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-images",
   "description": "This skill should be used when the user asks to \"upload images to Cloudflare\", \"implement direct creator upload\", \"configure image transformations\", \"optimize WebP/AVIF\", \"create image variants\", \"generate signed URLs\", \"add image watermarks\", \"integrate with Next.js/Remix\", \"configure webhooks\", \"debug CORS errors\", \"troubleshoot error 5408/9401-9413\", or \"build responsive images with Cloudflare Images API\".",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-kv/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-kv/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-kv",
   "description": "Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-manager/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-manager/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-manager",
   "description": "Comprehensive Cloudflare account management for deploying Workers, KV Storage, R2, Pages, DNS, and Routes. Use when deploying cloudflare services, managing worker containers, configuring KV/R2 storage, or setting up DNS/routing. Requires CLOUDFLARE_API_KEY in .env and Bun runtime with dependencies installed.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-mcp-server/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-mcp-server/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-mcp-server",
   "description": "Build MCP (Model Context Protocol) servers on Cloudflare Workers with tools, resources, and prompts.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-nextjs/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-nextjs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-nextjs",
   "description": "Deploy Next.js to Cloudflare Workers via OpenNext adapter. Use for SSR, ISR, App/Pages Router, or encountering worker size limits, runtime compatibility, connection scoping errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-nextjs/skills/cloudflare-nextjs/SKILL.md
+++ b/plugins/cloudflare-nextjs/skills/cloudflare-nextjs/SKILL.md
@@ -115,6 +115,16 @@ To add the OpenNext adapter to an existing Next.js application:
 bun add -d @opennextjs/cloudflare
 ```
 
+##### Secure Installation
+
+Adapter packages handle production traffic — pin exact versions and audit before upgrading. Follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 #### 2. Create wrangler.jsonc
 
 ```jsonc

--- a/plugins/cloudflare-queues/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-queues/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-queues",
   "description": "This skill should be used when the user asks to \"set up Cloudflare Queues\", \"create a message queue\", \"implement queue consumer\", \"process background jobs\", \"configure queue retry logic\", \"publish messages to queue\", \"implement dead letter queue\", or encountering \"queue timeout\", \"message retry\", \"throughput exceeded\", \"queue backlog\" errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-r2/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-r2/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-r2",
   "description": "Cloudflare R2 S3-compatible object storage with SQL, Iceberg, event notifications, and automation. Use for buckets, uploads, CORS, presigned URLs, large files, S3 migration, analytics, or encountering R2_ERROR, CORS failures, multipart issues.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-sandbox/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-sandbox/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-sandbox",
   "description": "Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-sandbox/skills/cloudflare-sandbox/SKILL.md
+++ b/plugins/cloudflare-sandbox/skills/cloudflare-sandbox/SKILL.md
@@ -127,6 +127,16 @@ Expected output:
 }
 ```
 
+## Secure Installation
+
+Sandbox SDK packages grant container access — verify before installing to prevent unauthorized code execution. Follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ---
 
 ## Architecture (Understanding the 3-Layer Model)

--- a/plugins/cloudflare-turnstile/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-turnstile/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-turnstile",
   "description": "Cloudflare Turnstile CAPTCHA-alternative bot protection. Use for forms, login security, API protection, or encountering CSP errors, token validation failures, error codes 100*/300*/600*.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-vectorize/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-vectorize/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-vectorize",
   "description": "Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-vectorize/skills/cloudflare-vectorize/SKILL.md
+++ b/plugins/cloudflare-vectorize/skills/cloudflare-vectorize/SKILL.md
@@ -388,6 +388,16 @@ bunx wrangler vectorize info <name>
 | `templates/document-ingestion.ts` | Document chunking pipeline |
 | `templates/metadata-filtering.ts` | Advanced filtering |
 
+## Secure Installation
+
+When installing vector database packages, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Official Documentation
 
 - [Vectorize Docs](https://developers.cloudflare.com/vectorize/)

--- a/plugins/cloudflare-workers-ai/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-workers-ai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-workers-ai",
   "description": "Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-workers/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-workers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-workers",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Comprehensive Cloudflare Workers platform guide covering runtime APIs, testing (Vitest), CI/CD, observability, framework integration, performance, security, and migration. Use for Workers development, deployment, debugging, or optimization.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-workers/skills/cloudflare-workers-ci-cd/SKILL.md
+++ b/plugins/cloudflare-workers/skills/cloudflare-workers-ci-cd/SKILL.md
@@ -658,6 +658,16 @@ Load reference files for detailed, specialized content:
 
 ---
 
+## Secure Installation
+
+When installing CI/CD dependencies, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Frozen lockfiles in CI** — Always use `npm ci` or `bun install --frozen-lockfile`
+- **Security gate** — Add `socket ci` to your CI pipeline to block PRs that violate your security policy
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Related Cloudflare Plugins
 
 **For deployment testing, load:**

--- a/plugins/cloudflare-workers/skills/cloudflare-workers-dev-experience/SKILL.md
+++ b/plugins/cloudflare-workers/skills/cloudflare-workers-dev-experience/SKILL.md
@@ -23,6 +23,16 @@ bun add -d wrangler @cloudflare/workers-types
 bunx wrangler dev
 ```
 
+## Secure Installation
+
+Scaffolding tools like `bunx create-cloudflare` download and execute remote code. Before running, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Essential wrangler.jsonc
 
 ```jsonc

--- a/plugins/cloudflare-workflows/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-workflows",
   "description": "Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-zero-trust-access/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-zero-trust-access/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-zero-trust-access",
   "description": "Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review practices with technical rigor and verification gates. Use for receiving feedback, requesting code-reviewer subagent reviews, or preventing false completion claims in pull requests.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/content-collections/.claude-plugin/plugin.json
+++ b/plugins/content-collections/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "content-collections",
   "description": "Content Collections TypeScript-first build tool for Markdown/MDX content. Use for blogs, docs, content sites with Vite + React, MDX components, type-safe Zod schemas, Contentlayer migration, or encountering TypeScript import errors, path alias issues, collection validation errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/csrf-protection/.claude-plugin/plugin.json
+++ b/plugins/csrf-protection/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "csrf-protection",
   "description": "Implements CSRF protection using synchronizer tokens, double-submit cookies, and SameSite attributes. Use when securing web forms, protecting state-changing endpoints, or implementing defense-in-depth authentication.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/database-schema-design/.claude-plugin/plugin.json
+++ b/plugins/database-schema-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "database-schema-design",
   "description": "Database schema design for PostgreSQL/MySQL with normalization, relationships, constraints. Use for new databases, schema reviews, migrations, or encountering missing PKs/FKs, wrong data types, premature denormalization, EAV anti-pattern.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/database-sharding/.claude-plugin/plugin.json
+++ b/plugins/database-sharding/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "database-sharding",
   "description": "Database sharding for PostgreSQL/MySQL with hash/range/directory strategies. Use for horizontal scaling, multi-tenant isolation, billions of records, or encountering wrong shard keys, hotspots, cross-shard transactions, rebalancing issues.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/defense-in-depth-validation/.claude-plugin/plugin.json
+++ b/plugins/defense-in-depth-validation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "defense-in-depth-validation",
   "description": "Validate at every layer data passes through to make bugs impossible. Use when invalid data causes failures deep in execution, requiring validation at multiple system layers.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/dependency-upgrade/.claude-plugin/plugin.json
+++ b/plugins/dependency-upgrade/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependency-upgrade",
-  "description": "Secure dependency upgrades with supply chain protection, cooldown periods, post-install script hardening, lockfile validation, and staged rollout across npm, Bun, pnpm, and Yarn. Use when upgrading dependencies, configuring security policies, or preventing supply chain attacks.",
-  "version": "3.3.0",
+  "description": "Secure dependency upgrades with supply chain protection, cooldowns, staged rollout, and Socket CLI integration. Use when upgrading deps, configuring security policies, or preventing supply chain attacks.",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"
@@ -14,6 +14,6 @@
     "upgrade",
     "tooling",
     "workflow",
-    "validation"
+    "cli"
   ]
 }

--- a/plugins/dependency-upgrade/skills/dependency-upgrade/SKILL.md
+++ b/plugins/dependency-upgrade/skills/dependency-upgrade/SKILL.md
@@ -97,14 +97,19 @@ Always ask these 3 questions before generating any config:
 | Biweekly | `"biweekly"` |
 | Monthly | `"monthly"` |
 
-**7. Install-Time Auditing**
+**7. Install-Time Security Tooling**
 
-| Option | Installs |
-|--------|----------|
-| npq | Pre-install package auditor (open source) |
-| Socket Firewall (sfw) | Real-time malicious package blocker |
-| Both | Both tools with shell aliases |
-| None | Skip |
+"Which security tools should protect dependency installation?"
+
+| Option | Free? | What It Does |
+|--------|-------|-------------|
+| socket npm wrapper | Yes (beta) | Wraps npm/npx, blocks malicious packages before install. Run `socket wrapper on` to enable system-wide. |
+| npq | Yes | Pre-install auditor (CVE, typosquat, age, provenance checks) |
+| Socket Firewall (sfw) | No | Real-time deep analysis, blocks malicious packages |
+| socket npm + npq | Yes | Both free tools combined |
+| None | — | Skip |
+
+Load `references/socket-cli-guide.md` for full Socket CLI setup including authentication and free vs authenticated features.
 
 **8. Lockfile Validation**
 
@@ -131,9 +136,10 @@ Always ask these 3 questions before generating any config:
 2. **Block post-install scripts** — Prevent arbitrary code execution during `npm install`
 3. **Freeze lockfiles in CI** — Use deterministic installs (`npm ci`, `--frozen-lockfile`)
 4. **Validate lockfile integrity** — Use `lockfile-lint` to detect injection
-5. **Audit before trusting** — Use `npq` or `sfw` to check packages before installing
+5. **Audit before trusting** — Use `npq` or Socket CLI to check packages before installing
 6. **Upgrade incrementally** — One major version at a time with testing between each
 7. **Never blindly upgrade** — Avoid `npm update` or `npm-check-updates -u` without review
+8. **Scan before and after** — Use `socket scan` to detect supply chain issues beyond CVEs
 
 ## Cooldown Period: Prevent Supply Chain Attacks
 
@@ -260,6 +266,49 @@ sfw yarn add <package>
 
 Load `references/supply-chain-security.md` for full comparison of npq vs sfw and what each validates.
 
+## Socket CLI Integration
+
+Socket CLI provides proactive supply chain security beyond basic vulnerability scanning — covering malware detection, typosquatting, protestware, install script risks, and license compliance.
+
+### Proactive Upgrade Workflow
+
+```
+1. PRE-UPGRADE:   socket scan create --report          → establish baseline
+2. EVALUATE:      socket package score npm <pkg>@<ver>  → assess target package safety
+3. SAFE INSTALL:  socket npm install <pkg>              → block malicious packages
+4. POST-UPGRADE:  socket scan create --report          → verify no new alerts
+5. DIFF:          socket scan diff <before> <after>     → see exactly what changed
+6. FIX:           socket fix --minimum-release-age 7d   → auto-fix any new CVEs
+7. OPTIMIZE:      socket optimize                       → apply security overrides
+```
+
+### Quick Reference
+
+```bash
+# Install
+npm install -g socket
+
+# Authenticate (required for scans, fixes, package scores)
+socket login
+
+# Check a package before upgrading
+socket package score npm <package>
+
+# Scan your whole project
+socket scan create --report
+
+# Auto-fix CVEs (complements Dependabot/Renovate)
+socket fix --minimum-release-age 7d
+
+# Gate CI on security policy
+socket ci
+
+# Safe npm wrapper (free, no auth needed)
+socket wrapper on
+```
+
+Load `references/socket-cli-guide.md` for comprehensive command reference, CI workflow templates, alert categories, and free vs authenticated feature matrix.
+
 ## Dependency Analysis
 
 ```bash
@@ -267,6 +316,10 @@ Load `references/supply-chain-security.md` for full comparison of npq vs sfw and
 bun audit       # Bun
 npm audit       # npm
 yarn audit      # Yarn
+
+# Socket: deep security assessment (CVEs + supply chain + license)
+socket package score npm <package>
+socket scan create --report
 
 # Check for outdated packages
 bun outdated
@@ -288,13 +341,22 @@ Upgrade one dependency at a time with testing between each:
 # 1. Create feature branch
 git checkout -b upgrade/<package>-<version>
 
-# 2. Upgrade single package
+# 2. (Optional) Baseline scan — capture current state
+socket scan create --report
+
+# 3. Evaluate target package before upgrading
+socket package score npm <package>@<version>
+
+# 4. Upgrade single package
 bun add <package>@<version>
 
-# 3. Test immediately
+# 5. Test immediately
 bun test && bunx tsc --noEmit && bun run build
 
-# 4. Commit and continue
+# 6. (Optional) Post-upgrade scan — verify no new alerts
+socket scan create --report
+
+# 7. Commit and continue
 git add -A && git commit -m "chore: upgrade <package> to <version>"
 ```
 
@@ -342,6 +404,28 @@ updates:
 ### Snyk
 
 Snyk includes a built-in 21-day cooldown for upgrade PRs. No configuration needed.
+
+### Socket Fix (complements Dependabot/Renovate)
+
+Socket Fix automatically resolves CVEs with intelligent upgrade planning. Runs alongside other automation tools — it focuses on CVE remediation specifically:
+
+```bash
+# Fix all fixable CVEs with cooldown alignment
+socket fix --minimum-release-age 7d
+
+# Conservative: no major version bumps
+socket fix --minimum-release-age 7d --no-major-updates
+
+# Target specific CVEs
+socket fix --id GHSA-hhq3-ff78-jv3g --minimum-release-age 7d
+
+# Preview without applying
+socket fix --no-apply-fixes --minimum-release-age 7d
+```
+
+For CI autopilot mode (auto-creates and auto-merges fix PRs), use `templates/socket-fix-ci.tmpl`.
+
+Load `references/socket-cli-guide.md` for full `socket fix` options including `--autopilot`, `--range-style`, and `--pr-limit`.
 
 Use `templates/dependabot-security.tmpl` or `templates/renovate-security.tmpl` for complete config files.
 
@@ -431,9 +515,11 @@ Security Pre-Checks:
 - [ ] Lockfile validation is active
 - [ ] Install auditing tools configured (if applicable)
 - [ ] CI uses frozen-lockfile install
+- [ ] Run `socket scan create --report` for baseline (if Socket available)
 
 During Upgrade:
 - [ ] Upgrade one dependency at a time
+- [ ] Check target package: `socket package score npm <pkg>` (if Socket available)
 - [ ] Respect cooldown period (don't force latest)
 - [ ] Update peer dependencies
 - [ ] Fix TypeScript errors
@@ -441,6 +527,8 @@ During Upgrade:
 - [ ] Check bundle size impact
 
 Post-Upgrade:
+- [ ] Post-upgrade scan: `socket scan diff` to verify no new alerts (if Socket available)
+- [ ] Consider `socket fix --minimum-release-age 7d` for any new CVEs
 - [ ] Full regression testing
 - [ ] Performance testing
 - [ ] Update documentation
@@ -471,8 +559,9 @@ Load these reference files when the user needs detailed information beyond the q
 |---------------|------|
 | `references/cooldown-config-guide.md` | Configuring cooldown for a specific PM, CI tool integration, or exclusion patterns |
 | `references/package-manager-security.md` | Full per-PM hardening guide including pnpm trust policy, blockExoticSubdeps, cross-PM cheat sheet |
-| `references/supply-chain-security.md` | Understanding attack vectors, incident history, npq vs sfw comparison, publisher security (2FA, provenance, OIDC) |
+| `references/supply-chain-security.md` | Understanding attack vectors, incident history, npq vs sfw vs Socket CLI comparison, publisher security (2FA, provenance, OIDC) |
 | `references/secrets-and-containers.md` | Setting up dev containers, secrets management with 1Password/Infisical |
+| `references/socket-cli-guide.md` | Using Socket CLI for scans, fixes, package scoring, CI integration, wrapper mode, alert categories |
 | `references/compatibility-matrix.md` | Checking version compatibility for React, Next.js, TypeScript, Tailwind upgrades |
 | `references/staged-upgrades.md` | Codemod automation, custom migration scripts, peer dependency handling, workspace upgrades |
 | `references/testing-strategy.md` | Full testing pyramid, CI integration, bundle analysis, performance testing |
@@ -490,3 +579,5 @@ Ready-to-use config files in `templates/`:
 | `dependabot-security.tmpl` | Dependabot config with 7-day cooldown |
 | `renovate-security.tmpl` | Renovate config with minimumReleaseAge + automerge rules |
 | `devcontainer-security.tmpl` | Hardened dev container with security options |
+| `socket-fix-ci.tmpl` | GitHub Actions: Socket Fix autopilot with cooldown-aligned CVE remediation |
+| `socket-scan-ci.tmpl` | GitHub Actions: Socket CI security gate for every push/PR |

--- a/plugins/dependency-upgrade/skills/dependency-upgrade/references/socket-cli-guide.md
+++ b/plugins/dependency-upgrade/skills/dependency-upgrade/references/socket-cli-guide.md
@@ -1,0 +1,418 @@
+# Socket CLI Guide
+
+Comprehensive reference for using Socket CLI to secure dependency upgrades with proactive scanning, automated CVE fixing, and CI enforcement.
+
+## Installation & Authentication
+
+```bash
+npm install -g socket
+```
+
+### Authentication
+
+```bash
+# Interactive login (stores token locally)
+socket login
+
+# Or set API token via environment variable
+export SOCKET_SECURITY_API_TOKEN=your-token-here
+
+# Or per-command
+SOCKET_SECURITY_API_TOKEN=xyz socket scan create --report
+```
+
+Generate API tokens at: https://socket.dev/settings/api-keys
+
+Required permissions vary per command (see each section below).
+
+### Free vs Authenticated Features
+
+| Feature | Free (No Token) | Authenticated |
+|---------|-----------------|---------------|
+| `socket npm` / `socket npx` | Yes (beta, default issues only) | Yes |
+| `socket wrapper on/off` | Yes | Yes |
+| `socket package shallow` | No | Yes (1 unit/pkg) |
+| `socket package score` (deep) | No | Yes (1 unit/pkg) |
+| `socket scan create` | No | Yes (1 unit) |
+| `socket scan report` | No | Yes (2 units) |
+| `socket ci` | No | Yes (1 unit + report) |
+| `socket fix` | No | Yes (101 units) |
+| `socket optimize` | No | Yes |
+
+## Package Assessment
+
+Evaluate packages before adding or upgrading them.
+
+### Shallow Score (package only)
+
+Quick assessment of a single package excluding its dependencies:
+
+```bash
+socket package shallow npm express
+socket package shallow npm express@4.18.2
+
+# Multiple packages, mixed ecosystems
+socket package shallow pkg:npm/express pkg:pypi/requests
+
+# Output formats
+socket package shallow npm express --json
+socket package shallow npm express --markdown
+```
+
+Returns scores for: Supply Chain Risk, Maintenance, Quality, Vulnerabilities, License.
+Also lists detected alerts with severity levels.
+
+### Deep Score (package + all transitives)
+
+Full assessment including all transitive dependencies:
+
+```bash
+socket package score npm eslint
+socket package score npm eslint --markdown
+
+# Specify exact version via purl
+socket package score 'pkg:npm/[email protected]'
+```
+
+The deep score reflects the minimum score across all transitive dependencies. A package with a high shallow score can have a low deep score if one of its dependencies is risky.
+
+### When to Use Each
+
+| Scenario | Use | Why |
+|----------|-----|-----|
+| Quick check before installing | `shallow` | Fast, evaluates just the target |
+| Evaluating a major upgrade | `score` (deep) | Catches transitive supply chain risks |
+| CI policy gate | `scan` (not package) | Evaluates your whole project |
+| Comparing two packages | `shallow` | Quick side-by-side comparison |
+
+## Project Scanning
+
+Scan your entire project for security issues.
+
+### Create a Scan
+
+```bash
+# Basic scan (auto-detects manifest files)
+socket scan create
+
+# Scan with policy report (recommended)
+socket scan create --report
+
+# Associate with repo/branch (for dashboard)
+socket scan create --repo=my-project --branch=main --default-branch --report
+
+# JSON output for automation
+socket scan create --report --json
+
+# Markdown output for sharing
+socket scan create --report --markdown
+```
+
+A scan uploads manifest files (package.json, requirements.txt, etc.) to Socket for analysis. No source code is sent.
+
+**API requirements**: 1 unit + `full-scans:create` permission. Report adds 2 units + `full-scans:list` + `security-policy:read`.
+
+### CI Gate: `socket ci`
+
+Shorthand for `socket scan create --report`. Creates a scan and exits with code 0 if the project passes your org's security policy, non-zero otherwise:
+
+```bash
+socket ci
+```
+
+Use in CI pipelines to block merges that introduce security policy violations.
+
+### Scan Reports
+
+```bash
+# View scan report with alert folding
+socket scan report <SCAN_ID> --fold=version --json
+
+# Include license policy
+socket scan report <SCAN_ID> --license --markdown
+
+# Quick health check (just true/false)
+socket scan report <SCAN_ID> --short
+```
+
+Fold levels: `none` (every occurrence) → `file` → `version` (recommended) → `pkg`.
+
+## Scan Diffs
+
+Compare two scans to see exactly what changed between upgrades:
+
+```bash
+socket scan diff <SCAN_ID_BEFORE> <SCAN_ID_AFTER>
+
+# JSON for automation
+socket scan diff <ID1> <ID2> --json > scan-delta.json
+
+# Markdown for PR comments
+socket scan diff <ID1> <ID2> --markdown
+```
+
+Shows packages added, removed, and changed — plus any new or resolved alerts.
+
+**API requirements**: 1 unit + `full-scans:list` permission.
+
+## Automated CVE Fixing: `socket fix`
+
+Automatically upgrade vulnerable dependencies to secure versions with intelligent upgrade planning.
+
+### Basic Usage
+
+```bash
+# Fix all fixable vulnerabilities
+socket fix
+
+# Fix specific CVEs
+socket fix --id GHSA-hhq3-ff78-jv3g
+socket fix --id CVE-2021-23337
+
+# Multiple IDs
+socket fix --id GHSA-xxxx-xxxx-xxxx,GHSA-yyyy-yyyy-yyyy
+socket fix --id GHSA-xxxx --id GHSA-yyyy
+
+# Fix in specific project directory
+socket fix ./path/to/project
+```
+
+### Cooldown-Aligned Fixing
+
+Align with your cooldown policy using `--minimum-release-age`:
+
+```bash
+# Only fix with packages vetted for at least 7 days (matches recommended cooldown)
+socket fix --minimum-release-age 7d
+
+# Conservative: 14 days
+socket fix --minimum-release-age 14d
+
+# Aggressive: 3 days
+socket fix --minimum-release-age 3d
+```
+
+Time formats: `1h` (hours), `3d` (days), `2w` (weeks).
+
+### Conservative Options
+
+```bash
+# Don't suggest major version upgrades (less risk of breakage)
+socket fix --no-major-updates
+
+# Preview changes without applying them
+socket fix --no-apply-fixes
+
+# Output suggested fixes to file
+socket fix --no-apply-fixes --output-file suggested-fixes.json
+
+# Show which direct deps introduce transitive CVEs
+socket fix --show-affected-direct-dependencies --output-file fixes.json
+
+# Pin to exact versions instead of preserving ranges
+socket fix --range-style pin
+```
+
+### CI/PR Mode (Autopilot)
+
+Run in GitHub Actions to automatically create fix PRs:
+
+```bash
+# Create PRs for fixable CVEs (auto-merge if checks pass)
+socket fix --autopilot
+
+# Limit number of PRs per run
+socket fix --autopilot --pr-limit 5
+```
+
+Required environment variables for CI:
+- `SOCKET_CLI_GITHUB_TOKEN` (or `GITHUB_TOKEN`) — for PR creation
+- `SOCKET_CLI_GIT_USER_NAME` — git commit author name
+- `SOCKET_CLI_GIT_USER_EMAIL` — git commit author email
+- `SOCKET_CLI_API_TOKEN` — Socket API token
+
+**API requirements**: 101 units + `full-scans:create` + `packages:list` permissions.
+
+### Output Formats
+
+```bash
+socket fix --json
+socket fix --markdown > security-fixes.md
+```
+
+## Dependency Optimization: `socket optimize`
+
+Apply `@socketregistry` overrides to patch known issues without changing direct dependency versions:
+
+```bash
+# Apply overrides
+socket optimize
+
+# Pin overrides to exact versions
+socket optimize --pin
+
+# Production dependencies only
+socket optimize --prod
+
+# For a specific project
+socket optimize ./path/to/project
+```
+
+This adds `overrides` (npm/pnpm) or `resolutions` (yarn) to your package.json that redirect vulnerable transitive dependencies to Socket's secure patches.
+
+## Safe Install Wrappers
+
+### `socket npm` and `socket npx`
+
+Run npm/npx through Socket to check packages before installation:
+
+```bash
+# Install with Socket protection
+socket npm install express
+socket npm install -g typescript
+
+# Run commands safely
+socket npx create-react-app my-app
+```
+
+These wrappers intercept the actual npm/npx resolution, check all resolved packages against Socket's database, and prompt before installing flagged packages.
+
+**Beta limitations**: Uses default issue set only (not configurable without auth). Windows limited to WSL.
+
+### System-Wide Wrapper: `socket wrapper`
+
+Enable automatic interception of all npm/npx commands on your system:
+
+```bash
+# Enable (creates shell aliases)
+socket wrapper on
+
+# Disable
+socket wrapper off
+```
+
+After enabling, any `npm install ...` command automatically runs through Socket. Requires restarting your shell or sourcing your RC file (e.g., `source ~/.zshrc`).
+
+### Manual Shell Aliases
+
+```bash
+# Add to ~/.zshrc or ~/.bashrc
+alias npm="socket-npm"
+alias npx="socket-npx"
+
+# zsh autocompletions
+compdef _npm socket-npm
+
+# bash autocompletions
+$(complete -p npm | sed 's/npm$/socket-npm/')
+```
+
+### Combining with npq
+
+npq (pre-install auditor) can use socket-npm as its package manager:
+
+```bash
+NPQ_PKG_MGR=socket-npm npq install express
+```
+
+Note: `socket npm` performs full transitive analysis and integrates into npm's install flow, so it's more thorough than npq's checks. Running both may be redundant.
+
+## Project Configuration: `socket.json`
+
+Store per-project defaults to avoid repeating flags:
+
+```bash
+# Interactive setup
+socket scan setup
+```
+
+Creates `socket.json` in the project root:
+
+```json
+{
+  "repo": "my-project",
+  "branch": "main",
+  "defaultBranch": true
+}
+```
+
+After setup, `socket scan create` automatically uses these values. Flags still override config.
+
+Commit `socket.json` to share defaults with your team, or add to `.gitignore` for personal use.
+
+## Alert Categories Quick Reference
+
+Socket detects issues across five categories:
+
+### Supply Chain Risk (most critical for upgrades)
+- **malware** — Known malicious package
+- **didYouMean** — Possible typosquat (similar name to popular package)
+- **gptMalware** — AI-detected malware
+- **troll** — Protestware or potentially unwanted behavior
+- **obfuscatedFile** — Obfuscated code detected
+- **installScripts** — Pre/post-install scripts present
+- **manifestConfusion** — Mismatch between package.json and tarball
+
+### Vulnerability
+- **criticalCVE**, **cve**, **mediumCVE**, **mildCVE** — Known CVEs by severity
+
+### Quality
+- **deprecated** — Package is deprecated
+- **unmaintained** — No recent maintenance activity
+- **unpopularPackage** — Very low download counts
+
+### Maintenance
+- Part of quality category; signals inactive packages
+
+### License
+- **noLicenseFound** — No license file detected
+- **copyleftLicense** — Copyleft license may restrict usage
+- **nonpermissiveLicense** — Non-permissive terms
+
+## Proactive Upgrade Workflow with Socket CLI
+
+Integrate Socket into every stage of dependency management:
+
+```
+1. PRE-UPGRADE:   socket scan create --report          → baseline scan
+2. EVALUATE:      socket package score npm <pkg>@<ver>  → assess target safety
+3. SAFE INSTALL:  socket npm install <pkg>              → block malicious packages
+4. POST-UPGRADE:  socket scan create --report          → verify no regressions
+5. DIFF:          socket scan diff <before> <after>     → see exactly what changed
+6. FIX:           socket fix --minimum-release-age 7d   → auto-fix any new CVEs
+7. OPTIMIZE:      socket optimize                       → apply security overrides
+```
+
+### Quick Reference: Command Cheat Sheet
+
+| Command | Purpose | Auth Required |
+|---------|---------|---------------|
+| `socket npm install <pkg>` | Install with malware check | No (beta) |
+| `socket npx <cmd>` | Run with malware check | No (beta) |
+| `socket wrapper on` | Auto-protect all npm/npx | No |
+| `socket package shallow npm <pkg>` | Quick package score | Yes |
+| `socket package score npm <pkg>` | Deep score (with transitives) | Yes |
+| `socket scan create --report` | Full project scan | Yes |
+| `socket scan diff <id1> <id2>` | Compare two scans | Yes |
+| `socket ci` | CI gate (scan + policy check) | Yes |
+| `socket fix` | Auto-fix CVEs | Yes |
+| `socket fix --minimum-release-age 7d` | Fix with cooldown alignment | Yes |
+| `socket fix --no-major-updates` | Fix without major bumps | Yes |
+| `socket fix --no-apply-fixes` | Preview fixes without applying | Yes |
+| `socket fix --autopilot` | CI auto-fix with PR creation | Yes |
+| `socket optimize` | Apply security overrides | Yes |
+| `socket login` | Store API token locally | — |
+| `socket scan setup` | Create socket.json defaults | — |
+
+## Supported Ecosystems
+
+Socket CLI supports:
+- **JavaScript/TypeScript**: npm, pnpm (v6+), Yarn (classic + berry), Bun
+- **Python**: pip, uv (requirements.txt, uv.lock)
+- **Java**: Maven, Gradle (with gradle.lockfile)
+- **Ruby**: RubyGems
+- **Go**: go.sum/go.mod
+- **Rust**: Cargo
+- **C#**: NuGet (packages.lock.json coming soon)
+
+`socket npm` / `socket npx` wrappers only work with npm. For other package managers, use `socket scan create` for analysis and `socket fix` for remediation.

--- a/plugins/dependency-upgrade/skills/dependency-upgrade/references/supply-chain-security.md
+++ b/plugins/dependency-upgrade/skills/dependency-upgrade/references/supply-chain-security.md
@@ -250,13 +250,20 @@ What sfw checks:
 
 ### Comparison
 
-| Feature | npq | sfw |
-|---------|-----|-----|
-| Analysis | Pre-install marshalls | Real-time deep analysis |
-| Data sources | Snyk CVE, npm metadata | Socket proprietary intelligence |
-| Interactivity | Prompts before install | Blocks and prompts flagged packages |
-| PM support | npm, pnpm, Bun (env vars) | npm, yarn, pnpm, pip, uv, cargo |
-| Open source | Yes | Client only |
+| Feature | npq | sfw | Socket CLI (`socket npm`) |
+|---------|-----|-----|---------------------------|
+| Analysis | Pre-install marshalls | Real-time deep analysis | Full transitive scan via npm integration |
+| Data sources | Snyk CVE, npm metadata | Socket proprietary intelligence | Socket proprietary intelligence |
+| Interactivity | Prompts before install | Blocks and prompts flagged packages | Prompts before installing flagged packages |
+| PM support | npm, pnpm, Bun (env vars) | npm, yarn, pnpm, pip, uv, cargo | npm, npx (wrapper mode) |
+| Open source | Yes | Client only | Client only (open source on GitHub) |
+| Free tier | Yes | No | Yes (beta, default issues only) |
+| CI integration | No | No | Yes (`socket ci`, `socket fix --autopilot`) |
+| Package scoring | No | No | Yes (`socket package score`) |
+| CVE auto-fixing | No | No | Yes (`socket fix`) |
+| Requires auth | No | Yes | No for wrapper, Yes for scans/fix |
+
+See `references/socket-cli-guide.md` for full Socket CLI documentation.
 
 ## Publisher Security
 

--- a/plugins/dependency-upgrade/skills/dependency-upgrade/templates/socket-fix-ci.tmpl
+++ b/plugins/dependency-upgrade/skills/dependency-upgrade/templates/socket-fix-ci.tmpl
@@ -1,0 +1,46 @@
+# Socket Fix CI Workflow
+# Automatically fixes CVEs with Socket and creates PRs
+# Runs twice daily. Complements Dependabot/Renovate.
+# Requires: SOCKET_CLI_API_TOKEN secret in GitHub repo/org settings
+#
+# Docs: https://docs.socket.dev/docs/socket-fix
+
+name: socket-fix
+on:
+  schedule:
+    - cron: '0 0 * * *'
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  socket-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      # -- uncomment and adjust for your package manager --
+      # - name: Setup pnpm
+      #   uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+      #   with:
+      #     version: '^10.16.0'
+      # - name: Setup Node.js
+      #   uses: actions/setup-node@v4
+      #   with:
+      #     node-version: "22"
+      #     cache: 'pnpm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Socket Fix
+        env:
+          SOCKET_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOCKET_CLI_GIT_USER_EMAIL: socket-fix[bot]@users.noreply.github.com
+          SOCKET_CLI_GIT_USER_NAME: socket-fix[bot]
+          SOCKET_CLI_API_TOKEN: ${{ secrets.SOCKET_CLI_API_TOKEN }}
+        run: npx @socketsecurity/cli fix --autopilot --minimum-release-age 7d

--- a/plugins/dependency-upgrade/skills/dependency-upgrade/templates/socket-scan-ci.tmpl
+++ b/plugins/dependency-upgrade/skills/dependency-upgrade/templates/socket-scan-ci.tmpl
@@ -1,0 +1,37 @@
+# Socket CI Security Gate
+# Blocks PRs that violate your organization's security policy
+# Runs on every push and pull request
+#
+# Requires: SOCKET_SECURITY_API_KEY secret in GitHub repo/org settings
+# Docs: https://docs.socket.dev/docs/socket-ci
+
+name: socket-security
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: socket-scan-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  socket-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Socket CLI
+        run: npm install -g socket
+
+      - name: Run Socket CI Gate
+        env:
+          SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+        run: socket ci

--- a/plugins/design-review/.claude-plugin/plugin.json
+++ b/plugins/design-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "design-review",
   "description": "7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/design-system-creation/.claude-plugin/plugin.json
+++ b/plugins/design-system-creation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "design-system-creation",
   "description": "Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/drizzle-orm-d1/.claude-plugin/plugin.json
+++ b/plugins/drizzle-orm-d1/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drizzle-orm-d1",
   "description": "Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transaction errors, foreign key constraint failures, or schema inference issues.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/drizzle-orm-d1/skills/drizzle-orm-d1/SKILL.md
+++ b/plugins/drizzle-orm-d1/skills/drizzle-orm-d1/SKILL.md
@@ -262,6 +262,16 @@ export type NewUser = InferInsertModel<typeof users>;
 
 ---
 
+## Secure Installation
+
+When installing Drizzle ORM and D1 driver packages, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Official Documentation
 
 - **Drizzle ORM**: https://orm.drizzle.team/

--- a/plugins/elevenlabs-agents/.claude-plugin/plugin.json
+++ b/plugins/elevenlabs-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "elevenlabs-agents",
   "description": "ElevenLabs Agents Platform for AI voice agents (React/JS/Native/Swift). Use for voice AI, RAG, tools, or encountering package deprecation, audio cutoff, CSP violations, webhook auth failures.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/elevenlabs-agents/skills/elevenlabs-agents/SKILL.md
+++ b/plugins/elevenlabs-agents/skills/elevenlabs-agents/SKILL.md
@@ -373,6 +373,16 @@ Composes with:
 
 ---
 
+## Secure Installation
+
+When installing AI agent SDK packages, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Resources
 
 **Templates** (`templates/`):

--- a/plugins/fastmcp/.claude-plugin/plugin.json
+++ b/plugins/fastmcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fastmcp",
   "description": "FastMCP Python framework for MCP servers with tools, resources, storage backends (memory/disk/Redis/DynamoDB). Use for Claude tool exposure, OAuth Proxy, cloud deployment, or encountering storage, lifespan, middleware, circular import, async errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/feature-dev/.claude-plugin/plugin.json
+++ b/plugins/feature-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "feature-dev",
   "description": "Automate 7-phase feature development with specialized agents (code-explorer, code-architect, code-reviewer). Use for multi-file features, architectural decisions, or encountering ambiguous requirements, integration patterns, design approach errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/firecrawl-scraper/.claude-plugin/plugin.json
+++ b/plugins/firecrawl-scraper/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "firecrawl-scraper",
   "description": "Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/frontend-design/.claude-plugin/plugin.json
+++ b/plugins/frontend-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend-design",
   "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/gemini-cli/.claude-plugin/plugin.json
+++ b/plugins/gemini-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gemini-cli",
   "description": "Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/github-project-automation/.claude-plugin/plugin.json
+++ b/plugins/github-project-automation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github-project-automation",
   "description": "GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/google-gemini-api/.claude-plugin/plugin.json
+++ b/plugins/google-gemini-api/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google-gemini-api",
   "description": "Google Gemini API with @google/genai SDK. Use for multimodal AI, thinking mode, function calling, or encountering SDK deprecation warnings, context errors, multimodal format errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/google-gemini-embeddings/.claude-plugin/plugin.json
+++ b/plugins/google-gemini-embeddings/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google-gemini-embeddings",
   "description": "Google Gemini embeddings API (gemini-embedding-001) for RAG and semantic search. Use for vector search, Vectorize integration, or encountering dimension mismatches, rate limits, text truncation.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/google-gemini-file-search/.claude-plugin/plugin.json
+++ b/plugins/google-gemini-file-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google-gemini-file-search",
   "description": "Google Gemini File Search for managed RAG with 100+ file formats. Use for document Q&A, knowledge bases, or encountering immutability errors, quota issues, polling failures. Supports Gemini 3 Pro/Flash (Gemini 2.5 legacy).",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/graphql-implementation/.claude-plugin/plugin.json
+++ b/plugins/graphql-implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "graphql-implementation",
   "description": "Builds GraphQL APIs with schema design, resolvers, error handling, and performance optimization using Apollo or Graphene. Use when creating flexible query APIs, migrating from REST, or implementing real-time subscriptions.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/health-check-endpoints/.claude-plugin/plugin.json
+++ b/plugins/health-check-endpoints/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "health-check-endpoints",
   "description": "Health check endpoints for liveness, readiness, dependency monitoring. Use for Kubernetes, load balancers, auto-scaling, or encountering probe failures, startup delays, dependency checks, timeout configuration errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/hono-routing/.claude-plugin/plugin.json
+++ b/plugins/hono-routing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hono-routing",
   "description": "Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/hono-routing/skills/hono-routing/SKILL.md
+++ b/plugins/hono-routing/skills/hono-routing/SKILL.md
@@ -473,6 +473,16 @@ export default app
 
 ---
 
+## Secure Installation
+
+When installing Hono and middleware packages, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Complete Setup Checklist
 
 - [ ] Installed Hono (`bun add hono`)

--- a/plugins/hugo/.claude-plugin/plugin.json
+++ b/plugins/hugo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hugo",
   "description": "Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/idempotency-handling/.claude-plugin/plugin.json
+++ b/plugins/idempotency-handling/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "idempotency-handling",
   "description": "Idempotent API operations with idempotency keys, Redis caching, DB constraints. Use for payment systems, webhook retries, safe retries, or encountering duplicate processing, race conditions, key expiry errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/image-optimization/.claude-plugin/plugin.json
+++ b/plugins/image-optimization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "image-optimization",
   "description": "Optimizes images for web performance using modern formats, responsive techniques, and lazy loading strategies. Use when improving page load times, implementing responsive images, or preparing assets for production deployment.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/inspira-ui/.claude-plugin/plugin.json
+++ b/plugins/inspira-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inspira-ui",
   "description": "120+ Vue/Nuxt animated components with TailwindCSS v4, motion-v, GSAP, Three.js. Use for hero sections, 3D effects, interactive backgrounds, or encountering setup, CSS variables, motion-v integration errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/inspira-ui/skills/inspira-ui/SKILL.md
+++ b/plugins/inspira-ui/skills/inspira-ui/SKILL.md
@@ -105,6 +105,16 @@ Add to your `main.css`. See [references/SETUP.md](references/SETUP.md) for compl
 
 Browse [inspira-ui.com/components](https://inspira-ui.com/components), copy what you need into `components/ui/`.
 
+## Secure Installation
+
+This installs 6+ packages including 3D libraries (`three`, `ogl`) with large dependency trees. Before installing, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Component Selection Workflow
 
 **What type of effect do you need?**

--- a/plugins/interaction-design/.claude-plugin/plugin.json
+++ b/plugins/interaction-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "interaction-design",
   "description": "Creates intuitive user experiences through feedback patterns, microinteractions, and accessible interaction design. Use when designing loading states, error handling UX, animation guidelines, or touch interactions.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/internationalization-i18n/.claude-plugin/plugin.json
+++ b/plugins/internationalization-i18n/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "internationalization-i18n",
   "description": "Implements multi-language support using i18next, gettext, or Intl API with translation workflows and RTL support. Use when building multilingual applications, handling date/currency formatting, or supporting right-to-left languages.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/jest-generator/.claude-plugin/plugin.json
+++ b/plugins/jest-generator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jest-generator",
   "description": "Generate Jest unit tests for JavaScript/TypeScript with mocking, coverage. Use for JS/TS modules, React components, test generation, or encountering missing coverage, improper mocking, test structure errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/kpi-dashboard-design/.claude-plugin/plugin.json
+++ b/plugins/kpi-dashboard-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kpi-dashboard-design",
   "description": "Designs effective KPI dashboards with proper metric selection, visual hierarchy, and data visualization best practices. Use when building executive dashboards, creating analytics views, or presenting business metrics.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/logging-best-practices/.claude-plugin/plugin.json
+++ b/plugins/logging-best-practices/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "logging-best-practices",
   "description": "Structured logging with proper levels, context, PII handling, centralized aggregation. Use for application logging, log management integration, distributed tracing, or encountering log bloat, PII exposure, missing context errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/maz-ui/.claude-plugin/plugin.json
+++ b/plugins/maz-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maz-ui",
   "description": "Maz-UI v4 - Modern Vue & Nuxt component library with 50+ standalone components, composables, directives, theming, i18n, and SSR support.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mcp-dynamic-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/mcp-dynamic-orchestrator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-dynamic-orchestrator",
   "description": "Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mcp-management/.claude-plugin/plugin.json
+++ b/plugins/mcp-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-management",
   "description": "Manage MCP servers - discover, analyze, execute tools/prompts/resources. Use for MCP integrations, capability discovery, tool filtering, programmatic execution, or encountering context bloat, server configuration, tool execution errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mcp-management/skills/mcp-management/SKILL.md
+++ b/plugins/mcp-management/skills/mcp-management/SKILL.md
@@ -127,6 +127,16 @@ bunx tsx cli.ts call-tool memory create_entities '{"entities":[...]}'
 
 Dispatch subagent to handle MCP operations, keeping main context clean.
 
+## Secure Installation
+
+When installing MCP server packages, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Integration Strategy
 
 ### Execution Priority

--- a/plugins/microservices-patterns/.claude-plugin/plugin.json
+++ b/plugins/microservices-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "microservices-patterns",
   "description": "Design microservices architectures with service boundaries, event-driven communication, and resilience patterns. Use when building distributed systems, decomposing monoliths, or implementing microservices.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ml-model-training/.claude-plugin/plugin.json
+++ b/plugins/ml-model-training/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-model-training",
   "description": "Train ML models with scikit-learn, PyTorch, TensorFlow. Use for classification/regression, neural networks, hyperparameter tuning, or encountering overfitting, underfitting, convergence issues.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ml-pipeline-automation/.claude-plugin/plugin.json
+++ b/plugins/ml-pipeline-automation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-pipeline-automation",
   "description": "Automate ML workflows with Airflow, Kubeflow, MLflow. Use for reproducible pipelines, retraining schedules, MLOps, or encountering task failures, dependency errors, experiment tracking issues.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-app-debugging/.claude-plugin/plugin.json
+++ b/plugins/mobile-app-debugging/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-app-debugging",
   "description": "Mobile app debugging for iOS, Android, cross-platform frameworks. Use for crashes, memory leaks, performance issues, network problems, or encountering Xcode instruments, Android Profiler, React Native debugger, native bridge errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-app-testing/.claude-plugin/plugin.json
+++ b/plugins/mobile-app-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-app-testing",
   "description": "Mobile app testing with unit tests, UI automation, performance testing. Use for test infrastructure, E2E tests, testing standards, or encountering test framework setup, device farms, flaky tests, platform-specific test errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-first-design/.claude-plugin/plugin.json
+++ b/plugins/mobile-first-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-first-design",
   "description": "Designs responsive interfaces starting from mobile screens with progressive enhancement for larger devices. Use when building responsive websites, optimizing for mobile users, or implementing adaptive layouts.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-offline-support/.claude-plugin/plugin.json
+++ b/plugins/mobile-offline-support/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-offline-support",
   "description": "Offline-first mobile apps with local storage, sync queues, conflict resolution. Use for offline functionality, data sync, connectivity handling, or encountering sync conflicts, queue management, storage limits, network transition errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/model-deployment/.claude-plugin/plugin.json
+++ b/plugins/model-deployment/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "model-deployment",
   "description": "Deploy ML models with FastAPI, Docker, Kubernetes. Use for serving predictions, containerization, monitoring, drift detection, or encountering latency issues, health check failures, version conflicts.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/motion/.claude-plugin/plugin.json
+++ b/plugins/motion/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "motion",
   "description": "Motion (Framer Motion) React animation library. Use for drag-and-drop, scroll animations, gestures, SVG morphing, or encountering bundle size, complex transitions, spring physics errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/multi-ai-consultant/.claude-plugin/plugin.json
+++ b/plugins/multi-ai-consultant/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "multi-ai-consultant",
   "description": "Consult external AIs (Gemini 2.5 Pro, OpenAI Codex, Claude) for second opinions. Use for debugging failures, architectural decisions, security validation, or need fresh perspective with synthesis.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mutation-testing/.claude-plugin/plugin.json
+++ b/plugins/mutation-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mutation-testing",
   "description": "Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nano-banana-prompts/.claude-plugin/plugin.json
+++ b/plugins/nano-banana-prompts/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nano-banana-prompts",
   "description": "Generate optimized prompts for Gemini 2.5 Flash Image (Nano Banana). Use for image generation, crafting photo prompts, art styles, or multi-turn editing workflows with best practices.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/neon-vercel-postgres/.claude-plugin/plugin.json
+++ b/plugins/neon-vercel-postgres/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "neon-vercel-postgres",
   "description": "Neon + Vercel serverless Postgres for edge and serverless environments. Use for Cloudflare Workers, Vercel Edge, Next.js apps with HTTP/WebSocket connections, database branching (git-like), Drizzle/Prisma ORM integration, migrations, PITR backups, or encountering connection pool exhausted errors, TCP connection issues, SSL config problems.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nextjs/.claude-plugin/plugin.json
+++ b/plugins/nextjs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nextjs",
   "description": "Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-content/.claude-plugin/plugin.json
+++ b/plugins/nuxt-content/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-content",
   "description": "Nuxt Content v3 Git-backed CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Vercel deployment, SQL storage, MDC components, content collections.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-content/skills/nuxt-content/SKILL.md
+++ b/plugins/nuxt-content/skills/nuxt-content/SKILL.md
@@ -720,6 +720,16 @@ This skill composes well with:
 
 ---
 
+## Secure Installation
+
+When installing CMS packages, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Additional Resources
 
 **Official Documentation**:

--- a/plugins/nuxt-seo/.claude-plugin/plugin.json
+++ b/plugins/nuxt-seo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-seo",
   "description": "Comprehensive guide for all 8 Nuxt SEO modules plus Pro modules. Use when building SEO-optimized Nuxt applications, implementing robots.txt/sitemaps, generating OG images, adding Schema.org data, managing meta tags, checking links, or encountering sitemap, robots.txt, OG image, schema validation, meta tag, canonical URL, or i18n SEO errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-studio/.claude-plugin/plugin.json
+++ b/plugins/nuxt-studio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-studio",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Visual CMS for Nuxt Content with Cloudflare deployment. Use when setting up Nuxt Studio, configuring OAuth authentication, deploying to Cloudflare Pages/Workers with subdomain routing, or troubleshooting Studio integration.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-ui-v4/.claude-plugin/plugin.json
+++ b/plugins/nuxt-ui-v4/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-ui-v4",
   "description": "Nuxt UI v4 with 125+ accessible components, Tailwind v4, Reka UI, AI chat integration with reasoning and tool calling. Use for dashboards, forms, overlays, editors, page layouts, or encountering theming, composable, TypeScript errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-ui-v4/skills/nuxt-ui-v4/SKILL.md
+++ b/plugins/nuxt-ui-v4/skills/nuxt-ui-v4/SKILL.md
@@ -65,6 +65,16 @@ npm create nuxt@latest -- -t ui/editor       # Rich text editor
 
 **Commands available**: `/nuxt-ui-v4:setup`, `/nuxt-ui:migrate`, `/nuxt-ui:theme`, `/nuxt-ui:component`
 
+## Secure Installation
+
+UI packages modify CSS and component trees — verify before allowing into your project. Follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ---
 
 ## Component Categories (125+ Total)

--- a/plugins/nuxt-v4/.claude-plugin/plugin.json
+++ b/plugins/nuxt-v4/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-v4",
   "description": "Comprehensive Nuxt 4 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 4 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 3, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-v4/skills/nuxt-core/SKILL.md
+++ b/plugins/nuxt-v4/skills/nuxt-core/SKILL.md
@@ -66,6 +66,16 @@ bunx nuxi add component MyButton
 bunx nuxi add composable useAuth
 ```
 
+## Secure Installation
+
+Scaffolding tools like `bunx nuxi init` download and execute remote code. Before running, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Directory Structure (Nuxt v4)
 
 ```

--- a/plugins/nuxt-v5/.claude-plugin/plugin.json
+++ b/plugins/nuxt-v5/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-v5",
   "description": "Comprehensive Nuxt 5 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 5 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 4, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-v5/skills/nuxt-core/SKILL.md
+++ b/plugins/nuxt-v5/skills/nuxt-core/SKILL.md
@@ -41,6 +41,16 @@ bunx nuxi add component MyButton
 bunx nuxi add composable useAuth
 ```
 
+## Secure Installation
+
+Scaffolding tools like `bunx nuxi init` download and execute remote code. Before running, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Directory Structure (Nuxt v5)
 
 ```

--- a/plugins/oauth-implementation/.claude-plugin/plugin.json
+++ b/plugins/oauth-implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oauth-implementation",
   "description": "OAuth 2.0 and OpenID Connect authentication with secure flows. Use for third-party integrations, SSO systems, token-based API access, or encountering authorization code flow, PKCE, token refresh, scope management errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/openai-agents/.claude-plugin/plugin.json
+++ b/plugins/openai-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-agents",
   "description": "OpenAI Agents SDK for JavaScript/TypeScript (text + voice agents). Use for multi-agent workflows, tools, guardrails, or encountering Zod errors, MCP failures, infinite loops, tool call issues.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/openai-api/.claude-plugin/plugin.json
+++ b/plugins/openai-api/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-api",
   "description": "Complete guide for OpenAI APIs: Chat Completions (GPT-5.2, GPT-4o), Embeddings, Images (GPT-Image-1.5), Audio (Whisper + TTS + Transcribe), Moderation. Includes Node.js SDK and fetch approaches.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/openai-assistants/.claude-plugin/plugin.json
+++ b/plugins/openai-assistants/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-assistants",
   "description": "OpenAI Assistants API v2 for stateful chatbots with Code Interpreter, File Search, RAG. Use for threads, vector stores, or encountering active run errors, indexing delays. ⚠️ Sunset August 26, 2026.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/openai-responses/.claude-plugin/plugin.json
+++ b/plugins/openai-responses/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-responses",
   "description": "OpenAI Responses API for stateful agentic applications with reasoning preservation. Use for MCP integration, built-in tools, background processing, or migrating from Chat Completions.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/payment-gateway-integration/.claude-plugin/plugin.json
+++ b/plugins/payment-gateway-integration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "payment-gateway-integration",
   "description": "Integrates payment processing with Stripe, PayPal, or Square including subscriptions, webhooks, and PCI compliance. Use when implementing checkout flows, recurring billing, or handling refunds and disputes.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/pinia-colada/.claude-plugin/plugin.json
+++ b/plugins/pinia-colada/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pinia-colada",
   "description": "Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/pinia-v3/.claude-plugin/plugin.json
+++ b/plugins/pinia-v3/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pinia-v3",
   "description": "Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/plan-interview/.claude-plugin/plugin.json
+++ b/plugins/plan-interview/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-interview",
   "description": "Adaptive interview-driven spec generation with quality review. Automatically adjusts depth based on plan complexity.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/playwright/.claude-plugin/plugin.json
+++ b/plugins/playwright/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright",
   "description": "Browser automation and E2E testing with Playwright. Auto-detects dev servers, writes clean test scripts. Test pages, fill forms, take screenshots, check responsive design, validate UX, test login flows, check links, automate any browser task. Use for cross-browser testing, visual regression, API testing, component testing in TypeScript/JavaScript and Python projects.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/playwright/skills/playwright/SKILL.md
+++ b/plugins/playwright/skills/playwright/SKILL.md
@@ -474,6 +474,16 @@ Check `headless: false` and ensure display available
 **Element not found:**
 Add wait: `await page.waitForSelector('.element', { timeout: 10000 })`
 
+## Secure Installation
+
+When installing Playwright and browser binaries, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (then manually run `npx playwright install` to download browsers)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## See Also
 
 - `vitest-testing` - Unit and integration testing

--- a/plugins/progressive-web-app/.claude-plugin/plugin.json
+++ b/plugins/progressive-web-app/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "progressive-web-app",
   "description": "Builds Progressive Web Apps with service workers, web manifest, offline support, and installation prompts. Use when creating installable web experiences, implementing offline functionality, or adding push notifications to web apps.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/push-notification-setup/.claude-plugin/plugin.json
+++ b/plugins/push-notification-setup/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "push-notification-setup",
   "description": "Implements push notifications across iOS, Android, and web using Firebase Cloud Messaging and native services. Use when adding notification capabilities, handling background messages, or setting up notification channels.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-best-practices/.claude-plugin/plugin.json
+++ b/plugins/react-best-practices/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-best-practices",
   "description": "React and Next.js performance optimization guidelines from Vercel Engineering. Use when writing/reviewing/refactoring React code for optimal performance. Covers async patterns, bundle optimization, server/client components, re-render optimization.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-composition-patterns/.claude-plugin/plugin.json
+++ b/plugins/react-composition-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-composition-patterns",
   "description": "React composition patterns from Vercel Engineering. Use when building scalable components, avoiding boolean prop proliferation, implementing compound components, or managing component state. Covers architecture, state management, and implementation patterns.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-hook-form-zod/.claude-plugin/plugin.json
+++ b/plugins/react-hook-form-zod/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-hook-form-zod",
   "description": "Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-native-skills/.claude-plugin/plugin.json
+++ b/plugins/react-native-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-skills",
   "description": "React Native and Expo best practices for building performant mobile apps. Use when building React Native components, optimizing list performance, implementing animations, or working with native modules.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/recommendation-engine/.claude-plugin/plugin.json
+++ b/plugins/recommendation-engine/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "recommendation-engine",
   "description": "Build recommendation systems with collaborative filtering, matrix factorization, hybrid approaches. Use for product recommendations, personalization, or encountering cold start, sparsity, quality evaluation issues.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/recommendation-system/.claude-plugin/plugin.json
+++ b/plugins/recommendation-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "recommendation-system",
   "description": "Deploy production recommendation systems with feature stores, caching, A/B testing. Use for personalization APIs, low latency serving, or encountering cache invalidation, experiment tracking, quality monitoring issues.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/responsive-web-design/.claude-plugin/plugin.json
+++ b/plugins/responsive-web-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "responsive-web-design",
   "description": "Builds adaptive web interfaces using Flexbox, CSS Grid, and media queries with a mobile-first approach. Use when creating multi-device layouts, implementing flexible UI systems, or ensuring cross-browser compatibility.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/rest-api-design/.claude-plugin/plugin.json
+++ b/plugins/rest-api-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rest-api-design",
   "description": "Designs RESTful APIs with proper resource naming, HTTP methods, status codes, and response formats. Use when building new APIs, establishing API conventions, or designing developer-friendly interfaces.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/root-cause-tracing/.claude-plugin/plugin.json
+++ b/plugins/root-cause-tracing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "root-cause-tracing",
   "description": "Systematically trace bugs backward through call stack to find original trigger. Use when errors occur deep in execution and you need to trace back to find the original trigger.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/security-headers-configuration/.claude-plugin/plugin.json
+++ b/plugins/security-headers-configuration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "security-headers-configuration",
   "description": "Configures HTTP security headers to protect against XSS, clickjacking, and MIME sniffing attacks. Use when hardening web applications, passing security audits, or implementing Content Security Policy.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/seo-keyword-cluster-builder/.claude-plugin/plugin.json
+++ b/plugins/seo-keyword-cluster-builder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seo-keyword-cluster-builder",
   "description": "Groups related keywords into topic clusters and creates content hub architecture recommendations with internal linking strategies. Use when planning content strategy, organizing keyword research, or building pillar page structures.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/seo-optimizer/.claude-plugin/plugin.json
+++ b/plugins/seo-optimizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seo-optimizer",
   "description": "SEO optimization with keyword analysis, readability assessment, technical validation, content quality. Use for search rankings, blog posts, content audits, or encountering keyword density, readability scores, meta tags, schema markup errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/sequential-thinking/.claude-plugin/plugin.json
+++ b/plugins/sequential-thinking/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sequential-thinking",
   "description": "Systematic step-by-step reasoning with revision and branching. Use for complex problems, multi-stage analysis, design planning, problem decomposition, or encountering unclear scope, alternative approaches needed, revision requirements.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/session-management/.claude-plugin/plugin.json
+++ b/plugins/session-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "session-management",
   "description": "Implements secure session management with JWT tokens, Redis storage, refresh flows, and proper cookie configuration. Use when building authentication systems, managing user sessions, or implementing secure logout functionality.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/shadcn-vue/.claude-plugin/plugin.json
+++ b/plugins/shadcn-vue/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shadcn-vue",
   "description": "shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/shadcn-vue/skills/shadcn-vue/SKILL.md
+++ b/plugins/shadcn-vue/skills/shadcn-vue/SKILL.md
@@ -554,6 +554,16 @@ This skill composes well with:
 
 ---
 
+## Secure Installation
+
+When installing packages during setup, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Additional Resources
 
 **Official Documentation**:

--- a/plugins/sql-query-optimization/.claude-plugin/plugin.json
+++ b/plugins/sql-query-optimization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sql-query-optimization",
   "description": "SQL query optimization for PostgreSQL/MySQL with indexing, EXPLAIN analysis. Use for slow queries, N+1 problems, missing indexes, or encountering sequential scans, OFFSET pagination, temp table spills, inefficient JOINs.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/supabase-postgres-best-practices/.claude-plugin/plugin.json
+++ b/plugins/supabase-postgres-best-practices/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "supabase-postgres-best-practices",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Postgres performance optimization and best practices from Supabase. 30 rules across 8 categories prioritized by impact.",
   "author": {
     "name": "Supabase",

--- a/plugins/sveltia-cms/.claude-plugin/plugin.json
+++ b/plugins/sveltia-cms/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sveltia-cms",
   "description": "Sveltia CMS Git-backed content management (Decap/Netlify CMS successor). 5x smaller bundle (300 KB), GraphQL performance, solves 260+ issues. Use for static sites (Hugo, Jekyll, 11ty, Gatsby, Astro, Next.js), blogs, docs, i18n, or encountering OAuth errors, TOML/YAML issues, CORS problems, content listing errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/swift-best-practices/.claude-plugin/plugin.json
+++ b/plugins/swift-best-practices/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swift-best-practices",
   "description": "This skill should be used when writing or reviewing Swift code for iOS or macOS projects. Apply modern Swift 6+ best practices, concurrency patterns, API design guidelines, and migration strategies. Covers async/await, actors, MainActor, Sendable, typed throws, and Swift 6 breaking changes.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/swift-settingskit/.claude-plugin/plugin.json
+++ b/plugins/swift-settingskit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swift-settingskit",
   "description": "SettingsKit for SwiftUI settings interfaces (iOS, macOS, watchOS, tvOS, visionOS). Use for settings/preferences screens, searchable settings, nested navigation, @Observable/@Bindable state, or encountering settings update errors, navigation state issues.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/systematic-debugging/.claude-plugin/plugin.json
+++ b/plugins/systematic-debugging/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "systematic-debugging",
   "description": "Four-phase debugging framework that ensures root cause investigation before attempting fixes. Never jump to solutions. Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tailwind-v4-shadcn/.claude-plugin/plugin.json
+++ b/plugins/tailwind-v4-shadcn/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tailwind-v4-shadcn",
   "description": "Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React. Use when: initializing React projects with Tailwind v4, setting up shadcn/ui, implementing dark mode, debugging CSS variable issues, fixing theme switching, migrating from Tailwind v3, or encountering color/theming problems. Covers: @theme inline pattern, CSS variable architecture, dark mode with ThemeProvider, component composition, vite.config setup, common v4 gotchas, and production-tested patterns.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tailwind-v4-shadcn/skills/tailwind-v4-shadcn/SKILL.md
+++ b/plugins/tailwind-v4-shadcn/skills/tailwind-v4-shadcn/SKILL.md
@@ -543,6 +543,16 @@ Load reference files based on user's specific needs:
 
 ---
 
+## Secure Installation
+
+When installing Tailwind and shadcn/ui packages, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Production Example
 
 This skill is based on the WordPress Auditor project:

--- a/plugins/tanstack-ai/.claude-plugin/plugin.json
+++ b/plugins/tanstack-ai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-ai",
   "description": "TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and tool definitions.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-query/.claude-plugin/plugin.json
+++ b/plugins/tanstack-query/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-query",
   "description": "TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-router/.claude-plugin/plugin.json
+++ b/plugins/tanstack-router/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-router",
   "description": "TanStack Router type-safe file-based routing for React. Use for SPAs, TanStack Query integration, Cloudflare Workers, or encountering devtools, type safety, loader, Vite bundling errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-start/.claude-plugin/plugin.json
+++ b/plugins/tanstack-start/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-start",
   "description": "TanStack Start (RC) full-stack React with server functions, SSR, Cloudflare Workers. Use for Next.js migration, edge rendering, or encountering hydration, auth, data pattern errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-table/.claude-plugin/plugin.json
+++ b/plugins/tanstack-table/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-table",
   "description": "TanStack Table v8 headless data tables with server-side features for Cloudflare Workers + D1. Use for pagination, filtering, sorting, virtualization, or encountering state management, TanStack Query coordination, URL sync errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/technical-specification/.claude-plugin/plugin.json
+++ b/plugins/technical-specification/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "technical-specification",
   "description": "Creates detailed technical specifications for software projects covering requirements, architecture, APIs, and testing strategies. Use when planning features, documenting system design, or creating architecture decision records.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/test-quality-analysis/.claude-plugin/plugin.json
+++ b/plugins/test-quality-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "test-quality-analysis",
   "description": "Detect test smells, overmocking, flaky tests, and coverage issues. Analyze test effectiveness, maintainability, and reliability. Use when reviewing tests or improving test quality.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/thesys-generative-ui/.claude-plugin/plugin.json
+++ b/plugins/thesys-generative-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thesys-generative-ui",
   "description": "AI-powered generative UI with Thesys - create React components from natural language.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/threejs/.claude-plugin/plugin.json
+++ b/plugins/threejs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "threejs",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Comprehensive Three.js skills for building 3D web experiences",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/turborepo/.claude-plugin/plugin.json
+++ b/plugins/turborepo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "turborepo",
   "description": "Turborepo high-performance monorepo build system. Use for monorepo setup, build optimization, task pipelines, caching strategies, or multi-package orchestration.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/typescript-mcp/.claude-plugin/plugin.json
+++ b/plugins/typescript-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-mcp",
   "description": "MCP servers with TypeScript on Cloudflare Workers using @modelcontextprotocol/sdk. Use for API integrations, stateless tools, edge deployments, or encountering export syntax, schema validation, memory leak, CORS, auth errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/typescript-mcp/skills/typescript-mcp/SKILL.md
+++ b/plugins/typescript-mcp/skills/typescript-mcp/SKILL.md
@@ -69,6 +69,16 @@ Use this skill when:
 
 ---
 
+## Secure Installation
+
+MCP server packages grant tool access to LLMs — a compromised SDK can expose full system control. Verify packages before installing. Follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Core Concepts
 
 **MCP Protocol Components**:

--- a/plugins/ultracite/.claude-plugin/plugin.json
+++ b/plugins/ultracite/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultracite",
   "description": "Ultracite multi-provider linting/formatting (Biome, ESLint, Oxlint). Use for v6/v7 setup, provider selection, Git hooks, MCP integration, AI hooks, migrations, or encountering configuration, type-aware linting, monorepo errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ultracite/skills/ultracite/SKILL.md
+++ b/plugins/ultracite/skills/ultracite/SKILL.md
@@ -823,6 +823,16 @@ Load reference files on-demand based on user questions or task requirements:
 - Editor integration
 - Migration limitations
 
+## Secure Installation
+
+When installing linting/formatting packages, follow supply chain security best practices:
+
+- **Block post-install scripts** — `npm config set ignore-scripts true` (or Bun: disabled by default)
+- **Cooldown period** — Wait 7 days for new package versions to be vetted by the community
+- **Audit before installing** — Run `socket package score npm <pkg>` or use `socket npm install <pkg>` to check packages
+
+Load the `dependency-upgrade` skill for full security configuration including Socket CLI integration, cooldown setup, lockfile validation, and CI enforcement.
+
 ## Summary
 
 Ultracite provides a unified linting and formatting solution with multi-provider support:

--- a/plugins/vercel-blob/.claude-plugin/plugin.json
+++ b/plugins/vercel-blob/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vercel-blob",
   "description": "Vercel Blob object storage with CDN for Next.js. Use for file uploads (images, PDFs, videos), presigned URLs, user-generated content, file management, or encountering BLOB_READ_WRITE_TOKEN errors, file size limits, client upload token errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/vercel-kv/.claude-plugin/plugin.json
+++ b/plugins/vercel-kv/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vercel-kv",
   "description": "Vercel KV (Redis-compatible key-value storage via Upstash). Use for Next.js caching, sessions, rate limiting, TTL data storage, or encountering KV_REST_API_URL errors, rate limit issues, JSON serialization errors. Provides strong consistency vs eventual consistency.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/verification-before-completion/.claude-plugin/plugin.json
+++ b/plugins/verification-before-completion/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "verification-before-completion",
   "description": "Run verification commands and confirm output before claiming success. Use when about to claim work is complete, fixed, or passing, before committing or creating PRs.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/vitest-testing/.claude-plugin/plugin.json
+++ b/plugins/vitest-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vitest-testing",
   "description": "Modern TypeScript/JavaScript testing with Vitest. Fast unit and integration tests, native ESM support, Vite-powered HMR, and comprehensive mocking. Use for testing TS/JS projects.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/vulnerability-scanning/.claude-plugin/plugin.json
+++ b/plugins/vulnerability-scanning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vulnerability-scanning",
   "description": "Implements automated security scanning for dependencies, code, and containers using tools like Trivy, Snyk, and npm audit. Use when setting up CI/CD security gates, conducting pre-deployment audits, or meeting compliance requirements.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/web-performance-audit/.claude-plugin/plugin.json
+++ b/plugins/web-performance-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "web-performance-audit",
   "description": "Web performance audits with Core Web Vitals, bottleneck identification, optimization recommendations. Use for page load times, performance reviews, UX optimization, or encountering LCP, FID, CLS issues, resource blocking, render delays.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/web-performance-optimization/.claude-plugin/plugin.json
+++ b/plugins/web-performance-optimization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "web-performance-optimization",
   "description": "Optimizes web application performance through code splitting, lazy loading, caching strategies, and Core Web Vitals monitoring. Use when improving page load times, implementing service workers, or reducing bundle sizes.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/websocket-implementation/.claude-plugin/plugin.json
+++ b/plugins/websocket-implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "websocket-implementation",
   "description": "Implements real-time WebSocket communication with connection management, room-based messaging, and horizontal scaling. Use when building chat systems, live notifications, collaborative tools, or real-time dashboards.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-backend-dev/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-backend-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-backend-dev",
   "description": "Add or modify WooCommerce backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code in WooCommerce projects.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-code-review/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-code-review",
   "description": "Review WooCommerce code changes for coding standards compliance. Use when reviewing code locally, performing automated PR reviews, or checking code quality in WooCommerce projects.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-copy-guidelines/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-copy-guidelines/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-copy-guidelines",
   "description": "Guidelines for UI text and copy in WooCommerce. Use when writing user-facing text, labels, buttons, messages, or documentation in WooCommerce projects.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-dev-cycle/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-dev-cycle/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-dev-cycle",
   "description": "Run tests, linting, and quality checks for WooCommerce development. Use when running tests, fixing code style, or following the development workflow in WooCommerce projects.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/wordpress-plugin-core/.claude-plugin/plugin.json
+++ b/plugins/wordpress-plugin-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wordpress-plugin-core",
   "description": "WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/xss-prevention/.claude-plugin/plugin.json
+++ b/plugins/xss-prevention/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xss-prevention",
   "description": "Prevents Cross-Site Scripting attacks through input sanitization, output encoding, and Content Security Policy. Use when handling user-generated content, implementing rich text editors, or securing web applications.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/zod/.claude-plugin/plugin.json
+++ b/plugins/zod/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zod",
   "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies (2kb gzipped).",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/zustand-state-management/.claude-plugin/plugin.json
+++ b/plugins/zustand-state-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zustand-state-management",
   "description": "Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loops.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/scripts/sync-plugins.sh
+++ b/scripts/sync-plugins.sh
@@ -17,6 +17,14 @@
 #   5. Generates keywords from skill name, category, and description
 #   6. Regenerates marketplace.json with updated data
 #
+# ⚠️  VERSIONING: This script uses a SINGLE GLOBAL VERSION for all plugins.
+#     The version is read from marketplace.json → .metadata.version and stamped
+#     onto every plugin.json and marketplace entry. There is no per-plugin
+#     versioning. To bump any plugin's version:
+#       1. Update .metadata.version in marketplace.json
+#       2. Run this script (all plugins get the same version)
+#     Do NOT manually edit plugin.json version — sync will overwrite it.
+#
 # Usage:
 #   ./scripts/sync-plugins.sh           # Full sync
 #   ./scripts/sync-plugins.sh --dry-run # Preview changes without modifying


### PR DESCRIPTION
## Summary

- Expand `dependency-upgrade` skill with Socket CLI integration for proactive supply chain security (new `references/socket-cli-guide.md`, 2 CI templates, expanded SKILL.md)
- Add contextually-tailored "Secure Installation" sections to **31 skills** (15 initially + 16 additional high-priority scaffolding/setup skills), each cross-referencing the `dependency-upgrade` skill
- Bump marketplace version to 3.3.1 across all 170 plugins via `sync-plugins.sh`

## Changes

### dependency-upgrade skill expansion
- **New**: `references/socket-cli-guide.md` (418 lines) — full Socket CLI reference (free + authenticated, all commands, CI workflows, alert categories)
- **New**: `templates/socket-fix-ci.tmpl` (46 lines) — GitHub Actions for `socket fix --autopilot`
- **New**: `templates/socket-scan-ci.tmpl` (37 lines) — GitHub Actions for `socket ci` security gate
- **Modified**: `SKILL.md` — expanded Q7 in Interactive Setup, added Socket CLI Integration section, updated staged upgrades/dependency analysis/checklist, added principle 8
- **Modified**: `references/supply-chain-security.md` — expanded to 3-tool comparison table (npq + sfw + Socket CLI)

### Secure Installation cross-references (31 skills)
Each skill gets a brief section (3 practices + pointer to `dependency-upgrade`) tailored to its domain:

**Batch 1 (15 skills)**: bun-package-manager, shadcn-vue, ultracite, cloudflare-workers-ci-cd, mcp-management, better-auth, bun-docker, nuxt-content, playwright, elevenlabs-agents, cloudflare-d1, tailwind-v4-shadcn, cloudflare-vectorize, hono-routing, drizzle-orm-d1

**Batch 2 (16 HIGH-priority scaffolding/setup skills)**: cloudflare-workers-dev-experience, aceternity-ui, nuxt-v5/nuxt-core, nuxt-v4/nuxt-core, inspira-ui, typescript-mcp, claude-agent-sdk, bun-nextjs, bun-sveltekit, bun-cloudflare-workers, cloudflare-sandbox, bun-tanstack-start, bun-nuxt, nuxt-ui-v4, cloudflare-nextjs, ai-sdk-core

### Infrastructure
- Bumped `.metadata.version` to 3.3.1 in marketplace.json, synced all 170 plugins
- Added versioning notes to `sync-plugins.sh` header and `CLAUDE.md`

## Test plan
- [x] Verified all 31 skills contain "Secure Installation" section
- [x] Verified all 31 skills reference `dependency-upgrade`
- [x] Frontmatter validation passed for all changed skills (pre-push hook)
- [x] Marketplace.json valid with 170 plugins at v3.3.1