### PR TITLE
fix(codeql): exclude hugo-book Go-template .js files (last 3 parse errors)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,15 +30,22 @@ jobs:
           # `javascript` scans the small number of real .mjs/.js scripts in
           # scripts/ and plugins/; `actions` scans the workflow/Action files.
           languages: javascript, actions
-          # Exclude Vue SFC transpile artifacts. The autobuild step compiles
-          # .vue files to intermediate .vue.ts files that the CodeQL TypeScript
-          # extractor cannot parse, producing a wave of "Declaration or
-          # statement expected" diagnostics. The .vue sources themselves are
-          # not directly analyzable by CodeQL either; excluding the artifacts
-          # silences the noise without losing real coverage.
+          # Exclude files CodeQL's JS/TS extractor cannot meaningfully parse:
+          #  1. Vue SFC transpile artifacts — the autobuild step compiles .vue
+          #     files to intermediate .vue.ts files that the TypeScript extractor
+          #     can't parse, producing "Declaration or statement expected" noise.
+          #     The .vue sources themselves aren't directly analyzable either.
+          #  2. Hugo Go-template files with a .js extension — the vendored
+          #     hugo-book theme ships service-worker / search scripts as .js files
+          #     containing Hugo {{ }} template directives. These are not valid JS
+          #     on disk; Hugo processes them at build time. Excluding the 3 known
+          #     files; the theme's other .js files are real JS and stay scanned.
           config: |
             paths-ignore:
               - "**/*.vue.ts"
+              - "plugins/hugo/skills/hugo/templates/hugo-docs/themes/hugo-book/assets/sw.js"
+              - "plugins/hugo/skills/hugo/templates/hugo-docs/themes/hugo-book/assets/sw-register.js"
+              - "plugins/hugo/skills/hugo/templates/hugo-docs/themes/hugo-book/assets/search.js"
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5


### PR DESCRIPTION
## What

The 3 remaining CodeQL parse errors on main are all in the vendored **hugo-book** theme:

| File | Cause |
|---|---|
| `plugins/hugo/.../hugo-book/assets/sw.js` | Contains Hugo `{{ }}` Go-template directives |
| `plugins/hugo/.../hugo-book/assets/sw-register.js` | Same |
| `plugins/hugo/.../hugo-book/assets/search.js` | Same |

These files have a `.js` extension but are **Hugo Go-templates** — they contain `{{ range .Site.AllPages }}`, `{{ $swJS.RelPermalink }}`, etc. Hugo processes the `{{ }}` directives at build time and emits real JS. On disk they are not valid JavaScript, so CodeQL's JS parser reports `Unexpected token` and skips them.

`hugo-book` is a third-party theme (ships its own `theme.toml`, `LICENSE`, `go.mod`) bundled as a reference starter in the hugo skill.

## Fix

Added the 3 files to the existing `paths-ignore` block in `codeql.yml`. **Scoped narrowly** — the theme has 11 `.js` files total; the other 8 are real JS and stay scanned. No code change to the theme itself (it works correctly under Hugo).

## Expected result
Post-merge CodeQL run: **0 parse errors, 0 cascade** (main is currently at 3 / 0 after PR #81).

## Verification
- YAML validates (`paths-ignore` now has 4 entries).
- gitleaks + JSON-schema pre-commit hooks pass.
- The 3 files are the only `.js` files under hugo-book containing `{{ }}` template syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to document and exclude Hugo theme template files and generated Vue artifacts.
  * Clarified the rationale for excluded files in the scanning configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->