### PR TITLE
chore(governance): add CODEOWNERS + tighten main branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS — routes required reviews on pull requests.
+#
+# This repo is a single-maintainer marketplace (secondsky). The default rule
+# assigns every path to @secondsky so branch protection's "require code owner
+# review" has an owner to request. Split per-plugin path ownership out as
+# additional maintainers are added.
+#
+# Syntax: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for the entire repository.
+* @secondsky


### PR DESCRIPTION
## What this PR does

Adds `.github/CODEOWNERS` (single owner `@secondsky` for all paths) so the newly-tightened branch protection's `require_code_owner_review` rule has an owner to route reviews to.

## Companion repo-settings changes (applied directly via API, not in this PR)

These were applied as repo settings — they don't live in the repo file tree, so they're documented here for transparency and revert.

### ✅ Ruleset `main-branch-protection` (id 11240677) — UPDATED
Previously enforced only deletion-block + non-fast-forward + a PR with 0 required approvals. Now also enforces:
- **Required status checks:** `Analyze` (CodeQL), `Dependency Review`, `Validate SKILL.md Frontmatter`, `Validate JSON Schemas` — CI is now mandatory, not advisory.
- **Reviews:** 1 approving review required, code-owner review required, last-push approval required, stale reviews dismissed on push, unresolved review conversations block merge.
- **Merge methods:** `squash` and `rebase` only (drops plain `merge` → enforces linear history per SECURITY.md).

This closes the residual gap from audit finding **E-005** ("No branch protection" was actually "minimal branch protection"; now substantive).

### ⚠️ Could NOT enable two secret-scanning toggles
Attempted `secret_scanning_validity_checks` and `secret_scanning_non_provider_patterns` via `PATCH /repos/...`. Both return HTTP 200 but silently stay `disabled`, and `PUT /secret-scanning/config` returns 404. These are **GHAS-licensed sub-features** and aren't available on this repo via API. Base secret scanning + push protection remain enabled (free for public repos).

## ⚠️ Merging this PR

The new branch-protection rule requires a code-owner review, and as the single owner you can't self-approve. **Merge via admin override** (the ruleset's bypass actor is `RepositoryRole: Admin, always`). After this PR merges, every subsequent PR will enforce the full rule on `main`.

## Things I deliberately did NOT change (flagged for your decision)

| Item | Why deferred |
|---|---|
| **Admin bypass on ruleset** | Current ruleset allows admins to bypass (`actor_id:5`). Your `SECURITY.md` E-005 spec says "no admin bypass". Leaving as-is — removing it would prevent you from merging this CODEOWNERS PR at all. Your call after merge. |
| **Signed-commits requirement** | Not enabled. Your pre-commit hooks (gitleaks, JSON-schema) push commits; requiring signatures could block them. `SECURITY.md` lists it as desired — test the hook-push path before enabling. |
| **Query suite / languages** | Left as `default` query suite, `javascript, actions` languages. `security-and-quality` would flood template/example code with FP quality nits; `python`/`ruby` would scan ~43KB of mostly-example code for real cost. Current config caught all 8 legit findings in PR #79. |
| **CodeQL workflow YAML** | Already best-practice (SHA-pinned, scoped perms, weekly). Prior audit (E-001, E-002) did that work. |

## Revert path
- **Ruleset:** `gh api -X PUT repos/secondsky/claude-skills/rulesets/11240677` with the pre-update payload (deletion + non_fast_forward + minimal pull_request, no required checks). Full prior state captured in this PR's research log.
- **CODEOWNERS:** `git revert` this commit.

## Verification (done)
- `gh api repos/.../rules/branches/main` confirms all 4 rules active on `main`.
- Latest CodeQL analysis on main returned 0 results (post PR #79).
- gitleaks + JSON-schema pre-commit hooks pass on this commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository ownership rules to support automatic code review assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->