### PR TITLE
fix(security): remediate all 8 open CodeQL code-scanning alerts

### DIFF
--- a/plugins/cloudflare-images/skills/cloudflare-images/examples/basic-upload/public/index.html
+++ b/plugins/cloudflare-images/skills/cloudflare-images/examples/basic-upload/public/index.html
@@ -323,13 +323,32 @@
                 const imageUrl = `https://imagedelivery.net/${ACCOUNT_HASH}/${imageId}/public`;
                 uploadedImage.src = imageUrl;
 
-                imageDetails.innerHTML = `
-                    <div><strong>Image ID:</strong> ${imageId}</div>
-                    <div><strong>Filename:</strong> ${file.name}</div>
-                    <div><strong>Size:</strong> ${(file.size / 1024).toFixed(1)} KB</div>
-                    <div><strong>Type:</strong> ${file.type}</div>
-                    <div><strong>URL:</strong> <a href="${imageUrl}" target="_blank">${imageUrl}</a></div>
-                `;
+                // Build details with the DOM API rather than innerHTML: file.name
+                // is user-controlled, so interpolating it into innerHTML would be
+                // DOM XSS. textContent never parses as HTML, so it is safe here.
+                imageDetails.replaceChildren();
+                const detailRows = [
+                    ['Image ID', imageId],
+                    ['Filename', file.name],
+                    ['Size', `${(file.size / 1024).toFixed(1)} KB`],
+                    ['Type', file.type],
+                ];
+                for (const [label, value] of detailRows) {
+                    const row = document.createElement('div');
+                    const strong = document.createElement('strong');
+                    strong.textContent = `${label}:`;
+                    row.append(strong, ' ', value);
+                    imageDetails.append(row);
+                }
+                const urlRow = document.createElement('div');
+                const urlLabel = document.createElement('strong');
+                urlLabel.textContent = 'URL:';
+                const urlLink = document.createElement('a');
+                urlLink.href = imageUrl;
+                urlLink.target = '_blank';
+                urlLink.textContent = imageUrl;
+                urlRow.append(urlLabel, ' ', urlLink);
+                imageDetails.append(urlRow);
 
                 uploadedImageContainer.style.display = 'block';
                 showSuccess('Image uploaded successfully!');

--- a/plugins/cloudflare-vectorize/skills/cloudflare-vectorize/templates/document-ingestion.ts
+++ b/plugins/cloudflare-vectorize/skills/cloudflare-vectorize/templates/document-ingestion.ts
@@ -100,11 +100,17 @@ async function extractTextFromHtml(html: string): Promise<string> {
 
 	const rewriter = new HTMLRewriter()
 		.on('script, style, noscript, iframe, svg', {
-			element() {
+			// HTMLRewriter has no standalone `endTag` handler on the content
+			// handlers object — end-tag callbacks are registered per-element via
+			// `el.onEndTag(...)`. Registering the decrement there (not as a
+			// sibling `endTag` key, which is silently ignored) is what keeps
+			// `skipDepth` balanced so visible text after a skipped element is
+			// processed again.
+			element(el) {
 				skipDepth++;
-			},
-			endTag() {
-				if (skipDepth > 0) skipDepth--;
+				el.onEndTag(() => {
+					if (skipDepth > 0) skipDepth--;
+				});
 			},
 		})
 		.on('*', {
@@ -116,6 +122,11 @@ async function extractTextFromHtml(html: string): Promise<string> {
 			},
 		});
 
+	// HTMLRewriter is a streaming transform: the element/text handlers fire as
+	// the output stream is consumed. Awaiting `.text()` drains that stream to
+	// completion, which is what drives every callback above — the resolved
+	// string itself is unused. (Reading is the engine, not waste; if the stream
+	// isn't drained the callbacks never fire.)
 	await rewriter.transform(new Response(html)).text();
 	// Collapse any whitespace introduced at streaming chunk boundaries.
 	return text.replace(/\s+/g, ' ').trim();

--- a/plugins/cloudflare-vectorize/skills/cloudflare-vectorize/templates/document-ingestion.ts
+++ b/plugins/cloudflare-vectorize/skills/cloudflare-vectorize/templates/document-ingestion.ts
@@ -82,6 +82,45 @@ function batchArray<T>(array: T[], batchSize: number): T[][] {
 	return batches;
 }
 
+/**
+ * Extract visible text from an HTML string using Cloudflare's HTMLRewriter.
+ *
+ * Why not regex: stripping tags with regular expressions is unsafe — regexes
+ * cannot reliably match `</script >`-style end tags, can reintroduce dangerous
+ * substrings when fragments recombine, and have no understanding of element
+ * semantics. HTMLRewriter is a streaming, dependency-free HTML tokenizer built
+ * into the Workers runtime, so it handles all of the above correctly.
+ *
+ * Drops the *content* of <script>, <style>, <noscript>, <iframe>, <svg> and
+ * collapses adjacent whitespace into single spaces.
+ */
+async function extractTextFromHtml(html: string): Promise<string> {
+	let skipDepth = 0;
+	let text = '';
+
+	const rewriter = new HTMLRewriter()
+		.on('script, style, noscript, iframe, svg', {
+			element() {
+				skipDepth++;
+			},
+			endTag() {
+				if (skipDepth > 0) skipDepth--;
+			},
+		})
+		.on('*', {
+			text(chunk) {
+				if (skipDepth > 0) return;
+				// chunk.text is a small piece of decoded text content; collapse
+				// whitespace so that block elements don't leave odd gaps.
+				text += chunk.text.replace(/\s+/g, ' ');
+			},
+		});
+
+	await rewriter.transform(new Response(html)).text();
+	// Collapse any whitespace introduced at streaming chunk boundaries.
+	return text.replace(/\s+/g, ' ').trim();
+}
+
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 		// Handle CORS
@@ -237,13 +276,8 @@ export default {
 				const response = await fetch(body.url);
 				const html = await response.text();
 
-				// Simple text extraction (production would use proper HTML parsing)
-				const text = html
-					.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-					.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-					.replace(/<[^>]+>/g, ' ')
-					.replace(/\s+/g, ' ')
-					.trim();
+				// Extract visible text with HTMLRewriter (see extractTextFromHtml).
+				const text = await extractTextFromHtml(html);
 
 				// Create document from fetched content
 				const doc: Document = {

--- a/plugins/cloudflare-workers/skills/cloudflare-workers-runtime-apis/templates/crypto-operations.ts
+++ b/plugins/cloudflare-workers/skills/cloudflare-workers-runtime-apis/templates/crypto-operations.ts
@@ -312,13 +312,29 @@ export function randomHex(length: number): string {
 
 /**
  * Generate random alphanumeric string
+ *
+ * Uses rejection sampling: `crypto.getRandomValues` returns unbiased bytes in
+ * [0, 255], but `% chars.length` introduces modulo bias (256 % 62 = 8, so the
+ * first 8 characters would be ~1.6% more likely than the rest). We discard any
+ * byte ≥ the largest multiple of `chars.length` below 256 (248) and draw a
+ * replacement, giving a perfectly uniform mapping. For tokens/IDs this matters
+ * even though the bias is small.
  */
 export function randomString(length: number): string {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  const bytes = randomBytes(length);
-  return Array.from(bytes)
-    .map((b) => chars[b % chars.length])
-    .join('');
+  const max = 256 - (256 % chars.length); // 248 — exclusive upper bound
+  let result = '';
+  while (result.length < length) {
+    const bytes = randomBytes(length - result.length);
+    for (const b of bytes) {
+      if (b < max) {
+        result += chars[b % chars.length];
+        if (result.length >= length) break;
+      }
+      // else: reject the biased byte and continue
+    }
+  }
+  return result;
 }
 
 /**

--- a/plugins/cloudflare-workers/skills/cloudflare-workers-runtime-apis/templates/crypto-operations.ts
+++ b/plugins/cloudflare-workers/skills/cloudflare-workers-runtime-apis/templates/crypto-operations.ts
@@ -314,11 +314,12 @@ export function randomHex(length: number): string {
  * Generate random alphanumeric string
  *
  * Uses rejection sampling: `crypto.getRandomValues` returns unbiased bytes in
- * [0, 255], but `% chars.length` introduces modulo bias (256 % 62 = 8, so the
- * first 8 characters would be ~1.6% more likely than the rest). We discard any
- * byte ≥ the largest multiple of `chars.length` below 256 (248) and draw a
- * replacement, giving a perfectly uniform mapping. For tokens/IDs this matters
- * even though the bias is small.
+ * [0, 255], but `% chars.length` introduces modulo bias. Since 256 = 62 × 4 + 8,
+ * each of the first 8 characters would receive 5 byte values while every other
+ * character receives only 4 — i.e. the first 8 would be 25% more likely than
+ * the rest. We discard any byte ≥ the largest multiple of `chars.length` below
+ * 256 (248) and draw a replacement, giving a perfectly uniform mapping. For
+ * tokens/IDs this matters even though the absolute bias is small.
  */
 export function randomString(length: number): string {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';

--- a/plugins/nextjs/skills/nextjs/templates/server-actions-form.tsx
+++ b/plugins/nextjs/skills/nextjs/templates/server-actions-form.tsx
@@ -189,7 +189,10 @@ export function ValidatedPostForm() {
 import { updateTag } from 'next/cache'
 
 export async function likePost(postId: string) {
-  await fetch(`https://api.example.com/posts/${postId}/like`, {
+  // Encode user-provided path params before interpolating into a URL to
+  // prevent request-forgery (e.g. `postId` carrying `../` or `?`/`#`).
+  const safePostId = encodeURIComponent(postId)
+  await fetch(`https://api.example.com/posts/${safePostId}/like`, {
     method: 'POST',
   })
 

--- a/scripts/fix-frontmatter.mjs
+++ b/scripts/fix-frontmatter.mjs
@@ -115,7 +115,10 @@ function fixDescriptionBlock(lines) {
 
       // ── single-line with unquoted colon → wrap in double quotes ──
       if (firstValue.includes(':') && !/^['"]/.test(firstValue)) {
-        const escaped = firstValue.replace(/"/g, '\\"');
+        // Escape backslashes first, then quotes — standard YAML double-quoted
+        // scalar order. Skipping the backslash escape produces invalid YAML
+        // when a value ends in `\` (e.g. `path\` → `"path\"` is unterminated).
+        const escaped = firstValue.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         out.push(`description: "${escaped}"`);
         changed = true;
         i++;


### PR DESCRIPTION
## Summary

Remediates all 8 open CodeQL (v2.26.2) code-scanning alerts on `main`: **7 fixed via code, 1 dismissed as false positive**. Targets the root cause of each finding rather than blanket-dismissing.

| # | Rule | Severity | File | Action |
|---|------|----------|------|--------|
| 1 | `js/request-forgery` | **critical** | `plugins/nextjs/.../server-actions-form.tsx` | **Fix:** `encodeURIComponent(postId)` before URL interpolation |
| 2 | `js/xss-through-dom` | high | `plugins/cloudflare-images/.../basic-upload/.../index.html` | **Fix:** replace `innerHTML` template literal (real DOM XSS via `file.name`) with `createElement` + `textContent` |
| 3 | `js/xss-through-dom` | high | `plugins/cloudflare-images/.../responsive-images-srcset.html` | **Dismiss** as false positive — `data-src` is a developer-set static attribute, not attacker-controlled |
| 4 | `js/biased-cryptographic-random` | high | `plugins/cloudflare-workers/.../crypto-operations.ts` | **Fix:** rejection sampling (discard byte ≥ 248) for unbiased modulo over 62-char alphabet |
| 5 | `js/incomplete-sanitization` | high | `scripts/fix-frontmatter.mjs` | **Fix:** escape backslashes before quotes in YAML double-quoted wrapping |
| 6 | `js/incomplete-multi-character-sanitization` | high | `plugins/cloudflare-vectorize/.../document-ingestion.ts` | **Fix:** HTMLRewriter refactor (with #7, #8) |
| 7 | `js/incomplete-multi-character-sanitization` | high | `plugins/cloudflare-vectorize/.../document-ingestion.ts` | **Fix:** HTMLRewriter refactor (with #6, #8) |
| 8 | `js/bad-tag-filter` | high | `plugins/cloudflare-vectorize/.../document-ingestion.ts` | **Fix:** HTMLRewriter refactor (with #6, #7) |

## Details

**#5 is the only shipped-script change** (`scripts/fix-frontmatter.mjs`). Without the backslash escape, a `description:` value ending in `\` produced `"...\"` — an unterminated YAML double-quoted scalar that corrupts frontmatter. The remaining 7 are in skill `templates/`/`examples/` sample code; since this repo's product is teaching correct patterns, insecure samples are themselves bugs worth fixing.

**document-ingestion.ts (#6/#7/#8):** replaced the regex chain that stripped `<script>`/`<style>` then all tags with an `extractTextFromHtml()` helper built on Cloudflare's `HTMLRewriter`. Regex-based HTML sanitization is unsound — it cannot reliably match `</script >`-style tags and can reintroduce dangerous substrings. `HTMLRewriter` is a dependency-free streaming HTML tokenizer built into the Workers runtime, and this file already uses Workers globals (`VectorizeIndex`, `Ai`, `R2Bucket`). Drops content of `script`/`style`/`noscript`/`iframe`/`svg` and collapses whitespace.

**#3 dismissal rationale:** the flagged flow is `lqipImage.src = lqipImage.getAttribute('data-src')`, but `data-src="https://imagedelivery.net/HASH/ID/w=1920,f=auto"` is a hardcoded static attribute in the template — no path for user content to reach it. Dismissed with `false positive` reason rather than contorting working code.

## Out of scope
- No changes to `codeql.yml` (config is already sound: `javascript, actions` languages, scoped permissions, pinned actions, weekly cadence).
- `document-ingestion.ts:237` has a separate unflagged SSRF surface (`fetch(body.url)` with raw user URL). It's a real open-redirect/SSRF in that template, but SSRF allowlisting is a larger design call — flagging for a follow-up if you want it hardened.

## Verification
- `node --check scripts/fix-frontmatter.mjs` ✓
- gitleaks + JSON-schema pre-commit hooks ✓
- CodeQL rescan on this PR is the source of truth — expected open-alert count drops **8 → 0** (7 auto-closed by code change + 1 dismissed).

## Lockstep versioning
No version bump in this PR. Per the repo convention the 142-plugin + marketplace + `package.json` lockstep bump happens at release time (manual, no tags). Flagging for your call once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image upload details rendering so filenames display safely without being interpreted as HTML.
  * Improved HTML content extraction during document ingestion, excluding non-visible content and normalizing whitespace.
  * Strengthened random string generation for more uniformly distributed results.
  * Improved handling of special characters in post identifiers and generated YAML descriptions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->