### PR TITLE
Add tech-debt + unknowns-discovery plugins; bump version to 3.7.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1436,6 +1436,17 @@
       "category": "Frontend"
     },
     {
+      "name": "unknowns-discovery",
+      "source": {
+        "source": "local",
+        "path": "./plugins/unknowns-discovery"
+      },
+      "policy": {
+        "installation": "AVAILABLE"
+      },
+      "category": "Developer Tools"
+    },
+    {
       "name": "vitest-testing",
       "source": {
         "source": "local",

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1348,6 +1348,17 @@
       "category": "Frontend"
     },
     {
+      "name": "tech-debt",
+      "source": {
+        "source": "local",
+        "path": "./plugins/tech-debt"
+      },
+      "policy": {
+        "installation": "AVAILABLE"
+      },
+      "category": "Developer Tools"
+    },
+    {
       "name": "technical-specification",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2092,6 +2092,21 @@
       "category": "frontend"
     },
     {
+      "name": "unknowns-discovery",
+      "source": "./plugins/unknowns-discovery",
+      "version": "3.7.0",
+      "description": "Discover and reduce task unknowns — blindspots, missing context, unknown unknowns — before committing to a plan, implementation, review, or merge.",
+      "keywords": [
+        "unknowns-discovery",
+        "unknowns",
+        "discovery",
+        "tooling",
+        "workflow",
+        "implementation"
+      ],
+      "category": "tooling"
+    },
+    {
       "name": "vitest-testing",
       "source": "./plugins/vitest-testing",
       "version": "3.7.0",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Production-tested skills for Claude Code - Cloudflare, AI, React, Tailwind v4, and modern web development",
-    "version": "3.6.3",
+    "version": "3.7.0",
     "homepage": "https://github.com/secondsky/claude-skills"
   },
   "plugins": [
     {
       "name": "aceternity-ui",
       "source": "./plugins/aceternity-ui",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "100+ animated React components (Aceternity UI) for Next.js with Tailwind. Use for hero sections, parallax, 3D effects, or encountering animation, shadcn CLI integration errors.",
       "keywords": [
         "aceternity-ui",
@@ -28,7 +28,7 @@
     {
       "name": "api-authentication",
       "source": "./plugins/api-authentication",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Secure API authentication with JWT, OAuth 2.0, API keys. Use for authentication systems, third-party integrations, service-to-service communication, or encountering token management, security headers, auth flow errors.",
       "keywords": [
         "api-authentication",
@@ -45,7 +45,7 @@
     {
       "name": "api-changelog-versioning",
       "source": "./plugins/api-changelog-versioning",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Creates comprehensive API changelogs documenting breaking changes, deprecations, and migration strategies for API consumers. Use when managing API versions, communicating breaking changes, or creating upgrade guides.",
       "keywords": [
         "api-changelog-versioning",
@@ -63,7 +63,7 @@
     {
       "name": "api-contract-testing",
       "source": "./plugins/api-contract-testing",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Verifies API contracts between services using consumer-driven contracts, schema validation, and tools like Pact. Use when testing microservices communication, preventing breaking changes, or validating OpenAPI specifications.",
       "keywords": [
         "api-contract-testing",
@@ -82,7 +82,7 @@
     {
       "name": "api-design-principles",
       "source": "./plugins/api-design-principles",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewing API specifications, or establishing API design standards.",
       "keywords": [
         "api-design-principles",
@@ -101,7 +101,7 @@
     {
       "name": "api-error-handling",
       "source": "./plugins/api-error-handling",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Implements standardized API error responses with proper status codes, logging, and user-friendly messages. Use when building production APIs, implementing error recovery patterns, or integrating error monitoring services.",
       "keywords": [
         "api-error-handling",
@@ -118,7 +118,7 @@
     {
       "name": "api-filtering-sorting",
       "source": "./plugins/api-filtering-sorting",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Builds flexible API filtering and sorting systems with query parameter parsing, validation, and security. Use when implementing search endpoints, building data grids, or creating dynamic query APIs.",
       "keywords": [
         "api-filtering-sorting",
@@ -136,7 +136,7 @@
     {
       "name": "api-gateway-configuration",
       "source": "./plugins/api-gateway-configuration",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Configures API gateways for routing, authentication, rate limiting, and request transformation in microservice architectures. Use when setting up Kong, Nginx, AWS API Gateway, or Traefik for centralized API management.",
       "keywords": [
         "api-gateway-configuration",
@@ -155,7 +155,7 @@
     {
       "name": "api-pagination",
       "source": "./plugins/api-pagination",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Implements efficient API pagination using offset, cursor, and keyset strategies for large datasets. Use when building paginated endpoints, implementing infinite scroll, or optimizing database queries for collections.",
       "keywords": [
         "api-pagination",
@@ -171,7 +171,7 @@
     {
       "name": "api-rate-limiting",
       "source": "./plugins/api-rate-limiting",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Implements API rate limiting using token bucket, sliding window, and Redis-based algorithms to protect against abuse. Use when securing public APIs, implementing tiered access, or preventing denial-of-service attacks.",
       "keywords": [
         "api-rate-limiting",
@@ -188,7 +188,7 @@
     {
       "name": "api-reference-documentation",
       "source": "./plugins/api-reference-documentation",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Creates professional API documentation using OpenAPI specifications with endpoints, authentication, and interactive examples. Use when documenting REST APIs, creating SDK references, or building developer portals.",
       "keywords": [
         "api-reference-documentation",
@@ -207,7 +207,7 @@
     {
       "name": "api-response-optimization",
       "source": "./plugins/api-response-optimization",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Optimizes API performance through payload reduction, caching strategies, and compression techniques. Use when improving API response times, reducing bandwidth usage, or implementing efficient caching.",
       "keywords": [
         "api-response-optimization",
@@ -225,7 +225,7 @@
     {
       "name": "api-security-hardening",
       "source": "./plugins/api-security-hardening",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "REST API security hardening with authentication, rate limiting, input validation, security headers. Use for production APIs, security audits, defense-in-depth, or encountering vulnerabilities, injection attacks, CORS issues.",
       "keywords": [
         "api-security-hardening",
@@ -245,7 +245,7 @@
     {
       "name": "api-testing",
       "source": "./plugins/api-testing",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "HTTP API testing for TypeScript (Supertest) and Python (httpx, pytest). Test REST APIs, GraphQL, request/response validation, authentication, and error handling.",
       "keywords": [
         "api-testing",
@@ -263,7 +263,7 @@
     {
       "name": "api-versioning-strategy",
       "source": "./plugins/api-versioning-strategy",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Implements API versioning using URL paths, headers, or query parameters with backward compatibility and deprecation strategies. Use when managing multiple API versions, planning breaking changes, or designing migration paths.",
       "keywords": [
         "api-versioning-strategy",
@@ -282,7 +282,7 @@
     {
       "name": "app-store-deployment",
       "source": "./plugins/app-store-deployment",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Publishes mobile applications to iOS App Store and Google Play with code signing, versioning, and CI/CD automation. Use when preparing app releases, configuring signing certificates, or setting up automated deployment pipelines.",
       "keywords": [
         "app-store-deployment",
@@ -296,7 +296,7 @@
     {
       "name": "architecture-patterns",
       "source": "./plugins/architecture-patterns",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Implement proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design. Use when architecting complex backend systems or refactoring existing applications for better maintainability.",
       "keywords": [
         "architecture-patterns",
@@ -310,7 +310,7 @@
     {
       "name": "auto-animate",
       "source": "./plugins/auto-animate",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity.",
       "keywords": [
         "auto-animate",
@@ -326,7 +326,7 @@
     {
       "name": "base-ui-react",
       "source": "./plugins/base-ui-react",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues.",
       "keywords": [
         "base-ui-react",
@@ -342,7 +342,7 @@
     {
       "name": "better-auth",
       "source": "./plugins/better-auth",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Skill for integrating Better Auth - comprehensive TypeScript authentication framework for Cloudflare D1, Next.js, Nuxt, and 15+ frameworks. Use when adding auth, encountering D1 adapter errors, or implementing OAuth/2FA/RBAC features.",
       "keywords": [
         "better-auth",
@@ -360,7 +360,7 @@
     {
       "name": "bun",
       "source": "./plugins/bun",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Comprehensive Bun runtime toolkit covering runtime, package manager, bundler, testing, HTTP servers, WebSockets, databases, framework integrations (Hono, Next.js, Nuxt, TanStack Start, SvelteKit), deployment, and Node.js compatibility.",
       "keywords": [
         "bun",
@@ -376,7 +376,7 @@
     {
       "name": "claude-code-bash-patterns",
       "source": "./plugins/claude-code-bash-patterns",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Claude Code Bash tool patterns with hooks, automation, git workflows. Use for PreToolUse hooks, command chaining, CLI orchestration, custom commands, or encountering bash permissions, command failures, security guards, hook configurations.",
       "keywords": [
         "claude-code-bash-patterns",
@@ -394,7 +394,7 @@
     {
       "name": "claude-hook-writer",
       "source": "./plugins/claude-hook-writer",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Expert guidance for writing secure, reliable, and performant Claude Code hooks - validates design decisions, enforces best practices, and prevents common pitfalls. Use when creating, reviewing, or debugging Claude Code hooks.",
       "keywords": [
         "claude-hook-writer",
@@ -409,7 +409,7 @@
     {
       "name": "cloudflare-agents",
       "source": "./plugins/cloudflare-agents",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Build AI agents on Cloudflare Workers with MCP integration, tool use, and LLM providers.",
       "keywords": [
         "cloudflare-agents",
@@ -426,7 +426,7 @@
     {
       "name": "cloudflare-browser-rendering",
       "source": "./plugins/cloudflare-browser-rendering",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded.",
       "keywords": [
         "cloudflare-browser-rendering",
@@ -442,7 +442,7 @@
     {
       "name": "cloudflare-cron-triggers",
       "source": "./plugins/cloudflare-cron-triggers",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors.",
       "keywords": [
         "cloudflare-cron-triggers",
@@ -458,7 +458,7 @@
     {
       "name": "cloudflare-d1",
       "source": "./plugins/cloudflare-d1",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors.",
       "keywords": [
         "cloudflare-d1",
@@ -473,7 +473,7 @@
     {
       "name": "cloudflare-durable-objects",
       "source": "./plugins/cloudflare-durable-objects",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors.",
       "keywords": [
         "cloudflare-durable-objects",
@@ -492,7 +492,7 @@
     {
       "name": "cloudflare-email-routing",
       "source": "./plugins/cloudflare-email-routing",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues.",
       "keywords": [
         "cloudflare-email-routing",
@@ -509,7 +509,7 @@
     {
       "name": "cloudflare-hyperdrive",
       "source": "./plugins/cloudflare-hyperdrive",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused.",
       "keywords": [
         "cloudflare-hyperdrive",
@@ -528,7 +528,7 @@
     {
       "name": "cloudflare-images",
       "source": "./plugins/cloudflare-images",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "This skill should be used when the user asks to \"upload images to Cloudflare\", \"implement direct creator upload\", \"configure image transformations\", \"optimize WebP/AVIF\", \"create image variants\", \"generate signed URLs\", \"add image watermarks\", \"integrate with Next.js/Remix\", \"configure webhooks\", \"debug CORS errors\", \"troubleshoot error 5408/9401-9413\", or \"build responsive images with Cloudflare Images API\".",
       "keywords": [
         "cloudflare-images",
@@ -547,7 +547,7 @@
     {
       "name": "cloudflare-kv",
       "source": "./plugins/cloudflare-kv",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues.",
       "keywords": [
         "cloudflare-kv",
@@ -563,7 +563,7 @@
     {
       "name": "cloudflare-manager",
       "source": "./plugins/cloudflare-manager",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Comprehensive Cloudflare account management for deploying Workers, KV Storage, R2, Pages, DNS, and Routes. Use when deploying cloudflare services, managing worker containers, configuring KV/R2 storage, or setting up DNS/routing. Requires CLOUDFLARE_API_KEY in .env and Bun runtime with dependencies installed.",
       "keywords": [
         "cloudflare-manager",
@@ -579,7 +579,7 @@
     {
       "name": "cloudflare-mcp-server",
       "source": "./plugins/cloudflare-mcp-server",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Build MCP (Model Context Protocol) servers on Cloudflare Workers with tools, resources, and prompts.",
       "keywords": [
         "cloudflare-mcp-server",
@@ -595,7 +595,7 @@
     {
       "name": "cloudflare-nextjs",
       "source": "./plugins/cloudflare-nextjs",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Deploy Next.js to Cloudflare Workers via the OpenNext adapter (@opennextjs/cloudflare). Use for SSR/ISR/SSG, App or Pages Router, getCloudflareContext, bindings (D1/R2/KV/AI/Hyperdrive), caching tiers, skew protection, multi-worker, custom worker, env vars, or worker size/runtime/keep_names/FinalizationRegistry/connection-scoping errors.",
       "keywords": [
         "cloudflare-nextjs",
@@ -616,7 +616,7 @@
     {
       "name": "cloudflare-queues",
       "source": "./plugins/cloudflare-queues",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "This skill should be used when the user asks to \"set up Cloudflare Queues\", \"create a message queue\", \"implement queue consumer\", \"process background jobs\", \"configure queue retry logic\", \"publish messages to queue\", \"implement dead letter queue\", or encountering \"queue timeout\", \"message retry\", \"throughput exceeded\", \"queue backlog\" errors.",
       "keywords": [
         "cloudflare-queues",
@@ -631,7 +631,7 @@
     {
       "name": "cloudflare-r2",
       "source": "./plugins/cloudflare-r2",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Cloudflare R2 S3-compatible object storage with SQL, Iceberg, event notifications, and automation. Use for buckets, uploads, CORS, presigned URLs, large files, S3 migration, analytics, or encountering R2_ERROR, CORS failures, multipart issues.",
       "keywords": [
         "cloudflare-r2",
@@ -648,7 +648,7 @@
     {
       "name": "cloudflare-sandbox",
       "source": "./plugins/cloudflare-sandbox",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations.",
       "keywords": [
         "cloudflare-sandbox",
@@ -663,7 +663,7 @@
     {
       "name": "cloudflare-turnstile",
       "source": "./plugins/cloudflare-turnstile",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Cloudflare Turnstile CAPTCHA-alternative bot protection. Use for forms, login security, API protection, or encountering CSP errors, token validation failures, error codes 100*/300*/600*.",
       "keywords": [
         "cloudflare-turnstile",
@@ -681,7 +681,7 @@
     {
       "name": "cloudflare-vectorize",
       "source": "./plugins/cloudflare-vectorize",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors.",
       "keywords": [
         "cloudflare-vectorize",
@@ -697,7 +697,7 @@
     {
       "name": "cloudflare-workers",
       "source": "./plugins/cloudflare-workers",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Comprehensive Cloudflare Workers platform guide covering runtime APIs, testing (Vitest), CI/CD, observability, framework integration, performance, security, and migration. Use for Workers development, deployment, debugging, or optimization.",
       "keywords": [
         "cloudflare-workers",
@@ -712,7 +712,7 @@
     {
       "name": "cloudflare-workers-ai",
       "source": "./plugins/cloudflare-workers-ai",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors.",
       "keywords": [
         "cloudflare-workers-ai",
@@ -727,7 +727,7 @@
     {
       "name": "cloudflare-workflows",
       "source": "./plugins/cloudflare-workflows",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors.",
       "keywords": [
         "cloudflare-workflows",
@@ -743,7 +743,7 @@
     {
       "name": "cloudflare-zero-trust-access",
       "source": "./plugins/cloudflare-zero-trust-access",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers.",
       "keywords": [
         "cloudflare-zero-trust-access",
@@ -764,7 +764,7 @@
     {
       "name": "code-review",
       "source": "./plugins/code-review",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Code review practices with technical rigor and verification gates. Use for receiving feedback, requesting code-reviewer subagent reviews, or preventing false completion claims in pull requests.",
       "keywords": [
         "code-review",
@@ -778,7 +778,7 @@
     {
       "name": "csrf-protection",
       "source": "./plugins/csrf-protection",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Implements CSRF protection using synchronizer tokens, double-submit cookies, and SameSite attributes. Use when securing web forms, protecting state-changing endpoints, or implementing defense-in-depth authentication.",
       "keywords": [
         "csrf-protection",
@@ -795,7 +795,7 @@
     {
       "name": "cybersecurity",
       "source": "./plugins/cybersecurity",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "OSS-only security for OWASP Top 10, pentest, vuln testing (XSS, SSRF, CSRF, business-logic, Host header), threat modeling (STRIDE, ATT&CK), Sigma rules, SAST, code audit, AI/LLM red-team, or replacing paid tools (Burp, Nessus, Splunk) with OSS.",
       "keywords": [
         "cybersecurity",
@@ -817,7 +817,7 @@
     {
       "name": "defense-in-depth-validation",
       "source": "./plugins/defense-in-depth-validation",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Validate at every layer data passes through to make bugs impossible. Use when invalid data causes failures deep in execution, requiring validation at multiple system layers.",
       "keywords": [
         "defense-in-depth-validation",
@@ -835,7 +835,7 @@
     {
       "name": "delegate-my-work",
       "source": "./plugins/delegate-my-work",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Interview employees to find recurring work, map accessible AI and automation tools, and spec each loop with preferred and fallback routes.",
       "keywords": [
         "delegate-my-work",
@@ -849,7 +849,7 @@
     {
       "name": "dependency-upgrade",
       "source": "./plugins/dependency-upgrade",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Secure dependency upgrades with supply chain protection, cooldowns, staged rollout, and Socket CLI integration. Use when upgrading deps, configuring security policies, or preventing supply chain attacks.",
       "keywords": [
         "dependency-upgrade",
@@ -864,7 +864,7 @@
     {
       "name": "design-review",
       "source": "./plugins/design-review",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states.",
       "keywords": [
         "design-review",
@@ -879,7 +879,7 @@
     {
       "name": "design-system-creation",
       "source": "./plugins/design-system-creation",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency.",
       "keywords": [
         "design-system-creation",
@@ -894,7 +894,7 @@
     {
       "name": "drizzle-orm-d1",
       "source": "./plugins/drizzle-orm-d1",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transaction errors, foreign key constraint failures, or schema inference issues.",
       "keywords": [
         "drizzle-orm-d1",
@@ -911,7 +911,7 @@
     {
       "name": "feature-dev",
       "source": "./plugins/feature-dev",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Automate 7-phase feature development with specialized agents (code-explorer, code-architect, code-reviewer). Use for multi-file features, architectural decisions, or encountering ambiguous requirements, integration patterns, design approach errors.",
       "keywords": [
         "feature-dev",
@@ -925,7 +925,7 @@
     {
       "name": "firecrawl-scraper",
       "source": "./plugins/firecrawl-scraper",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors.",
       "keywords": [
         "firecrawl-scraper",
@@ -941,7 +941,7 @@
     {
       "name": "frontend-design",
       "source": "./plugins/frontend-design",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.",
       "keywords": [
         "frontend-design",
@@ -955,7 +955,7 @@
     {
       "name": "gemini-cli",
       "source": "./plugins/gemini-cli",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool.",
       "keywords": [
         "gemini-cli",
@@ -970,7 +970,7 @@
     {
       "name": "github-project-automation",
       "source": "./plugins/github-project-automation",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors.",
       "keywords": [
         "github-project-automation",
@@ -987,7 +987,7 @@
     {
       "name": "graphql-implementation",
       "source": "./plugins/graphql-implementation",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Builds GraphQL APIs with schema design, resolvers, error handling, and performance optimization using Apollo or Graphene. Use when creating flexible query APIs, migrating from REST, or implementing real-time subscriptions.",
       "keywords": [
         "graphql-implementation",
@@ -1003,7 +1003,7 @@
     {
       "name": "health-check-endpoints",
       "source": "./plugins/health-check-endpoints",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Health check endpoints for liveness, readiness, dependency monitoring. Use for Kubernetes, load balancers, auto-scaling, or encountering probe failures, startup delays, dependency checks, timeout configuration errors.",
       "keywords": [
         "health-check-endpoints",
@@ -1019,7 +1019,7 @@
     {
       "name": "hono-routing",
       "source": "./plugins/hono-routing",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors.",
       "keywords": [
         "hono-routing",
@@ -1036,7 +1036,7 @@
     {
       "name": "hugo",
       "source": "./plugins/hugo",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors.",
       "keywords": [
         "hugo",
@@ -1050,7 +1050,7 @@
     {
       "name": "idempotency-handling",
       "source": "./plugins/idempotency-handling",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Idempotent API operations with idempotency keys, Redis caching, DB constraints. Use for payment systems, webhook retries, safe retries, or encountering duplicate processing, race conditions, key expiry errors.",
       "keywords": [
         "idempotency-handling",
@@ -1065,7 +1065,7 @@
     {
       "name": "image-optimization",
       "source": "./plugins/image-optimization",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Optimizes images for web performance using modern formats, responsive techniques, and lazy loading strategies. Use when improving page load times, implementing responsive images, or preparing assets for production deployment.",
       "keywords": [
         "image-optimization",
@@ -1080,7 +1080,7 @@
     {
       "name": "inspira-ui",
       "source": "./plugins/inspira-ui",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "120+ Vue/Nuxt animated components with TailwindCSS v4, motion-v, GSAP, Three.js. Use for hero sections, 3D effects, interactive backgrounds, or encountering setup, CSS variables, motion-v integration errors.",
       "keywords": [
         "inspira-ui",
@@ -1096,7 +1096,7 @@
     {
       "name": "interaction-design",
       "source": "./plugins/interaction-design",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Creates intuitive user experiences through feedback patterns, microinteractions, and accessible interaction design. Use when designing loading states, error handling UX, animation guidelines, or touch interactions.",
       "keywords": [
         "interaction-design",
@@ -1110,7 +1110,7 @@
     {
       "name": "internationalization-i18n",
       "source": "./plugins/internationalization-i18n",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Implements multi-language support using i18next, gettext, or Intl API with translation workflows and RTL support. Use when building multilingual applications, handling date/currency formatting, or supporting right-to-left languages.",
       "keywords": [
         "internationalization-i18n",
@@ -1124,7 +1124,7 @@
     {
       "name": "jest-generator",
       "source": "./plugins/jest-generator",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Generate Jest unit tests for JavaScript/TypeScript with mocking, coverage. Use for JS/TS modules, React components, test generation, or encountering missing coverage, improper mocking, test structure errors.",
       "keywords": [
         "jest-generator",
@@ -1140,7 +1140,7 @@
     {
       "name": "kpi-dashboard-design",
       "source": "./plugins/kpi-dashboard-design",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Designs effective KPI dashboards with proper metric selection, visual hierarchy, and data visualization best practices. Use when building executive dashboards, creating analytics views, or presenting business metrics.",
       "keywords": [
         "kpi-dashboard-design",
@@ -1155,7 +1155,7 @@
     {
       "name": "logging-best-practices",
       "source": "./plugins/logging-best-practices",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Structured logging with proper levels, context, PII handling, centralized aggregation. Use for application logging, log management integration, distributed tracing, or encountering log bloat, PII exposure, missing context errors.",
       "keywords": [
         "logging-best-practices",
@@ -1171,7 +1171,7 @@
     {
       "name": "maz-ui",
       "source": "./plugins/maz-ui",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Maz-UI v4 - Modern Vue & Nuxt component library with 50+ standalone components, composables, directives, theming, i18n, and SSR support.",
       "keywords": [
         "maz-ui",
@@ -1185,7 +1185,7 @@
     {
       "name": "mcp-dynamic-orchestrator",
       "source": "./plugins/mcp-dynamic-orchestrator",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets.",
       "keywords": [
         "mcp-dynamic-orchestrator",
@@ -1200,7 +1200,7 @@
     {
       "name": "mcp-management",
       "source": "./plugins/mcp-management",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Manage MCP servers - discover, analyze, execute tools/prompts/resources. Use for MCP integrations, capability discovery, tool filtering, programmatic execution, or encountering context bloat, server configuration, tool execution errors.",
       "keywords": [
         "mcp-management",
@@ -1214,7 +1214,7 @@
     {
       "name": "microservices-patterns",
       "source": "./plugins/microservices-patterns",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Design microservices architectures with service boundaries, event-driven communication, and resilience patterns. Use when building distributed systems, decomposing monoliths, or implementing microservices.",
       "keywords": [
         "microservices-patterns",
@@ -1227,7 +1227,7 @@
     {
       "name": "ml-model-training",
       "source": "./plugins/ml-model-training",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Train ML models with scikit-learn, PyTorch, TensorFlow. Use for classification/regression, neural networks, hyperparameter tuning, or encountering overfitting, underfitting, convergence issues.",
       "keywords": [
         "ml-model-training",
@@ -1243,7 +1243,7 @@
     {
       "name": "ml-pipeline-automation",
       "source": "./plugins/ml-pipeline-automation",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Automate ML workflows with Airflow, Kubeflow, MLflow. Use for reproducible pipelines, retraining schedules, MLOps, or encountering task failures, dependency errors, experiment tracking issues.",
       "keywords": [
         "ml-pipeline-automation",
@@ -1258,7 +1258,7 @@
     {
       "name": "mobile-app-debugging",
       "source": "./plugins/mobile-app-debugging",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Mobile app debugging for iOS, Android, cross-platform frameworks. Use for crashes, memory leaks, performance issues, network problems, or encountering Xcode instruments, Android Profiler, React Native debugger, native bridge errors.",
       "keywords": [
         "mobile-app-debugging",
@@ -1272,7 +1272,7 @@
     {
       "name": "mobile-app-testing",
       "source": "./plugins/mobile-app-testing",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Mobile app testing with unit tests, UI automation, performance testing. Use for test infrastructure, E2E tests, testing standards, or encountering test framework setup, device farms, flaky tests, platform-specific test errors.",
       "keywords": [
         "mobile-app-testing",
@@ -1287,7 +1287,7 @@
     {
       "name": "mobile-first-design",
       "source": "./plugins/mobile-first-design",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Designs responsive interfaces starting from mobile screens with progressive enhancement for larger devices. Use when building responsive websites, optimizing for mobile users, or implementing adaptive layouts.",
       "keywords": [
         "mobile-first-design",
@@ -1303,7 +1303,7 @@
     {
       "name": "mobile-offline-support",
       "source": "./plugins/mobile-offline-support",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Offline-first mobile apps with local storage, sync queues, conflict resolution. Use for offline functionality, data sync, connectivity handling, or encountering sync conflicts, queue management, storage limits, network transition errors.",
       "keywords": [
         "mobile-offline-support",
@@ -1317,7 +1317,7 @@
     {
       "name": "model-deployment",
       "source": "./plugins/model-deployment",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Deploy ML models with FastAPI, Docker, Kubernetes. Use for serving predictions, containerization, monitoring, drift detection, or encountering latency issues, health check failures, version conflicts.",
       "keywords": [
         "model-deployment",
@@ -1332,7 +1332,7 @@
     {
       "name": "motion",
       "source": "./plugins/motion",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Motion (Framer Motion) React animation library. Use for drag-and-drop, scroll animations, gestures, SVG morphing, or encountering bundle size, complex transitions, spring physics errors.",
       "keywords": [
         "motion",
@@ -1345,7 +1345,7 @@
     {
       "name": "multi-ai-consultant",
       "source": "./plugins/multi-ai-consultant",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Consult external AIs (Gemini 2.5 Pro, OpenAI Codex, Claude) for second opinions. Use for debugging failures, architectural decisions, security validation, or need fresh perspective with synthesis.",
       "keywords": [
         "multi-ai-consultant",
@@ -1362,7 +1362,7 @@
     {
       "name": "mutation-testing",
       "source": "./plugins/mutation-testing",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.",
       "keywords": [
         "mutation-testing",
@@ -1377,7 +1377,7 @@
     {
       "name": "nano-banana-prompts",
       "source": "./plugins/nano-banana-prompts",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Generate optimized prompts for Gemini 2.5 Flash Image (Nano Banana). Use for image generation, crafting photo prompts, art styles, or multi-turn editing workflows with best practices.",
       "keywords": [
         "nano-banana-prompts",
@@ -1392,7 +1392,7 @@
     {
       "name": "nextjs",
       "source": "./plugins/nextjs",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors.",
       "keywords": [
         "nextjs",
@@ -1407,7 +1407,7 @@
     {
       "name": "nuxt-content",
       "source": "./plugins/nuxt-content",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Nuxt Content v3 Git-backed CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Vercel deployment, SQL storage, MDC components, content collections.",
       "keywords": [
         "nuxt-content",
@@ -1425,7 +1425,7 @@
     {
       "name": "nuxt-seo",
       "source": "./plugins/nuxt-seo",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Comprehensive guide for all 8 Nuxt SEO modules plus Pro modules. Use when building SEO-optimized Nuxt applications, implementing robots.txt/sitemaps, generating OG images, adding Schema.org data, managing meta tags, checking links, or encountering sitemap, robots.txt, OG image, schema validation, meta tag, canonical URL, or i18n SEO errors.",
       "keywords": [
         "nuxt-seo",
@@ -1441,7 +1441,7 @@
     {
       "name": "nuxt-studio",
       "source": "./plugins/nuxt-studio",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Visual CMS for Nuxt Content with Cloudflare deployment. Use when setting up Nuxt Studio, configuring OAuth authentication, deploying to Cloudflare Pages/Workers with subdomain routing, or troubleshooting Studio integration.",
       "keywords": [
         "nuxt-studio",
@@ -1457,7 +1457,7 @@
     {
       "name": "nuxt-ui-v4",
       "source": "./plugins/nuxt-ui-v4",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Nuxt UI v4 with 125+ accessible components, Tailwind v4, Reka UI, AI chat integration with reasoning and tool calling. Use for dashboards, forms, overlays, editors, page layouts, or encountering theming, composable, TypeScript errors.",
       "keywords": [
         "nuxt-ui-v4",
@@ -1470,7 +1470,7 @@
     {
       "name": "nuxt-v4",
       "source": "./plugins/nuxt-v4",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Comprehensive Nuxt 4 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 4 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 3, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
       "keywords": [
         "nuxt-v4",
@@ -1485,7 +1485,7 @@
     {
       "name": "nuxt-v5",
       "source": "./plugins/nuxt-v5",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Comprehensive Nuxt 5 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 5 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 4, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
       "keywords": [
         "nuxt-v5",
@@ -1500,7 +1500,7 @@
     {
       "name": "oauth-implementation",
       "source": "./plugins/oauth-implementation",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "OAuth 2.0 and OpenID Connect authentication with secure flows. Use for third-party integrations, SSO systems, token-based API access, or encountering authorization code flow, PKCE, token refresh, scope management errors.",
       "keywords": [
         "oauth-implementation",
@@ -1520,7 +1520,7 @@
     {
       "name": "payment-gateway-integration",
       "source": "./plugins/payment-gateway-integration",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Integrates payment processing with Stripe, PayPal, or Square including subscriptions, webhooks, and PCI compliance. Use when implementing checkout flows, recurring billing, or handling refunds and disputes.",
       "keywords": [
         "payment-gateway-integration",
@@ -1537,7 +1537,7 @@
     {
       "name": "pinia-colada",
       "source": "./plugins/pinia-colada",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors.",
       "keywords": [
         "pinia-colada",
@@ -1555,7 +1555,7 @@
     {
       "name": "pinia-v3",
       "source": "./plugins/pinia-v3",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors.",
       "keywords": [
         "pinia-v3",
@@ -1570,7 +1570,7 @@
     {
       "name": "plan-interview",
       "source": "./plugins/plan-interview",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Adaptive interview-driven spec generation with quality review. Automatically adjusts depth based on plan complexity.",
       "keywords": [
         "plan-interview",
@@ -1584,7 +1584,7 @@
     {
       "name": "playwright",
       "source": "./plugins/playwright",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Browser automation and E2E testing with Playwright. Auto-detects dev servers, writes clean test scripts. Test pages, fill forms, take screenshots, check responsive design, validate UX, test login flows, check links, automate any browser task. Use for cross-browser testing, visual regression, API testing, component testing in TypeScript/JavaScript and Python projects.",
       "keywords": [
         "playwright",
@@ -1597,7 +1597,7 @@
     {
       "name": "progressive-web-app",
       "source": "./plugins/progressive-web-app",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Builds Progressive Web Apps with service workers, web manifest, offline support, and installation prompts. Use when creating installable web experiences, implementing offline functionality, or adding push notifications to web apps.",
       "keywords": [
         "progressive-web-app",
@@ -1612,7 +1612,7 @@
     {
       "name": "push-notification-setup",
       "source": "./plugins/push-notification-setup",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Implements push notifications across iOS, Android, and web using Firebase Cloud Messaging and native services. Use when adding notification capabilities, handling background messages, or setting up notification channels.",
       "keywords": [
         "push-notification-setup",
@@ -1628,7 +1628,7 @@
     {
       "name": "react-best-practices",
       "source": "./plugins/react-best-practices",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "React and Next.js performance optimization guidelines from Vercel Engineering. Use when writing/reviewing/refactoring React code for optimal performance. Covers async patterns, bundle optimization, server/client components, re-render optimization.",
       "keywords": [
         "react-best-practices",
@@ -1645,7 +1645,7 @@
     {
       "name": "react-composition-patterns",
       "source": "./plugins/react-composition-patterns",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "React composition patterns from Vercel Engineering. Use when building scalable components, avoiding boolean prop proliferation, implementing compound components, or managing component state. Covers architecture, state management, and implementation patterns.",
       "keywords": [
         "react-composition-patterns",
@@ -1662,7 +1662,7 @@
     {
       "name": "react-hook-form-zod",
       "source": "./plugins/react-hook-form-zod",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems.",
       "keywords": [
         "react-hook-form-zod",
@@ -1679,7 +1679,7 @@
     {
       "name": "react-native-skills",
       "source": "./plugins/react-native-skills",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "React Native and Expo best practices for building performant mobile apps. Use when building React Native components, optimizing list performance, implementing animations, or working with native modules.",
       "keywords": [
         "react-native-skills",
@@ -1694,7 +1694,7 @@
     {
       "name": "recommendation-engine",
       "source": "./plugins/recommendation-engine",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Build recommendation systems with collaborative filtering, matrix factorization, hybrid approaches. Use for product recommendations, personalization, or encountering cold start, sparsity, quality evaluation issues.",
       "keywords": [
         "recommendation-engine",
@@ -1711,7 +1711,7 @@
     {
       "name": "recommendation-system",
       "source": "./plugins/recommendation-system",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Deploy production recommendation systems with feature stores, caching, A/B testing. Use for personalization APIs, low latency serving, or encountering cache invalidation, experiment tracking, quality monitoring issues.",
       "keywords": [
         "recommendation-system",
@@ -1729,7 +1729,7 @@
     {
       "name": "responsive-web-design",
       "source": "./plugins/responsive-web-design",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Builds adaptive web interfaces using Flexbox, CSS Grid, and media queries with a mobile-first approach. Use when creating multi-device layouts, implementing flexible UI systems, or ensuring cross-browser compatibility.",
       "keywords": [
         "responsive-web-design",
@@ -1745,7 +1745,7 @@
     {
       "name": "rest-api-design",
       "source": "./plugins/rest-api-design",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Designs RESTful APIs with proper resource naming, HTTP methods, status codes, and response formats. Use when building new APIs, establishing API conventions, or designing developer-friendly interfaces.",
       "keywords": [
         "rest-api-design",
@@ -1761,7 +1761,7 @@
     {
       "name": "root-cause-tracing",
       "source": "./plugins/root-cause-tracing",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Systematically trace bugs backward through call stack to find original trigger. Use when errors occur deep in execution and you need to trace back to find the original trigger.",
       "keywords": [
         "root-cause-tracing",
@@ -1776,7 +1776,7 @@
     {
       "name": "security-headers-configuration",
       "source": "./plugins/security-headers-configuration",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Configures HTTP security headers to protect against XSS, clickjacking, and MIME sniffing attacks. Use when hardening web applications, passing security audits, or implementing Content Security Policy.",
       "keywords": [
         "security-headers-configuration",
@@ -1795,7 +1795,7 @@
     {
       "name": "seo-keyword-cluster-builder",
       "source": "./plugins/seo-keyword-cluster-builder",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Groups related keywords into topic clusters and creates content hub architecture recommendations with internal linking strategies. Use when planning content strategy, organizing keyword research, or building pillar page structures.",
       "keywords": [
         "seo-keyword-cluster-builder",
@@ -1812,7 +1812,7 @@
     {
       "name": "seo-optimizer",
       "source": "./plugins/seo-optimizer",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "SEO optimization with keyword analysis, readability assessment, technical validation, content quality. Use for search rankings, blog posts, content audits, or encountering keyword density, readability scores, meta tags, schema markup errors.",
       "keywords": [
         "seo-optimizer",
@@ -1828,7 +1828,7 @@
     {
       "name": "sequential-thinking",
       "source": "./plugins/sequential-thinking",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Systematic step-by-step reasoning with revision and branching. Use for complex problems, multi-stage analysis, design planning, problem decomposition, or encountering unclear scope, alternative approaches needed, revision requirements.",
       "keywords": [
         "sequential-thinking",
@@ -1842,7 +1842,7 @@
     {
       "name": "session-management",
       "source": "./plugins/session-management",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Implements secure session management with JWT tokens, Redis storage, refresh flows, and proper cookie configuration. Use when building authentication systems, managing user sessions, or implementing secure logout functionality.",
       "keywords": [
         "session-management",
@@ -1859,7 +1859,7 @@
     {
       "name": "shadcn-vue",
       "source": "./plugins/shadcn-vue",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors.",
       "keywords": [
         "shadcn-vue",
@@ -1873,7 +1873,7 @@
     {
       "name": "systematic-debugging",
       "source": "./plugins/systematic-debugging",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Four-phase debugging framework that ensures root cause investigation before attempting fixes. Never jump to solutions. Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes.",
       "keywords": [
         "systematic-debugging",
@@ -1887,7 +1887,7 @@
     {
       "name": "tailwind-v4-shadcn",
       "source": "./plugins/tailwind-v4-shadcn",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React. Use when: initializing React projects with Tailwind v4, setting up shadcn/ui, implementing dark mode, debugging CSS variable issues, fixing theme switching, migrating from Tailwind v3, or encountering color/theming problems. Covers: @theme inline pattern, CSS variable architecture, dark mode with ThemeProvider, component composition, vite.config setup, common v4 gotchas, and production-tested patterns.",
       "keywords": [
         "tailwind-v4-shadcn",
@@ -1903,7 +1903,7 @@
     {
       "name": "tanstack-ai",
       "source": "./plugins/tanstack-ai",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and tool definitions.",
       "keywords": [
         "tanstack-ai",
@@ -1919,7 +1919,7 @@
     {
       "name": "tanstack-query",
       "source": "./plugins/tanstack-query",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors.",
       "keywords": [
         "tanstack-query",
@@ -1935,7 +1935,7 @@
     {
       "name": "tanstack-router",
       "source": "./plugins/tanstack-router",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "TanStack Router type-safe file-based routing for React. Use for SPAs, TanStack Query integration, Cloudflare Workers, or encountering devtools, type safety, loader, Vite bundling errors.",
       "keywords": [
         "tanstack-router",
@@ -1949,7 +1949,7 @@
     {
       "name": "tanstack-start",
       "source": "./plugins/tanstack-start",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "TanStack Start (RC) full-stack React with server functions, SSR, Cloudflare Workers. Use for Next.js migration, edge rendering, or encountering hydration, auth, data pattern errors.",
       "keywords": [
         "tanstack-start",
@@ -1966,7 +1966,7 @@
     {
       "name": "tanstack-table",
       "source": "./plugins/tanstack-table",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "TanStack Table v8 headless data tables with server-side features for Cloudflare Workers + D1. Use for pagination, filtering, sorting, virtualization, or encountering state management, TanStack Query coordination, URL sync errors.",
       "keywords": [
         "tanstack-table",
@@ -1979,9 +1979,23 @@
       "category": "frontend"
     },
     {
+      "name": "tech-debt",
+      "source": "./plugins/tech-debt",
+      "version": "3.7.0",
+      "description": "Multi-skill plugin: tech-debt",
+      "keywords": [
+        "tech-debt",
+        "tech",
+        "debt",
+        "tooling",
+        "workflow"
+      ],
+      "category": "tooling"
+    },
+    {
       "name": "technical-specification",
       "source": "./plugins/technical-specification",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Creates detailed technical specifications for software projects covering requirements, architecture, APIs, and testing strategies. Use when planning features, documenting system design, or creating architecture decision records.",
       "keywords": [
         "technical-specification",
@@ -1997,7 +2011,7 @@
     {
       "name": "test-quality-analysis",
       "source": "./plugins/test-quality-analysis",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Detect test smells, overmocking, flaky tests, and coverage issues. Analyze test effectiveness, maintainability, and reliability. Use when reviewing tests or improving test quality.",
       "keywords": [
         "test-quality-analysis",
@@ -2013,7 +2027,7 @@
     {
       "name": "thesys-generative-ui",
       "source": "./plugins/thesys-generative-ui",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "AI-powered generative UI with Thesys - create React components from natural language.",
       "keywords": [
         "thesys-generative-ui",
@@ -2028,7 +2042,7 @@
     {
       "name": "threejs",
       "source": "./plugins/threejs",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Comprehensive Three.js skills for building 3D web experiences",
       "keywords": [
         "threejs",
@@ -2040,7 +2054,7 @@
     {
       "name": "turborepo",
       "source": "./plugins/turborepo",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Turborepo high-performance monorepo build system. Use for monorepo setup, build optimization, task pipelines, caching strategies, or multi-package orchestration.",
       "keywords": [
         "turborepo",
@@ -2053,7 +2067,7 @@
     {
       "name": "typescript-migration",
       "source": "./plugins/typescript-migration",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "TypeScript version migration guide (5.x to 6 to 7, tsgo native port). Use for TS 6 tsconfig breaking changes, TS 7 Go rewrite rollout, or TS5xxx deprecation codes.",
       "keywords": [
         "typescript-migration",
@@ -2066,7 +2080,7 @@
     {
       "name": "ultracite",
       "source": "./plugins/ultracite",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Ultracite multi-provider linting/formatting (Biome, ESLint, Oxlint). Use for v6/v7 setup, provider selection, Git hooks, MCP integration, AI hooks, migrations, or encountering configuration, type-aware linting, monorepo errors.",
       "keywords": [
         "ultracite",
@@ -2080,7 +2094,7 @@
     {
       "name": "vitest-testing",
       "source": "./plugins/vitest-testing",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Modern TypeScript/JavaScript testing with Vitest. Fast unit and integration tests, native ESM support, Vite-powered HMR, and comprehensive mocking. Use for testing TS/JS projects.",
       "keywords": [
         "vitest-testing",
@@ -2097,7 +2111,7 @@
     {
       "name": "vulnerability-scanning",
       "source": "./plugins/vulnerability-scanning",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Implements automated security scanning for dependencies, code, and containers using tools like Trivy, Snyk, and npm audit. Use when setting up CI/CD security gates, conducting pre-deployment audits, or meeting compliance requirements.",
       "keywords": [
         "vulnerability-scanning",
@@ -2113,7 +2127,7 @@
     {
       "name": "web-performance-audit",
       "source": "./plugins/web-performance-audit",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Web performance audits with Core Web Vitals, bottleneck identification, optimization recommendations. Use for page load times, performance reviews, UX optimization, or encountering LCP, FID, CLS issues, resource blocking, render delays.",
       "keywords": [
         "web-performance-audit",
@@ -2130,7 +2144,7 @@
     {
       "name": "web-performance-optimization",
       "source": "./plugins/web-performance-optimization",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Optimizes web application performance through code splitting, lazy loading, caching strategies, and Core Web Vitals monitoring. Use when improving page load times, implementing service workers, or reducing bundle sizes.",
       "keywords": [
         "web-performance-optimization",
@@ -2145,7 +2159,7 @@
     {
       "name": "websocket-implementation",
       "source": "./plugins/websocket-implementation",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Implements real-time WebSocket communication with connection management, room-based messaging, and horizontal scaling. Use when building chat systems, live notifications, collaborative tools, or real-time dashboards.",
       "keywords": [
         "websocket-implementation",
@@ -2159,7 +2173,7 @@
     {
       "name": "woocommerce-backend-dev",
       "source": "./plugins/woocommerce-backend-dev",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Add or modify WooCommerce backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code in WooCommerce projects.",
       "keywords": [
         "woocommerce-backend-dev",
@@ -2176,7 +2190,7 @@
     {
       "name": "woocommerce-code-review",
       "source": "./plugins/woocommerce-code-review",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Review WooCommerce code changes for coding standards compliance. Use when reviewing code locally, performing automated PR reviews, or checking code quality in WooCommerce projects.",
       "keywords": [
         "woocommerce-code-review",
@@ -2192,7 +2206,7 @@
     {
       "name": "woocommerce-copy-guidelines",
       "source": "./plugins/woocommerce-copy-guidelines",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Guidelines for UI text and copy in WooCommerce. Use when writing user-facing text, labels, buttons, messages, or documentation in WooCommerce projects.",
       "keywords": [
         "woocommerce-copy-guidelines",
@@ -2208,7 +2222,7 @@
     {
       "name": "woocommerce-dev-cycle",
       "source": "./plugins/woocommerce-dev-cycle",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Run tests, linting, and quality checks for WooCommerce development. Use when running tests, fixing code style, or following the development workflow in WooCommerce projects.",
       "keywords": [
         "woocommerce-dev-cycle",
@@ -2224,7 +2238,7 @@
     {
       "name": "wordpress-plugin-core",
       "source": "./plugins/wordpress-plugin-core",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors.",
       "keywords": [
         "wordpress-plugin-core",
@@ -2245,7 +2259,7 @@
     {
       "name": "xss-prevention",
       "source": "./plugins/xss-prevention",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Prevents Cross-Site Scripting attacks through input sanitization, output encoding, and Content Security Policy. Use when handling user-generated content, implementing rich text editors, or securing web applications.",
       "keywords": [
         "xss-prevention",
@@ -2261,7 +2275,7 @@
     {
       "name": "zod",
       "source": "./plugins/zod",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies (2kb gzipped).",
       "keywords": [
         "zod",
@@ -2276,7 +2290,7 @@
     {
       "name": "zustand-state-management",
       "source": "./plugins/zustand-state-management",
-      "version": "3.6.3",
+      "version": "3.7.0",
       "description": "Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loops.",
       "keywords": [
         "zustand-state-management",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Production-tested skills for Claude Code - Cloudflare, AI, React, Tailwind v4, and modern web development",
   "scripts": {
     "validate": "./scripts/validate-json-schemas.sh",

--- a/plugins/aceternity-ui/.claude-plugin/plugin.json
+++ b/plugins/aceternity-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aceternity-ui",
   "description": "100+ animated React components (Aceternity UI) for Next.js with Tailwind. Use for hero sections, parallax, 3D effects, or encountering animation, shadcn CLI integration errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/aceternity-ui/.codex-plugin/plugin.json
+++ b/plugins/aceternity-ui/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aceternity-ui",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "100+ animated React components (Aceternity UI) for Next.js with Tailwind. Use for hero sections, parallax, 3D effects, or encountering animation, shadcn CLI integration errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-authentication/.claude-plugin/plugin.json
+++ b/plugins/api-authentication/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-authentication",
   "description": "Secure API authentication with JWT, OAuth 2.0, API keys. Use for authentication systems, third-party integrations, service-to-service communication, or encountering token management, security headers, auth flow errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-authentication/.codex-plugin/plugin.json
+++ b/plugins/api-authentication/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-authentication",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Secure API authentication with JWT, OAuth 2.0, API keys. Use for authentication systems, third-party integrations, service-to-service communication, or encountering token management, security headers, auth flow errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-changelog-versioning/.claude-plugin/plugin.json
+++ b/plugins/api-changelog-versioning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-changelog-versioning",
   "description": "Creates comprehensive API changelogs documenting breaking changes, deprecations, and migration strategies for API consumers. Use when managing API versions, communicating breaking changes, or creating upgrade guides.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-changelog-versioning/.codex-plugin/plugin.json
+++ b/plugins/api-changelog-versioning/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-changelog-versioning",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Creates comprehensive API changelogs documenting breaking changes, deprecations, and migration strategies for API consumers. Use when managing API versions, communicating breaking changes, or creating upgrade guides.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-contract-testing/.claude-plugin/plugin.json
+++ b/plugins/api-contract-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-contract-testing",
   "description": "Verifies API contracts between services using consumer-driven contracts, schema validation, and tools like Pact. Use when testing microservices communication, preventing breaking changes, or validating OpenAPI specifications.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-contract-testing/.codex-plugin/plugin.json
+++ b/plugins/api-contract-testing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-contract-testing",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Verifies API contracts between services using consumer-driven contracts, schema validation, and tools like Pact. Use when testing microservices communication, preventing breaking changes, or validating OpenAPI specifications.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-design-principles/.claude-plugin/plugin.json
+++ b/plugins/api-design-principles/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-design-principles",
   "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewing API specifications, or establishing API design standards.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-design-principles/.codex-plugin/plugin.json
+++ b/plugins/api-design-principles/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-design-principles",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewing API specifications, or establishing API design standards.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-error-handling/.claude-plugin/plugin.json
+++ b/plugins/api-error-handling/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-error-handling",
   "description": "Implements standardized API error responses with proper status codes, logging, and user-friendly messages. Use when building production APIs, implementing error recovery patterns, or integrating error monitoring services.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-error-handling/.codex-plugin/plugin.json
+++ b/plugins/api-error-handling/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-error-handling",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Implements standardized API error responses with proper status codes, logging, and user-friendly messages. Use when building production APIs, implementing error recovery patterns, or integrating error monitoring services.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-filtering-sorting/.claude-plugin/plugin.json
+++ b/plugins/api-filtering-sorting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-filtering-sorting",
   "description": "Builds flexible API filtering and sorting systems with query parameter parsing, validation, and security. Use when implementing search endpoints, building data grids, or creating dynamic query APIs.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-filtering-sorting/.codex-plugin/plugin.json
+++ b/plugins/api-filtering-sorting/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-filtering-sorting",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Builds flexible API filtering and sorting systems with query parameter parsing, validation, and security. Use when implementing search endpoints, building data grids, or creating dynamic query APIs.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-gateway-configuration/.claude-plugin/plugin.json
+++ b/plugins/api-gateway-configuration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-gateway-configuration",
   "description": "Configures API gateways for routing, authentication, rate limiting, and request transformation in microservice architectures. Use when setting up Kong, Nginx, AWS API Gateway, or Traefik for centralized API management.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-gateway-configuration/.codex-plugin/plugin.json
+++ b/plugins/api-gateway-configuration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-gateway-configuration",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Configures API gateways for routing, authentication, rate limiting, and request transformation in microservice architectures. Use when setting up Kong, Nginx, AWS API Gateway, or Traefik for centralized API management.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-pagination/.claude-plugin/plugin.json
+++ b/plugins/api-pagination/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-pagination",
   "description": "Implements efficient API pagination using offset, cursor, and keyset strategies for large datasets. Use when building paginated endpoints, implementing infinite scroll, or optimizing database queries for collections.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-pagination/.codex-plugin/plugin.json
+++ b/plugins/api-pagination/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-pagination",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Implements efficient API pagination using offset, cursor, and keyset strategies for large datasets. Use when building paginated endpoints, implementing infinite scroll, or optimizing database queries for collections.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-rate-limiting/.claude-plugin/plugin.json
+++ b/plugins/api-rate-limiting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-rate-limiting",
   "description": "Implements API rate limiting using token bucket, sliding window, and Redis-based algorithms to protect against abuse. Use when securing public APIs, implementing tiered access, or preventing denial-of-service attacks.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-rate-limiting/.codex-plugin/plugin.json
+++ b/plugins/api-rate-limiting/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-rate-limiting",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Implements API rate limiting using token bucket, sliding window, and Redis-based algorithms to protect against abuse. Use when securing public APIs, implementing tiered access, or preventing denial-of-service attacks.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-reference-documentation/.claude-plugin/plugin.json
+++ b/plugins/api-reference-documentation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-reference-documentation",
   "description": "Creates professional API documentation using OpenAPI specifications with endpoints, authentication, and interactive examples. Use when documenting REST APIs, creating SDK references, or building developer portals.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-reference-documentation/.codex-plugin/plugin.json
+++ b/plugins/api-reference-documentation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-reference-documentation",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Creates professional API documentation using OpenAPI specifications with endpoints, authentication, and interactive examples. Use when documenting REST APIs, creating SDK references, or building developer portals.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-response-optimization/.claude-plugin/plugin.json
+++ b/plugins/api-response-optimization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-response-optimization",
   "description": "Optimizes API performance through payload reduction, caching strategies, and compression techniques. Use when improving API response times, reducing bandwidth usage, or implementing efficient caching.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-response-optimization/.codex-plugin/plugin.json
+++ b/plugins/api-response-optimization/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-response-optimization",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Optimizes API performance through payload reduction, caching strategies, and compression techniques. Use when improving API response times, reducing bandwidth usage, or implementing efficient caching.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-security-hardening/.claude-plugin/plugin.json
+++ b/plugins/api-security-hardening/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-security-hardening",
   "description": "REST API security hardening with authentication, rate limiting, input validation, security headers. Use for production APIs, security audits, defense-in-depth, or encountering vulnerabilities, injection attacks, CORS issues.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-security-hardening/.codex-plugin/plugin.json
+++ b/plugins/api-security-hardening/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-security-hardening",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "REST API security hardening with authentication, rate limiting, input validation, security headers. Use for production APIs, security audits, defense-in-depth, or encountering vulnerabilities, injection attacks, CORS issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-testing/.claude-plugin/plugin.json
+++ b/plugins/api-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-testing",
   "description": "HTTP API testing for TypeScript (Supertest) and Python (httpx, pytest). Test REST APIs, GraphQL, request/response validation, authentication, and error handling.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-testing/.codex-plugin/plugin.json
+++ b/plugins/api-testing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-testing",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "HTTP API testing for TypeScript (Supertest) and Python (httpx, pytest). Test REST APIs, GraphQL, request/response validation, authentication, and error handling.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-versioning-strategy/.claude-plugin/plugin.json
+++ b/plugins/api-versioning-strategy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-versioning-strategy",
   "description": "Implements API versioning using URL paths, headers, or query parameters with backward compatibility and deprecation strategies. Use when managing multiple API versions, planning breaking changes, or designing migration paths.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-versioning-strategy/.codex-plugin/plugin.json
+++ b/plugins/api-versioning-strategy/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-versioning-strategy",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Implements API versioning using URL paths, headers, or query parameters with backward compatibility and deprecation strategies. Use when managing multiple API versions, planning breaking changes, or designing migration paths.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/app-store-deployment/.claude-plugin/plugin.json
+++ b/plugins/app-store-deployment/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "app-store-deployment",
   "description": "Publishes mobile applications to iOS App Store and Google Play with code signing, versioning, and CI/CD automation. Use when preparing app releases, configuring signing certificates, or setting up automated deployment pipelines.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/app-store-deployment/.codex-plugin/plugin.json
+++ b/plugins/app-store-deployment/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-deployment",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Publishes mobile applications to iOS App Store and Google Play with code signing, versioning, and CI/CD automation. Use when preparing app releases, configuring signing certificates, or setting up automated deployment pipelines.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/architecture-patterns/.claude-plugin/plugin.json
+++ b/plugins/architecture-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "architecture-patterns",
   "description": "Implement proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design. Use when architecting complex backend systems or refactoring existing applications for better maintainability.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/architecture-patterns/.codex-plugin/plugin.json
+++ b/plugins/architecture-patterns/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "architecture-patterns",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Implement proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design. Use when architecting complex backend systems or refactoring existing applications for better maintainability.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/auto-animate/.claude-plugin/plugin.json
+++ b/plugins/auto-animate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-animate",
   "description": "AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/auto-animate/.codex-plugin/plugin.json
+++ b/plugins/auto-animate/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-animate",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/base-ui-react/.claude-plugin/plugin.json
+++ b/plugins/base-ui-react/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "base-ui-react",
   "description": "MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/base-ui-react/.codex-plugin/plugin.json
+++ b/plugins/base-ui-react/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "base-ui-react",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/better-auth/.claude-plugin/plugin.json
+++ b/plugins/better-auth/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-auth",
   "description": "Skill for integrating Better Auth - comprehensive TypeScript authentication framework for Cloudflare D1, Next.js, Nuxt, and 15+ frameworks. Use when adding auth, encountering D1 adapter errors, or implementing OAuth/2FA/RBAC features.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/better-auth/.codex-plugin/plugin.json
+++ b/plugins/better-auth/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-auth",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Skill for integrating Better Auth - comprehensive TypeScript authentication framework for Cloudflare D1, Next.js, Nuxt, and 15+ frameworks. Use when adding auth, encountering D1 adapter errors, or implementing OAuth/2FA/RBAC features.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/bun/.claude-plugin/plugin.json
+++ b/plugins/bun/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bun",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Comprehensive Bun runtime toolkit covering runtime, package manager, bundler, testing, HTTP servers, WebSockets, databases, framework integrations (Hono, Next.js, Nuxt, TanStack Start, SvelteKit), deployment, and Node.js compatibility.",
   "author": {
     "name": "Claude Skills",

--- a/plugins/bun/.codex-plugin/plugin.json
+++ b/plugins/bun/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bun",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Comprehensive Bun runtime toolkit covering runtime, package manager, bundler, testing, HTTP servers, WebSockets, databases, framework integrations (Hono, Next.js, Nuxt, TanStack Start, SvelteKit), deployment, and Node.js compatibility.",
   "author": {
     "name": "Claude Skills",

--- a/plugins/claude-code-bash-patterns/.claude-plugin/plugin.json
+++ b/plugins/claude-code-bash-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-bash-patterns",
   "description": "Claude Code Bash tool patterns with hooks, automation, git workflows. Use for PreToolUse hooks, command chaining, CLI orchestration, custom commands, or encountering bash permissions, command failures, security guards, hook configurations.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/claude-code-bash-patterns/.codex-plugin/plugin.json
+++ b/plugins/claude-code-bash-patterns/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-bash-patterns",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Claude Code Bash tool patterns with hooks, automation, git workflows. Use for PreToolUse hooks, command chaining, CLI orchestration, custom commands, or encountering bash permissions, command failures, security guards, hook configurations.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/claude-hook-writer/.claude-plugin/plugin.json
+++ b/plugins/claude-hook-writer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hook-writer",
   "description": "Expert guidance for writing secure, reliable, and performant Claude Code hooks - validates design decisions, enforces best practices, and prevents common pitfalls. Use when creating, reviewing, or debugging Claude Code hooks.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/claude-hook-writer/.codex-plugin/plugin.json
+++ b/plugins/claude-hook-writer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hook-writer",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Expert guidance for writing secure, reliable, and performant Claude Code hooks - validates design decisions, enforces best practices, and prevents common pitfalls. Use when creating, reviewing, or debugging Claude Code hooks.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-agents/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-agents",
   "description": "Build AI agents on Cloudflare Workers with MCP integration, tool use, and LLM providers.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-agents/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-agents/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-agents",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Build AI agents on Cloudflare Workers with MCP integration, tool use, and LLM providers.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-browser-rendering/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-browser-rendering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-browser-rendering",
   "description": "Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-browser-rendering/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-browser-rendering/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-browser-rendering",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-cron-triggers/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-cron-triggers/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-cron-triggers",
   "description": "Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-cron-triggers/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-cron-triggers/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-cron-triggers",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-d1/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-d1/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-d1",
   "description": "Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-d1/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-d1/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-d1",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-durable-objects/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-durable-objects/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-durable-objects",
   "description": "Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-durable-objects/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-durable-objects/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-durable-objects",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-email-routing/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-email-routing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-email-routing",
   "description": "Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-email-routing/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-email-routing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-email-routing",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-hyperdrive/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-hyperdrive/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-hyperdrive",
   "description": "Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-hyperdrive/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-hyperdrive/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-hyperdrive",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-images/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-images/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-images",
   "description": "This skill should be used when the user asks to \"upload images to Cloudflare\", \"implement direct creator upload\", \"configure image transformations\", \"optimize WebP/AVIF\", \"create image variants\", \"generate signed URLs\", \"add image watermarks\", \"integrate with Next.js/Remix\", \"configure webhooks\", \"debug CORS errors\", \"troubleshoot error 5408/9401-9413\", or \"build responsive images with Cloudflare Images API\".",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-images/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-images/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-images",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "This skill should be used when the user asks to \"upload images to Cloudflare\", \"implement direct creator upload\", \"configure image transformations\", \"optimize WebP/AVIF\", \"create image variants\", \"generate signed URLs\", \"add image watermarks\", \"integrate with Next.js/Remix\", \"configure webhooks\", \"debug CORS errors\", \"troubleshoot error 5408/9401-9413\", or \"build responsive images with Cloudflare Images API\".",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-kv/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-kv/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-kv",
   "description": "Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-kv/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-kv/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-kv",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-manager/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-manager/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-manager",
   "description": "Comprehensive Cloudflare account management for deploying Workers, KV Storage, R2, Pages, DNS, and Routes. Use when deploying cloudflare services, managing worker containers, configuring KV/R2 storage, or setting up DNS/routing. Requires CLOUDFLARE_API_KEY in .env and Bun runtime with dependencies installed.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-manager/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-manager/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-manager",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Comprehensive Cloudflare account management for deploying Workers, KV Storage, R2, Pages, DNS, and Routes. Use when deploying cloudflare services, managing worker containers, configuring KV/R2 storage, or setting up DNS/routing. Requires CLOUDFLARE_API_KEY in .env and Bun runtime with dependencies installed.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-mcp-server/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-mcp-server/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-mcp-server",
   "description": "Build MCP (Model Context Protocol) servers on Cloudflare Workers with tools, resources, and prompts.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-mcp-server/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-mcp-server/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-mcp-server",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Build MCP (Model Context Protocol) servers on Cloudflare Workers with tools, resources, and prompts.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-nextjs/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-nextjs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-nextjs",
   "description": "Deploy Next.js to Cloudflare Workers via the OpenNext adapter (@opennextjs/cloudflare). Use for SSR/ISR/SSG, App or Pages Router, getCloudflareContext, bindings (D1/R2/KV/AI/Hyperdrive), caching tiers, skew protection, multi-worker, custom worker, env vars, or worker size/runtime/keep_names/FinalizationRegistry/connection-scoping errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-nextjs/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-nextjs/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-nextjs",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Deploy Next.js to Cloudflare Workers via the OpenNext adapter (@opennextjs/cloudflare). Use for SSR/ISR/SSG, App or Pages Router, getCloudflareContext, bindings (D1/R2/KV/AI/Hyperdrive), caching tiers, skew protection, multi-worker, custom worker, env vars, or worker size/runtime/keep_names/FinalizationRegistry/connection-scoping errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-queues/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-queues/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-queues",
   "description": "This skill should be used when the user asks to \"set up Cloudflare Queues\", \"create a message queue\", \"implement queue consumer\", \"process background jobs\", \"configure queue retry logic\", \"publish messages to queue\", \"implement dead letter queue\", or encountering \"queue timeout\", \"message retry\", \"throughput exceeded\", \"queue backlog\" errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-queues/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-queues/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-queues",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "This skill should be used when the user asks to \"set up Cloudflare Queues\", \"create a message queue\", \"implement queue consumer\", \"process background jobs\", \"configure queue retry logic\", \"publish messages to queue\", \"implement dead letter queue\", or encountering \"queue timeout\", \"message retry\", \"throughput exceeded\", \"queue backlog\" errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-r2/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-r2/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-r2",
   "description": "Cloudflare R2 S3-compatible object storage with SQL, Iceberg, event notifications, and automation. Use for buckets, uploads, CORS, presigned URLs, large files, S3 migration, analytics, or encountering R2_ERROR, CORS failures, multipart issues.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-r2/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-r2/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-r2",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Cloudflare R2 S3-compatible object storage with SQL, Iceberg, event notifications, and automation. Use for buckets, uploads, CORS, presigned URLs, large files, S3 migration, analytics, or encountering R2_ERROR, CORS failures, multipart issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-sandbox/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-sandbox/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-sandbox",
   "description": "Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-sandbox/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-sandbox/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-sandbox",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-turnstile/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-turnstile/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-turnstile",
   "description": "Cloudflare Turnstile CAPTCHA-alternative bot protection. Use for forms, login security, API protection, or encountering CSP errors, token validation failures, error codes 100*/300*/600*.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-turnstile/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-turnstile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-turnstile",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Cloudflare Turnstile CAPTCHA-alternative bot protection. Use for forms, login security, API protection, or encountering CSP errors, token validation failures, error codes 100*/300*/600*.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-vectorize/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-vectorize/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-vectorize",
   "description": "Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-vectorize/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-vectorize/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-vectorize",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-workers-ai/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-workers-ai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-workers-ai",
   "description": "Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-workers-ai/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-workers-ai/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-workers-ai",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-workers/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-workers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-workers",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Comprehensive Cloudflare Workers platform guide covering runtime APIs, testing (Vitest), CI/CD, observability, framework integration, performance, security, and migration. Use for Workers development, deployment, debugging, or optimization.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-workers/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-workers/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-workers",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Comprehensive Cloudflare Workers platform guide covering runtime APIs, testing (Vitest), CI/CD, observability, framework integration, performance, security, and migration. Use for Workers development, deployment, debugging, or optimization.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-workflows/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-workflows",
   "description": "Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-workflows/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-workflows/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-workflows",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-zero-trust-access/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-zero-trust-access/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-zero-trust-access",
   "description": "Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-zero-trust-access/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-zero-trust-access/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-zero-trust-access",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review practices with technical rigor and verification gates. Use for receiving feedback, requesting code-reviewer subagent reviews, or preventing false completion claims in pull requests.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/code-review/.codex-plugin/plugin.json
+++ b/plugins/code-review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-review",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Code review practices with technical rigor and verification gates. Use for receiving feedback, requesting code-reviewer subagent reviews, or preventing false completion claims in pull requests.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/csrf-protection/.claude-plugin/plugin.json
+++ b/plugins/csrf-protection/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "csrf-protection",
   "description": "Implements CSRF protection using synchronizer tokens, double-submit cookies, and SameSite attributes. Use when securing web forms, protecting state-changing endpoints, or implementing defense-in-depth authentication.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/csrf-protection/.codex-plugin/plugin.json
+++ b/plugins/csrf-protection/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "csrf-protection",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Implements CSRF protection using synchronizer tokens, double-submit cookies, and SameSite attributes. Use when securing web forms, protecting state-changing endpoints, or implementing defense-in-depth authentication.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cybersecurity/.claude-plugin/plugin.json
+++ b/plugins/cybersecurity/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cybersecurity",
   "description": "OSS-only security for OWASP Top 10, pentest, vuln testing (XSS, SSRF, CSRF, business-logic, Host header), threat modeling (STRIDE, ATT&CK), Sigma rules, SAST, code audit, AI/LLM red-team, or replacing paid tools (Burp, Nessus, Splunk) with OSS.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cybersecurity/.codex-plugin/plugin.json
+++ b/plugins/cybersecurity/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cybersecurity",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "OSS-only security for OWASP Top 10, pentest, vuln testing (XSS, SSRF, CSRF, business-logic, Host header), threat modeling (STRIDE, ATT&CK), Sigma rules, SAST, code audit, AI/LLM red-team, or replacing paid tools (Burp, Nessus, Splunk) with OSS.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/defense-in-depth-validation/.claude-plugin/plugin.json
+++ b/plugins/defense-in-depth-validation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "defense-in-depth-validation",
   "description": "Validate at every layer data passes through to make bugs impossible. Use when invalid data causes failures deep in execution, requiring validation at multiple system layers.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/defense-in-depth-validation/.codex-plugin/plugin.json
+++ b/plugins/defense-in-depth-validation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "defense-in-depth-validation",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Validate at every layer data passes through to make bugs impossible. Use when invalid data causes failures deep in execution, requiring validation at multiple system layers.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/delegate-my-work/.claude-plugin/plugin.json
+++ b/plugins/delegate-my-work/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "delegate-my-work",
   "description": "Interview employees to find recurring work, map accessible AI and automation tools, and spec each loop with preferred and fallback routes.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/delegate-my-work/.codex-plugin/plugin.json
+++ b/plugins/delegate-my-work/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "delegate-my-work",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Interview employees to find recurring work, map accessible AI and automation tools, and spec each loop with preferred and fallback routes.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/dependency-upgrade/.claude-plugin/plugin.json
+++ b/plugins/dependency-upgrade/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependency-upgrade",
   "description": "Secure dependency upgrades with supply chain protection, cooldowns, staged rollout, and Socket CLI integration. Use when upgrading deps, configuring security policies, or preventing supply chain attacks.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/dependency-upgrade/.codex-plugin/plugin.json
+++ b/plugins/dependency-upgrade/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-upgrade",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Secure dependency upgrades with supply chain protection, cooldowns, staged rollout, and Socket CLI integration. Use when upgrading deps, configuring security policies, or preventing supply chain attacks.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/design-review/.claude-plugin/plugin.json
+++ b/plugins/design-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "design-review",
   "description": "7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/design-review/.codex-plugin/plugin.json
+++ b/plugins/design-review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "design-review",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/design-system-creation/.claude-plugin/plugin.json
+++ b/plugins/design-system-creation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "design-system-creation",
   "description": "Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/design-system-creation/.codex-plugin/plugin.json
+++ b/plugins/design-system-creation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system-creation",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/drizzle-orm-d1/.claude-plugin/plugin.json
+++ b/plugins/drizzle-orm-d1/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drizzle-orm-d1",
   "description": "Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transaction errors, foreign key constraint failures, or schema inference issues.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/drizzle-orm-d1/.codex-plugin/plugin.json
+++ b/plugins/drizzle-orm-d1/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "drizzle-orm-d1",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transaction errors, foreign key constraint failures, or schema inference issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/feature-dev/.claude-plugin/plugin.json
+++ b/plugins/feature-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "feature-dev",
   "description": "Automate 7-phase feature development with specialized agents (code-explorer, code-architect, code-reviewer). Use for multi-file features, architectural decisions, or encountering ambiguous requirements, integration patterns, design approach errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/feature-dev/.codex-plugin/plugin.json
+++ b/plugins/feature-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-dev",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Automate 7-phase feature development with specialized agents (code-explorer, code-architect, code-reviewer). Use for multi-file features, architectural decisions, or encountering ambiguous requirements, integration patterns, design approach errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/firecrawl-scraper/.claude-plugin/plugin.json
+++ b/plugins/firecrawl-scraper/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "firecrawl-scraper",
   "description": "Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/firecrawl-scraper/.codex-plugin/plugin.json
+++ b/plugins/firecrawl-scraper/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-scraper",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/frontend-design/.claude-plugin/plugin.json
+++ b/plugins/frontend-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend-design",
   "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/frontend-design/.codex-plugin/plugin.json
+++ b/plugins/frontend-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-design",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/gemini-cli/.claude-plugin/plugin.json
+++ b/plugins/gemini-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gemini-cli",
   "description": "Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/gemini-cli/.codex-plugin/plugin.json
+++ b/plugins/gemini-cli/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-cli",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/github-project-automation/.claude-plugin/plugin.json
+++ b/plugins/github-project-automation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github-project-automation",
   "description": "GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/github-project-automation/.codex-plugin/plugin.json
+++ b/plugins/github-project-automation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-project-automation",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/graphql-implementation/.claude-plugin/plugin.json
+++ b/plugins/graphql-implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "graphql-implementation",
   "description": "Builds GraphQL APIs with schema design, resolvers, error handling, and performance optimization using Apollo or Graphene. Use when creating flexible query APIs, migrating from REST, or implementing real-time subscriptions.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/graphql-implementation/.codex-plugin/plugin.json
+++ b/plugins/graphql-implementation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-implementation",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Builds GraphQL APIs with schema design, resolvers, error handling, and performance optimization using Apollo or Graphene. Use when creating flexible query APIs, migrating from REST, or implementing real-time subscriptions.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/health-check-endpoints/.claude-plugin/plugin.json
+++ b/plugins/health-check-endpoints/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "health-check-endpoints",
   "description": "Health check endpoints for liveness, readiness, dependency monitoring. Use for Kubernetes, load balancers, auto-scaling, or encountering probe failures, startup delays, dependency checks, timeout configuration errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/health-check-endpoints/.codex-plugin/plugin.json
+++ b/plugins/health-check-endpoints/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "health-check-endpoints",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Health check endpoints for liveness, readiness, dependency monitoring. Use for Kubernetes, load balancers, auto-scaling, or encountering probe failures, startup delays, dependency checks, timeout configuration errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/hono-routing/.claude-plugin/plugin.json
+++ b/plugins/hono-routing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hono-routing",
   "description": "Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/hono-routing/.codex-plugin/plugin.json
+++ b/plugins/hono-routing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hono-routing",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/hugo/.claude-plugin/plugin.json
+++ b/plugins/hugo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hugo",
   "description": "Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/hugo/.codex-plugin/plugin.json
+++ b/plugins/hugo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hugo",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/idempotency-handling/.claude-plugin/plugin.json
+++ b/plugins/idempotency-handling/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "idempotency-handling",
   "description": "Idempotent API operations with idempotency keys, Redis caching, DB constraints. Use for payment systems, webhook retries, safe retries, or encountering duplicate processing, race conditions, key expiry errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/idempotency-handling/.codex-plugin/plugin.json
+++ b/plugins/idempotency-handling/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idempotency-handling",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Idempotent API operations with idempotency keys, Redis caching, DB constraints. Use for payment systems, webhook retries, safe retries, or encountering duplicate processing, race conditions, key expiry errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/image-optimization/.claude-plugin/plugin.json
+++ b/plugins/image-optimization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "image-optimization",
   "description": "Optimizes images for web performance using modern formats, responsive techniques, and lazy loading strategies. Use when improving page load times, implementing responsive images, or preparing assets for production deployment.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/image-optimization/.codex-plugin/plugin.json
+++ b/plugins/image-optimization/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "image-optimization",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Optimizes images for web performance using modern formats, responsive techniques, and lazy loading strategies. Use when improving page load times, implementing responsive images, or preparing assets for production deployment.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/inspira-ui/.claude-plugin/plugin.json
+++ b/plugins/inspira-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inspira-ui",
   "description": "120+ Vue/Nuxt animated components with TailwindCSS v4, motion-v, GSAP, Three.js. Use for hero sections, 3D effects, interactive backgrounds, or encountering setup, CSS variables, motion-v integration errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/inspira-ui/.codex-plugin/plugin.json
+++ b/plugins/inspira-ui/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "inspira-ui",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "120+ Vue/Nuxt animated components with TailwindCSS v4, motion-v, GSAP, Three.js. Use for hero sections, 3D effects, interactive backgrounds, or encountering setup, CSS variables, motion-v integration errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/interaction-design/.claude-plugin/plugin.json
+++ b/plugins/interaction-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "interaction-design",
   "description": "Creates intuitive user experiences through feedback patterns, microinteractions, and accessible interaction design. Use when designing loading states, error handling UX, animation guidelines, or touch interactions.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/interaction-design/.codex-plugin/plugin.json
+++ b/plugins/interaction-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "interaction-design",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Creates intuitive user experiences through feedback patterns, microinteractions, and accessible interaction design. Use when designing loading states, error handling UX, animation guidelines, or touch interactions.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/internationalization-i18n/.claude-plugin/plugin.json
+++ b/plugins/internationalization-i18n/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "internationalization-i18n",
   "description": "Implements multi-language support using i18next, gettext, or Intl API with translation workflows and RTL support. Use when building multilingual applications, handling date/currency formatting, or supporting right-to-left languages.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/internationalization-i18n/.codex-plugin/plugin.json
+++ b/plugins/internationalization-i18n/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "internationalization-i18n",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Implements multi-language support using i18next, gettext, or Intl API with translation workflows and RTL support. Use when building multilingual applications, handling date/currency formatting, or supporting right-to-left languages.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/jest-generator/.claude-plugin/plugin.json
+++ b/plugins/jest-generator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jest-generator",
   "description": "Generate Jest unit tests for JavaScript/TypeScript with mocking, coverage. Use for JS/TS modules, React components, test generation, or encountering missing coverage, improper mocking, test structure errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/jest-generator/.codex-plugin/plugin.json
+++ b/plugins/jest-generator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-generator",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Generate Jest unit tests for JavaScript/TypeScript with mocking, coverage. Use for JS/TS modules, React components, test generation, or encountering missing coverage, improper mocking, test structure errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/kpi-dashboard-design/.claude-plugin/plugin.json
+++ b/plugins/kpi-dashboard-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kpi-dashboard-design",
   "description": "Designs effective KPI dashboards with proper metric selection, visual hierarchy, and data visualization best practices. Use when building executive dashboards, creating analytics views, or presenting business metrics.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/kpi-dashboard-design/.codex-plugin/plugin.json
+++ b/plugins/kpi-dashboard-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kpi-dashboard-design",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Designs effective KPI dashboards with proper metric selection, visual hierarchy, and data visualization best practices. Use when building executive dashboards, creating analytics views, or presenting business metrics.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/logging-best-practices/.claude-plugin/plugin.json
+++ b/plugins/logging-best-practices/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "logging-best-practices",
   "description": "Structured logging with proper levels, context, PII handling, centralized aggregation. Use for application logging, log management integration, distributed tracing, or encountering log bloat, PII exposure, missing context errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/logging-best-practices/.codex-plugin/plugin.json
+++ b/plugins/logging-best-practices/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "logging-best-practices",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Structured logging with proper levels, context, PII handling, centralized aggregation. Use for application logging, log management integration, distributed tracing, or encountering log bloat, PII exposure, missing context errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/maz-ui/.claude-plugin/plugin.json
+++ b/plugins/maz-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maz-ui",
   "description": "Maz-UI v4 - Modern Vue & Nuxt component library with 50+ standalone components, composables, directives, theming, i18n, and SSR support.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/maz-ui/.codex-plugin/plugin.json
+++ b/plugins/maz-ui/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maz-ui",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Maz-UI v4 - Modern Vue & Nuxt component library with 50+ standalone components, composables, directives, theming, i18n, and SSR support.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/mcp-dynamic-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/mcp-dynamic-orchestrator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-dynamic-orchestrator",
   "description": "Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mcp-dynamic-orchestrator/.codex-plugin/plugin.json
+++ b/plugins/mcp-dynamic-orchestrator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-dynamic-orchestrator",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/mcp-management/.claude-plugin/plugin.json
+++ b/plugins/mcp-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-management",
   "description": "Manage MCP servers - discover, analyze, execute tools/prompts/resources. Use for MCP integrations, capability discovery, tool filtering, programmatic execution, or encountering context bloat, server configuration, tool execution errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mcp-management/.codex-plugin/plugin.json
+++ b/plugins/mcp-management/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-management",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Manage MCP servers - discover, analyze, execute tools/prompts/resources. Use for MCP integrations, capability discovery, tool filtering, programmatic execution, or encountering context bloat, server configuration, tool execution errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/microservices-patterns/.claude-plugin/plugin.json
+++ b/plugins/microservices-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "microservices-patterns",
   "description": "Design microservices architectures with service boundaries, event-driven communication, and resilience patterns. Use when building distributed systems, decomposing monoliths, or implementing microservices.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/microservices-patterns/.codex-plugin/plugin.json
+++ b/plugins/microservices-patterns/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "microservices-patterns",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Design microservices architectures with service boundaries, event-driven communication, and resilience patterns. Use when building distributed systems, decomposing monoliths, or implementing microservices.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/ml-model-training/.claude-plugin/plugin.json
+++ b/plugins/ml-model-training/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-model-training",
   "description": "Train ML models with scikit-learn, PyTorch, TensorFlow. Use for classification/regression, neural networks, hyperparameter tuning, or encountering overfitting, underfitting, convergence issues.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ml-model-training/.codex-plugin/plugin.json
+++ b/plugins/ml-model-training/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ml-model-training",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Train ML models with scikit-learn, PyTorch, TensorFlow. Use for classification/regression, neural networks, hyperparameter tuning, or encountering overfitting, underfitting, convergence issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/ml-pipeline-automation/.claude-plugin/plugin.json
+++ b/plugins/ml-pipeline-automation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-pipeline-automation",
   "description": "Automate ML workflows with Airflow, Kubeflow, MLflow. Use for reproducible pipelines, retraining schedules, MLOps, or encountering task failures, dependency errors, experiment tracking issues.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ml-pipeline-automation/.codex-plugin/plugin.json
+++ b/plugins/ml-pipeline-automation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ml-pipeline-automation",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Automate ML workflows with Airflow, Kubeflow, MLflow. Use for reproducible pipelines, retraining schedules, MLOps, or encountering task failures, dependency errors, experiment tracking issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/mobile-app-debugging/.claude-plugin/plugin.json
+++ b/plugins/mobile-app-debugging/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-app-debugging",
   "description": "Mobile app debugging for iOS, Android, cross-platform frameworks. Use for crashes, memory leaks, performance issues, network problems, or encountering Xcode instruments, Android Profiler, React Native debugger, native bridge errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-app-debugging/.codex-plugin/plugin.json
+++ b/plugins/mobile-app-debugging/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-app-debugging",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Mobile app debugging for iOS, Android, cross-platform frameworks. Use for crashes, memory leaks, performance issues, network problems, or encountering Xcode instruments, Android Profiler, React Native debugger, native bridge errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/mobile-app-testing/.claude-plugin/plugin.json
+++ b/plugins/mobile-app-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-app-testing",
   "description": "Mobile app testing with unit tests, UI automation, performance testing. Use for test infrastructure, E2E tests, testing standards, or encountering test framework setup, device farms, flaky tests, platform-specific test errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-app-testing/.codex-plugin/plugin.json
+++ b/plugins/mobile-app-testing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-app-testing",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Mobile app testing with unit tests, UI automation, performance testing. Use for test infrastructure, E2E tests, testing standards, or encountering test framework setup, device farms, flaky tests, platform-specific test errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/mobile-first-design/.claude-plugin/plugin.json
+++ b/plugins/mobile-first-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-first-design",
   "description": "Designs responsive interfaces starting from mobile screens with progressive enhancement for larger devices. Use when building responsive websites, optimizing for mobile users, or implementing adaptive layouts.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-first-design/.codex-plugin/plugin.json
+++ b/plugins/mobile-first-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-first-design",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Designs responsive interfaces starting from mobile screens with progressive enhancement for larger devices. Use when building responsive websites, optimizing for mobile users, or implementing adaptive layouts.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/mobile-offline-support/.claude-plugin/plugin.json
+++ b/plugins/mobile-offline-support/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-offline-support",
   "description": "Offline-first mobile apps with local storage, sync queues, conflict resolution. Use for offline functionality, data sync, connectivity handling, or encountering sync conflicts, queue management, storage limits, network transition errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-offline-support/.codex-plugin/plugin.json
+++ b/plugins/mobile-offline-support/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-offline-support",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Offline-first mobile apps with local storage, sync queues, conflict resolution. Use for offline functionality, data sync, connectivity handling, or encountering sync conflicts, queue management, storage limits, network transition errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/model-deployment/.claude-plugin/plugin.json
+++ b/plugins/model-deployment/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "model-deployment",
   "description": "Deploy ML models with FastAPI, Docker, Kubernetes. Use for serving predictions, containerization, monitoring, drift detection, or encountering latency issues, health check failures, version conflicts.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/model-deployment/.codex-plugin/plugin.json
+++ b/plugins/model-deployment/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "model-deployment",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Deploy ML models with FastAPI, Docker, Kubernetes. Use for serving predictions, containerization, monitoring, drift detection, or encountering latency issues, health check failures, version conflicts.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/motion/.claude-plugin/plugin.json
+++ b/plugins/motion/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "motion",
   "description": "Motion (Framer Motion) React animation library. Use for drag-and-drop, scroll animations, gestures, SVG morphing, or encountering bundle size, complex transitions, spring physics errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/motion/.codex-plugin/plugin.json
+++ b/plugins/motion/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "motion",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Motion (Framer Motion) React animation library. Use for drag-and-drop, scroll animations, gestures, SVG morphing, or encountering bundle size, complex transitions, spring physics errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/multi-ai-consultant/.claude-plugin/plugin.json
+++ b/plugins/multi-ai-consultant/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "multi-ai-consultant",
   "description": "Consult external AIs (Gemini 2.5 Pro, OpenAI Codex, Claude) for second opinions. Use for debugging failures, architectural decisions, security validation, or need fresh perspective with synthesis.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/multi-ai-consultant/.codex-plugin/plugin.json
+++ b/plugins/multi-ai-consultant/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-ai-consultant",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Consult external AIs (Gemini 2.5 Pro, OpenAI Codex, Claude) for second opinions. Use for debugging failures, architectural decisions, security validation, or need fresh perspective with synthesis.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/mutation-testing/.claude-plugin/plugin.json
+++ b/plugins/mutation-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mutation-testing",
   "description": "Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mutation-testing/.codex-plugin/plugin.json
+++ b/plugins/mutation-testing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mutation-testing",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nano-banana-prompts/.claude-plugin/plugin.json
+++ b/plugins/nano-banana-prompts/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nano-banana-prompts",
   "description": "Generate optimized prompts for Gemini 2.5 Flash Image (Nano Banana). Use for image generation, crafting photo prompts, art styles, or multi-turn editing workflows with best practices.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nano-banana-prompts/.codex-plugin/plugin.json
+++ b/plugins/nano-banana-prompts/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-banana-prompts",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Generate optimized prompts for Gemini 2.5 Flash Image (Nano Banana). Use for image generation, crafting photo prompts, art styles, or multi-turn editing workflows with best practices.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nextjs/.claude-plugin/plugin.json
+++ b/plugins/nextjs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nextjs",
   "description": "Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nextjs/.codex-plugin/plugin.json
+++ b/plugins/nextjs/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-content/.claude-plugin/plugin.json
+++ b/plugins/nuxt-content/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-content",
   "description": "Nuxt Content v3 Git-backed CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Vercel deployment, SQL storage, MDC components, content collections.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-content/.codex-plugin/plugin.json
+++ b/plugins/nuxt-content/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-content",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Nuxt Content v3 Git-backed CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Vercel deployment, SQL storage, MDC components, content collections.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-seo/.claude-plugin/plugin.json
+++ b/plugins/nuxt-seo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-seo",
   "description": "Comprehensive guide for all 8 Nuxt SEO modules plus Pro modules. Use when building SEO-optimized Nuxt applications, implementing robots.txt/sitemaps, generating OG images, adding Schema.org data, managing meta tags, checking links, or encountering sitemap, robots.txt, OG image, schema validation, meta tag, canonical URL, or i18n SEO errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-seo/.codex-plugin/plugin.json
+++ b/plugins/nuxt-seo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-seo",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Comprehensive guide for all 8 Nuxt SEO modules plus Pro modules. Use when building SEO-optimized Nuxt applications, implementing robots.txt/sitemaps, generating OG images, adding Schema.org data, managing meta tags, checking links, or encountering sitemap, robots.txt, OG image, schema validation, meta tag, canonical URL, or i18n SEO errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-studio/.claude-plugin/plugin.json
+++ b/plugins/nuxt-studio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-studio",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Visual CMS for Nuxt Content with Cloudflare deployment. Use when setting up Nuxt Studio, configuring OAuth authentication, deploying to Cloudflare Pages/Workers with subdomain routing, or troubleshooting Studio integration.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-studio/.codex-plugin/plugin.json
+++ b/plugins/nuxt-studio/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-studio",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Visual CMS for Nuxt Content with Cloudflare deployment. Use when setting up Nuxt Studio, configuring OAuth authentication, deploying to Cloudflare Pages/Workers with subdomain routing, or troubleshooting Studio integration.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-ui-v4/.claude-plugin/plugin.json
+++ b/plugins/nuxt-ui-v4/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-ui-v4",
   "description": "Nuxt UI v4 with 125+ accessible components, Tailwind v4, Reka UI, AI chat integration with reasoning and tool calling. Use for dashboards, forms, overlays, editors, page layouts, or encountering theming, composable, TypeScript errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-ui-v4/.codex-plugin/plugin.json
+++ b/plugins/nuxt-ui-v4/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-ui-v4",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Nuxt UI v4 with 125+ accessible components, Tailwind v4, Reka UI, AI chat integration with reasoning and tool calling. Use for dashboards, forms, overlays, editors, page layouts, or encountering theming, composable, TypeScript errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-v4/.claude-plugin/plugin.json
+++ b/plugins/nuxt-v4/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-v4",
   "description": "Comprehensive Nuxt 4 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 4 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 3, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-v4/.codex-plugin/plugin.json
+++ b/plugins/nuxt-v4/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-v4",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Comprehensive Nuxt 4 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 4 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 3, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-v5/.claude-plugin/plugin.json
+++ b/plugins/nuxt-v5/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-v5",
   "description": "Comprehensive Nuxt 5 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 5 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 4, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-v5/.codex-plugin/plugin.json
+++ b/plugins/nuxt-v5/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-v5",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Comprehensive Nuxt 5 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 5 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 4, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/oauth-implementation/.claude-plugin/plugin.json
+++ b/plugins/oauth-implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oauth-implementation",
   "description": "OAuth 2.0 and OpenID Connect authentication with secure flows. Use for third-party integrations, SSO systems, token-based API access, or encountering authorization code flow, PKCE, token refresh, scope management errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/oauth-implementation/.codex-plugin/plugin.json
+++ b/plugins/oauth-implementation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth-implementation",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "OAuth 2.0 and OpenID Connect authentication with secure flows. Use for third-party integrations, SSO systems, token-based API access, or encountering authorization code flow, PKCE, token refresh, scope management errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/payment-gateway-integration/.claude-plugin/plugin.json
+++ b/plugins/payment-gateway-integration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "payment-gateway-integration",
   "description": "Integrates payment processing with Stripe, PayPal, or Square including subscriptions, webhooks, and PCI compliance. Use when implementing checkout flows, recurring billing, or handling refunds and disputes.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/payment-gateway-integration/.codex-plugin/plugin.json
+++ b/plugins/payment-gateway-integration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "payment-gateway-integration",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Integrates payment processing with Stripe, PayPal, or Square including subscriptions, webhooks, and PCI compliance. Use when implementing checkout flows, recurring billing, or handling refunds and disputes.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/pinia-colada/.claude-plugin/plugin.json
+++ b/plugins/pinia-colada/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pinia-colada",
   "description": "Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/pinia-colada/.codex-plugin/plugin.json
+++ b/plugins/pinia-colada/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pinia-colada",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/pinia-v3/.claude-plugin/plugin.json
+++ b/plugins/pinia-v3/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pinia-v3",
   "description": "Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/pinia-v3/.codex-plugin/plugin.json
+++ b/plugins/pinia-v3/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pinia-v3",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/plan-interview/.claude-plugin/plugin.json
+++ b/plugins/plan-interview/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-interview",
   "description": "Adaptive interview-driven spec generation with quality review. Automatically adjusts depth based on plan complexity.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/plan-interview/.codex-plugin/plugin.json
+++ b/plugins/plan-interview/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plan-interview",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Adaptive interview-driven spec generation with quality review. Automatically adjusts depth based on plan complexity.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/playwright/.claude-plugin/plugin.json
+++ b/plugins/playwright/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright",
   "description": "Browser automation and E2E testing with Playwright. Auto-detects dev servers, writes clean test scripts. Test pages, fill forms, take screenshots, check responsive design, validate UX, test login flows, check links, automate any browser task. Use for cross-browser testing, visual regression, API testing, component testing in TypeScript/JavaScript and Python projects.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/playwright/.codex-plugin/plugin.json
+++ b/plugins/playwright/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Browser automation and E2E testing with Playwright. Auto-detects dev servers, writes clean test scripts. Test pages, fill forms, take screenshots, check responsive design, validate UX, test login flows, check links, automate any browser task. Use for cross-browser testing, visual regression, API testing, component testing in TypeScript/JavaScript and Python projects.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/progressive-web-app/.claude-plugin/plugin.json
+++ b/plugins/progressive-web-app/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "progressive-web-app",
   "description": "Builds Progressive Web Apps with service workers, web manifest, offline support, and installation prompts. Use when creating installable web experiences, implementing offline functionality, or adding push notifications to web apps.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/progressive-web-app/.codex-plugin/plugin.json
+++ b/plugins/progressive-web-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "progressive-web-app",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Builds Progressive Web Apps with service workers, web manifest, offline support, and installation prompts. Use when creating installable web experiences, implementing offline functionality, or adding push notifications to web apps.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/push-notification-setup/.claude-plugin/plugin.json
+++ b/plugins/push-notification-setup/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "push-notification-setup",
   "description": "Implements push notifications across iOS, Android, and web using Firebase Cloud Messaging and native services. Use when adding notification capabilities, handling background messages, or setting up notification channels.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/push-notification-setup/.codex-plugin/plugin.json
+++ b/plugins/push-notification-setup/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "push-notification-setup",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Implements push notifications across iOS, Android, and web using Firebase Cloud Messaging and native services. Use when adding notification capabilities, handling background messages, or setting up notification channels.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/react-best-practices/.claude-plugin/plugin.json
+++ b/plugins/react-best-practices/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-best-practices",
   "description": "React and Next.js performance optimization guidelines from Vercel Engineering. Use when writing/reviewing/refactoring React code for optimal performance. Covers async patterns, bundle optimization, server/client components, re-render optimization.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-best-practices/.codex-plugin/plugin.json
+++ b/plugins/react-best-practices/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-best-practices",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "React and Next.js performance optimization guidelines from Vercel Engineering. Use when writing/reviewing/refactoring React code for optimal performance. Covers async patterns, bundle optimization, server/client components, re-render optimization.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/react-composition-patterns/.claude-plugin/plugin.json
+++ b/plugins/react-composition-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-composition-patterns",
   "description": "React composition patterns from Vercel Engineering. Use when building scalable components, avoiding boolean prop proliferation, implementing compound components, or managing component state. Covers architecture, state management, and implementation patterns.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-composition-patterns/.codex-plugin/plugin.json
+++ b/plugins/react-composition-patterns/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-composition-patterns",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "React composition patterns from Vercel Engineering. Use when building scalable components, avoiding boolean prop proliferation, implementing compound components, or managing component state. Covers architecture, state management, and implementation patterns.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/react-hook-form-zod/.claude-plugin/plugin.json
+++ b/plugins/react-hook-form-zod/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-hook-form-zod",
   "description": "Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-hook-form-zod/.codex-plugin/plugin.json
+++ b/plugins/react-hook-form-zod/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hook-form-zod",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/react-native-skills/.claude-plugin/plugin.json
+++ b/plugins/react-native-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-skills",
   "description": "React Native and Expo best practices for building performant mobile apps. Use when building React Native components, optimizing list performance, implementing animations, or working with native modules.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-native-skills/.codex-plugin/plugin.json
+++ b/plugins/react-native-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-skills",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "React Native and Expo best practices for building performant mobile apps. Use when building React Native components, optimizing list performance, implementing animations, or working with native modules.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/recommendation-engine/.claude-plugin/plugin.json
+++ b/plugins/recommendation-engine/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "recommendation-engine",
   "description": "Build recommendation systems with collaborative filtering, matrix factorization, hybrid approaches. Use for product recommendations, personalization, or encountering cold start, sparsity, quality evaluation issues.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/recommendation-engine/.codex-plugin/plugin.json
+++ b/plugins/recommendation-engine/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "recommendation-engine",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Build recommendation systems with collaborative filtering, matrix factorization, hybrid approaches. Use for product recommendations, personalization, or encountering cold start, sparsity, quality evaluation issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/recommendation-system/.claude-plugin/plugin.json
+++ b/plugins/recommendation-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "recommendation-system",
   "description": "Deploy production recommendation systems with feature stores, caching, A/B testing. Use for personalization APIs, low latency serving, or encountering cache invalidation, experiment tracking, quality monitoring issues.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/recommendation-system/.codex-plugin/plugin.json
+++ b/plugins/recommendation-system/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "recommendation-system",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Deploy production recommendation systems with feature stores, caching, A/B testing. Use for personalization APIs, low latency serving, or encountering cache invalidation, experiment tracking, quality monitoring issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/responsive-web-design/.claude-plugin/plugin.json
+++ b/plugins/responsive-web-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "responsive-web-design",
   "description": "Builds adaptive web interfaces using Flexbox, CSS Grid, and media queries with a mobile-first approach. Use when creating multi-device layouts, implementing flexible UI systems, or ensuring cross-browser compatibility.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/responsive-web-design/.codex-plugin/plugin.json
+++ b/plugins/responsive-web-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "responsive-web-design",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Builds adaptive web interfaces using Flexbox, CSS Grid, and media queries with a mobile-first approach. Use when creating multi-device layouts, implementing flexible UI systems, or ensuring cross-browser compatibility.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/rest-api-design/.claude-plugin/plugin.json
+++ b/plugins/rest-api-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rest-api-design",
   "description": "Designs RESTful APIs with proper resource naming, HTTP methods, status codes, and response formats. Use when building new APIs, establishing API conventions, or designing developer-friendly interfaces.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/rest-api-design/.codex-plugin/plugin.json
+++ b/plugins/rest-api-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-api-design",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Designs RESTful APIs with proper resource naming, HTTP methods, status codes, and response formats. Use when building new APIs, establishing API conventions, or designing developer-friendly interfaces.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/root-cause-tracing/.claude-plugin/plugin.json
+++ b/plugins/root-cause-tracing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "root-cause-tracing",
   "description": "Systematically trace bugs backward through call stack to find original trigger. Use when errors occur deep in execution and you need to trace back to find the original trigger.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/root-cause-tracing/.codex-plugin/plugin.json
+++ b/plugins/root-cause-tracing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "root-cause-tracing",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Systematically trace bugs backward through call stack to find original trigger. Use when errors occur deep in execution and you need to trace back to find the original trigger.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/security-headers-configuration/.claude-plugin/plugin.json
+++ b/plugins/security-headers-configuration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "security-headers-configuration",
   "description": "Configures HTTP security headers to protect against XSS, clickjacking, and MIME sniffing attacks. Use when hardening web applications, passing security audits, or implementing Content Security Policy.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/security-headers-configuration/.codex-plugin/plugin.json
+++ b/plugins/security-headers-configuration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-headers-configuration",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Configures HTTP security headers to protect against XSS, clickjacking, and MIME sniffing attacks. Use when hardening web applications, passing security audits, or implementing Content Security Policy.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/seo-keyword-cluster-builder/.claude-plugin/plugin.json
+++ b/plugins/seo-keyword-cluster-builder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seo-keyword-cluster-builder",
   "description": "Groups related keywords into topic clusters and creates content hub architecture recommendations with internal linking strategies. Use when planning content strategy, organizing keyword research, or building pillar page structures.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/seo-keyword-cluster-builder/.codex-plugin/plugin.json
+++ b/plugins/seo-keyword-cluster-builder/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "seo-keyword-cluster-builder",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Groups related keywords into topic clusters and creates content hub architecture recommendations with internal linking strategies. Use when planning content strategy, organizing keyword research, or building pillar page structures.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/seo-optimizer/.claude-plugin/plugin.json
+++ b/plugins/seo-optimizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seo-optimizer",
   "description": "SEO optimization with keyword analysis, readability assessment, technical validation, content quality. Use for search rankings, blog posts, content audits, or encountering keyword density, readability scores, meta tags, schema markup errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/seo-optimizer/.codex-plugin/plugin.json
+++ b/plugins/seo-optimizer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "seo-optimizer",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "SEO optimization with keyword analysis, readability assessment, technical validation, content quality. Use for search rankings, blog posts, content audits, or encountering keyword density, readability scores, meta tags, schema markup errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/sequential-thinking/.claude-plugin/plugin.json
+++ b/plugins/sequential-thinking/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sequential-thinking",
   "description": "Systematic step-by-step reasoning with revision and branching. Use for complex problems, multi-stage analysis, design planning, problem decomposition, or encountering unclear scope, alternative approaches needed, revision requirements.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/sequential-thinking/.codex-plugin/plugin.json
+++ b/plugins/sequential-thinking/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sequential-thinking",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Systematic step-by-step reasoning with revision and branching. Use for complex problems, multi-stage analysis, design planning, problem decomposition, or encountering unclear scope, alternative approaches needed, revision requirements.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/session-management/.claude-plugin/plugin.json
+++ b/plugins/session-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "session-management",
   "description": "Implements secure session management with JWT tokens, Redis storage, refresh flows, and proper cookie configuration. Use when building authentication systems, managing user sessions, or implementing secure logout functionality.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/session-management/.codex-plugin/plugin.json
+++ b/plugins/session-management/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session-management",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Implements secure session management with JWT tokens, Redis storage, refresh flows, and proper cookie configuration. Use when building authentication systems, managing user sessions, or implementing secure logout functionality.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/shadcn-vue/.claude-plugin/plugin.json
+++ b/plugins/shadcn-vue/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shadcn-vue",
   "description": "shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/shadcn-vue/.codex-plugin/plugin.json
+++ b/plugins/shadcn-vue/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shadcn-vue",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/systematic-debugging/.claude-plugin/plugin.json
+++ b/plugins/systematic-debugging/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "systematic-debugging",
   "description": "Four-phase debugging framework that ensures root cause investigation before attempting fixes. Never jump to solutions. Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/systematic-debugging/.codex-plugin/plugin.json
+++ b/plugins/systematic-debugging/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "systematic-debugging",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Four-phase debugging framework that ensures root cause investigation before attempting fixes. Never jump to solutions. Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/tailwind-v4-shadcn/.claude-plugin/plugin.json
+++ b/plugins/tailwind-v4-shadcn/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tailwind-v4-shadcn",
   "description": "Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React. Use when: initializing React projects with Tailwind v4, setting up shadcn/ui, implementing dark mode, debugging CSS variable issues, fixing theme switching, migrating from Tailwind v3, or encountering color/theming problems. Covers: @theme inline pattern, CSS variable architecture, dark mode with ThemeProvider, component composition, vite.config setup, common v4 gotchas, and production-tested patterns.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tailwind-v4-shadcn/.codex-plugin/plugin.json
+++ b/plugins/tailwind-v4-shadcn/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-v4-shadcn",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React. Use when: initializing React projects with Tailwind v4, setting up shadcn/ui, implementing dark mode, debugging CSS variable issues, fixing theme switching, migrating from Tailwind v3, or encountering color/theming problems. Covers: @theme inline pattern, CSS variable architecture, dark mode with ThemeProvider, component composition, vite.config setup, common v4 gotchas, and production-tested patterns.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/tanstack-ai/.claude-plugin/plugin.json
+++ b/plugins/tanstack-ai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-ai",
   "description": "TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and tool definitions.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-ai/.codex-plugin/plugin.json
+++ b/plugins/tanstack-ai/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-ai",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and tool definitions.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/tanstack-query/.claude-plugin/plugin.json
+++ b/plugins/tanstack-query/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-query",
   "description": "TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-query/.codex-plugin/plugin.json
+++ b/plugins/tanstack-query/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-query",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/tanstack-router/.claude-plugin/plugin.json
+++ b/plugins/tanstack-router/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-router",
   "description": "TanStack Router type-safe file-based routing for React. Use for SPAs, TanStack Query integration, Cloudflare Workers, or encountering devtools, type safety, loader, Vite bundling errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-router/.codex-plugin/plugin.json
+++ b/plugins/tanstack-router/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-router",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "TanStack Router type-safe file-based routing for React. Use for SPAs, TanStack Query integration, Cloudflare Workers, or encountering devtools, type safety, loader, Vite bundling errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/tanstack-start/.claude-plugin/plugin.json
+++ b/plugins/tanstack-start/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-start",
   "description": "TanStack Start (RC) full-stack React with server functions, SSR, Cloudflare Workers. Use for Next.js migration, edge rendering, or encountering hydration, auth, data pattern errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-start/.codex-plugin/plugin.json
+++ b/plugins/tanstack-start/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-start",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "TanStack Start (RC) full-stack React with server functions, SSR, Cloudflare Workers. Use for Next.js migration, edge rendering, or encountering hydration, auth, data pattern errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/tanstack-table/.claude-plugin/plugin.json
+++ b/plugins/tanstack-table/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-table",
   "description": "TanStack Table v8 headless data tables with server-side features for Cloudflare Workers + D1. Use for pagination, filtering, sorting, virtualization, or encountering state management, TanStack Query coordination, URL sync errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-table/.codex-plugin/plugin.json
+++ b/plugins/tanstack-table/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-table",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "TanStack Table v8 headless data tables with server-side features for Cloudflare Workers + D1. Use for pagination, filtering, sorting, virtualization, or encountering state management, TanStack Query coordination, URL sync errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/tech-debt/.claude-plugin/plugin.json
+++ b/plugins/tech-debt/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "tech-debt",
+  "description": "Multi-skill plugin: tech-debt",
+  "version": "3.7.0",
+  "author": {
+    "name": "Claude Skills Maintainers",
+    "email": "maintainers@example.com"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/secondsky/claude-skills",
+  "keywords": [
+    "tech-debt",
+    "tech",
+    "debt",
+    "tooling",
+    "workflow"
+  ]
+}

--- a/plugins/tech-debt/.codex-plugin/plugin.json
+++ b/plugins/tech-debt/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "tech-debt",
+  "version": "3.7.0",
+  "description": "Multi-skill plugin: tech-debt",
+  "author": {
+    "name": "Claude Skills Maintainers",
+    "email": "maintainers@example.com"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/secondsky/claude-skills",
+  "keywords": [
+    "tech-debt",
+    "tech",
+    "debt",
+    "tooling",
+    "workflow"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Tech Debt",
+    "shortDescription": "Multi-skill plugin: tech-debt",
+    "longDescription": "Multi-skill plugin: tech-debt",
+    "developerName": "Claude Skills Maintainers",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Help me with Tech Debt.",
+      "Show me best practices for Tech Debt.",
+      "Guide me through using Tech Debt effectively."
+    ]
+  }
+}

--- a/plugins/tech-debt/README.md
+++ b/plugins/tech-debt/README.md
@@ -1,0 +1,33 @@
+# tech-debt
+
+A two-mode skill for managing technical debt across its lifecycle. The skill **routes** between the two modes based on whether the user is making a change right now.
+
+## What it does
+
+- **Mode A — Prevent:** while making a change (feature/fix/refactor), rework it toward the intended end state. Delete dead compatibility paths instead of preserving them; prefer one clear component over mode flags. (Stance: `zero-tech-debt`.)
+- **Mode B — Triage:** while assessing existing code, categorize debt (code / architecture / test / dependency / documentation / infrastructure), score it by Impact × Risk × inverse-Effort, and produce a phased remediation plan that runs alongside feature work. (Stance: `anthropics/tech-debt`.)
+
+The router lives in `skills/tech-debt/SKILL.md`. Each mode's full steps, rules, and examples live in its own reference:
+
+- `skills/tech-debt/references/prevent-during-change.md` — Mode A
+- `skills/tech-debt/references/triage-backlog.md` — Mode B
+
+## Auto-Trigger Keywords
+
+### Primary
+- tech debt, technical debt, tech-debt audit, tech-debt assessment
+- refactor, refactoring, rework this change
+- zero tech debt, "no bandaids", "do this properly"
+
+### Secondary
+- dead code, compatibility cruft, mode flag, wrapper, fallback, alias, route alias
+- code health, code quality, maintenance backlog, remediation plan
+- architecture debt, dependency debt, test debt, documentation debt, infrastructure debt
+- "what should we refactor", prioritize, prioritization
+
+### Error-based
+- "this change got messy", "too many conditionals", "why is this still here"
+- regressions shipping (test debt), flaky tests
+- security vulnerability from an outdated dependency, CVE
+- onboarding pain, tribal knowledge, "nobody knows how this works"
+- manual deploy broke (infra debt), no monitoring caught the incident

--- a/plugins/tech-debt/skills/tech-debt/SKILL.md
+++ b/plugins/tech-debt/skills/tech-debt/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: tech-debt
+description: Use when reworking a change to prevent tech debt, or auditing existing debt to categorize, score, and prioritize the refactor backlog.
+license: MIT
+metadata:
+  keywords:
+    - tech-debt
+    - technical-debt
+    - refactor
+    - cleanup
+    - dead-code
+    - remediation
+    - architecture-debt
+    - code-smell
+    - mode-flags
+    - compatibility-cruft
+    - backward-compatible
+    - maintenance
+---
+
+# Tech Debt
+
+## Overview
+
+Two complementary stances on technical debt, picked apart by the router in this file:
+
+- **Mode A — Prevent:** while you're *making a change*, rework it toward the intended end state. Delete the dead compatibility path instead of preserving it.
+- **Mode B — Triage:** while you're *assessing existing code*, categorize, score, and prioritize the debt into a remediation plan.
+
+They run at different points in a debt's lifecycle: prevent when writing, triage when planning. Triage output feeds back into prevent, one item at a time.
+
+## When to use
+
+Use Mode A when:
+
+- You are implementing, finishing, or reviewing a feature / fix / refactor and the user wants the change clean.
+- You're about to keep a fallback, alias, mode flag, or wrapper "just in case" — check it has a caller first.
+- The user says "do this properly", "no bandaids", "zero tech debt", or "don't leave a mess".
+
+Use Mode B when:
+
+- The user asks for a tech-debt audit, code-health review, or "what should we refactor?"
+- The user wants to prioritize a maintenance / refactor backlog or roadmap.
+- Debt has accumulated and nobody is sure what to fix first.
+
+**When NOT to use:**
+
+- A single obvious local fix with no structural angle — just fix it; don't invoke a debt framework.
+- Style/formatting nits — point them at the linter/formatter, not here.
+- Greenfield where the intended end state is genuinely unknown (Mode A can't target what isn't defined yet).
+
+## How this skill works — router
+
+**This skill is a ROUTER.** This file stays a thin orchestrator. It picks exactly one mode (or the chain A→B→A), then you **load the matching `references/*.md` and follow it.** The two reference docs hold the actual steps, rules, and examples.
+
+**Never inline a reference doc's body.** If a branch is more than a 2–3 line summary, it belongs in `references/`. The decision of *which* branch to take stays here.
+
+Why: keeping the router thin keeps it scannable, and loading the branch body only when the mode is confirmed saves context on the wrong branch.
+
+## Routing
+
+Decision criterion — one boolean property of the task: **Is the user actively making a change right now** (writing/editing code, has a diff)? `yes` → Mode A; `no` → Mode B. The chain rule: once a triaged item is being implemented, switch to Mode A for that change.
+
+```dot
+digraph tech_debt_route {
+  rankdir=TB;
+  node [shape=box];
+
+  start  [label="User task touches tech debt" shape=oval];
+  q      [label="Actively making a change\n(writing/editing code, has a diff)?" shape=diamond];
+  a      [label="MODE A — PREVENT\nRework THIS change to the\nintended end state"];
+  b      [label="MODE B — TRIAGE\nCategorize + score the\nwhole codebase's debt"];
+  loadA  [label="Load references/prevent-during-change.md"];
+  loadB  [label="Load references/triage-backlog.md"];
+  chain  [label="Implementing a triaged item?\nSwitch to Mode A for that change" shape=diamond];
+
+  start -> q;
+  q -> a [label="yes"];
+  q -> b [label="no — assessing existing code"];
+  a -> loadA;
+  b -> loadB;
+  loadB -> chain;
+  chain -> loadA [label="yes, per item"];
+}
+```
+
+### Routing table
+
+| If the user is… | Mode | Load |
+|---|---|---|
+| implementing/finishing a feature, fix, or refactor and wants the change clean | A | `references/prevent-during-change.md` |
+| about to preserve a fallback/alias/flag "just in case" | A | `references/prevent-during-change.md` |
+| asking for a tech-debt audit / "what should we refactor" / code-health review | B | `references/triage-backlog.md` |
+| asking to prioritize a maintenance or refactor backlog | B | `references/triage-backlog.md` |
+| fixing an item that came out of a triage | A (per item) | `references/prevent-during-change.md` |
+
+## Mode A — Prevent (during a change)
+
+Rework the change from the **intended end state**, not the path that led to the current patch. Optimize for the code that *should* exist; delete dead compatibility paths rather than improving them. Prefer one clear component/flow over mode flags.
+
+**Load `references/prevent-during-change.md` and follow it.**
+
+## Mode B — Triage (audit a backlog)
+
+Systematically identify, categorize, and prioritize existing debt across the codebase. Produce a prioritized list with effort estimates and a phased remediation plan that can run alongside feature work.
+
+**Load `references/triage-backlog.md` and follow it.**
+
+## Bottom line
+
+Prevent new debt while you're changing the code; triage old debt when you're planning what to fix.

--- a/plugins/tech-debt/skills/tech-debt/references/prevent-during-change.md
+++ b/plugins/tech-debt/skills/tech-debt/references/prevent-during-change.md
@@ -1,0 +1,91 @@
+# Mode A — Prevent tech debt during a change
+
+You're here because the user is actively making a change (implementing/finishing/reviewing a feature, fix, or refactor) and wants it clean. This is the `zero-tech-debt` stance: rework the change as if the intended UX and architecture had existed from day one.
+
+## Core principle
+
+**Optimize for the code that should exist — don't minimize the diff from the old code.**
+
+The temptation while editing is to keep the change small by preserving the old shape and bolting the new behavior on (a mode flag, a wrapper, a fallback branch). That preservation is how debt is born. Instead, reshape toward the end state and let the diff be what it has to be.
+
+## Steps
+
+1. **State the intended end state in one or two sentences.** Product intent, not implementation history. If you can't state it, stop and ask — you can't rework toward an undefined target. This single sentence is the ruler every later decision is measured against.
+
+2. **Search for actual callers before keeping anything for compatibility.** Before you preserve a mode, prop, wrapper, route alias, or fallback, grep the codebase (and any known consumers) for callers. **If it has no current caller, delete it.** "Might be used later" is not a caller. Unreferenced compat is dead weight you'll maintain forever.
+
+3. **Reshape to the final product surface.** Prefer one clear component or flow over a mode flag that switches between two shapes. Splitting is warranted only when it creates an obvious boundary — state, layout, controls, or domain commands — not as a way to avoid touching the old code.
+
+4. **Consolidate shared rules into a single location.** Feature flags, permissions, route gating, URL state, and command naming should each live in one place. Duplicating a rule across the new and old paths guarantees they drift.
+
+5. **Verify the intended flow.** Run the happy path and anything you deleted assumptions from — navigation, permissions, state transitions. Deleted compat can break a caller you missed in step 2; a test or manual check catches it now.
+
+## Rules
+
+- **Optimize for the code that should exist**, not for the smallest diff from the old code.
+- **Delete dead compatibility paths** instead of making them better. A better bandaid is still a bandaid.
+- **Do not invent a generic framework for one feature.** Speculate-generalize nothing. Generalize after the second concrete need, not before.
+- **Keep the refactor scoped** to the change at hand so the final shape stays coherent. Don't opportunistically rewrite adjacent code; do delete the cruft your change makes unreachable.
+- **Prefer names that describe product intent** (`PasswordResetEmail`) over implementation history (`LegacyV2Notifier`). The name is the first thing future readers see.
+
+## Before / after — collapsing a mode flag
+
+The flagship rule is "prefer one clear component over mode flags." A `mode` prop that branches a single component into two unrelated shapes is the most common debt introduced during edits.
+
+Before — one component, two shapes welded together by a flag:
+
+```tsx
+// ❌ One component, two unrelated shapes fused by a mode flag.
+// Each new requirement touches both branches; they drift over time.
+function Notification({ mode, user, systemAlert }: NotificationProps) {
+  if (mode === "user") {
+    return (
+      <Card>
+        <Avatar src={user.avatar} />
+        <Text>{user.name} sent you a message.</Text>
+      </Card>
+    );
+  }
+  return (
+    <Banner tone={systemAlert.severity}>
+      <Text>{systemAlert.message}</Text>
+    </Banner>
+  );
+}
+```
+
+After — two clear components, each with one shape:
+
+```tsx
+// ✅ Two components with an obvious boundary (different data, different surface).
+// Each can evolve independently; no shared branch to drift.
+function UserMessage({ user }: { user: User }) {
+  return (
+    <Card>
+      <Avatar src={user.avatar} />
+      <Text>{user.name} sent you a message.</Text>
+    </Card>
+  );
+}
+
+function SystemBanner({ alert }: { alert: SystemAlert }) {
+  return (
+    <Banner tone={alert.severity}>
+      <Text>{alert.message}</Text>
+    </Banner>
+  );
+}
+```
+
+Call sites that used to pass `mode="user"` / `mode="system"` now render the right component directly. If a call site genuinely needs to switch between them, that switch is routing logic — put it at the call site, not welded into the component.
+
+This is one example, not a recipe. The rule generalizes: when an edit would add a branch that exists only to preserve the old shape, split instead.
+
+## Red flags — when NOT to apply Mode A
+
+- **Greenfield where the end state is genuinely unknown.** You can't rework toward a target you haven't defined. Build the first cut, apply Mode A once the shape proves out.
+- **Intentionally temporary change** — a feature-flagged rollout, an A/B variant, an incident hotfix you'll revert. The flag *is* the end state for now. Re-evaluate when the flag is supposed to come down.
+- **Frozen/legacy surface with an explicit "do not touch" boundary.** Deleting the compat there can break out-of-tree consumers you can't see. Triage it (Mode B) and surface the risk instead of deleting silently.
+- **The "end state" you'd build requires a much larger refactor than the change at hand.** Note it for triage; don't expand the scope of this change beyond what stays coherent.
+
+When in doubt, state the end state (step 1) and let that sentence decide. If it says the compat survives, it survives for a reason you can name.

--- a/plugins/tech-debt/skills/tech-debt/references/triage-backlog.md
+++ b/plugins/tech-debt/skills/tech-debt/references/triage-backlog.md
@@ -1,0 +1,70 @@
+# Mode B — Triage an existing tech-debt backlog
+
+You're here because the user is assessing existing code, not making a change right now. Goal: systematically identify, categorize, and prioritize debt, and produce a remediation plan that can run alongside feature work.
+
+## Categories
+
+Classify every item into exactly one primary category (use the second-most-fitting only if it's truly mixed, and note both).
+
+| Type | Examples | Risk if unfixed |
+|------|----------|-----------------|
+| **Code debt** | Duplicated logic, poor abstractions, magic numbers, dead code | Bugs, slow development |
+| **Architecture debt** | Monolith that should be split, wrong data store, missing service boundary | Scaling limits, hard to change |
+| **Test debt** | Low coverage, flaky tests, missing integration tests, no CI gates | Regressions ship to production |
+| **Dependency debt** | Outdated libraries, unmaintained deps, pinned ancient versions | Security vulnerabilities, blocked upgrades |
+| **Documentation debt** | Missing runbooks, outdated READMEs, tribal knowledge, no ADRs | Onboarding pain, single points of failure |
+| **Infrastructure debt** | Manual deploys, no monitoring/alerting, no IaC, no backups | Incidents, slow recovery |
+
+## Prioritization framework
+
+Score each item on three axes:
+
+- **Impact (1–5):** How much does it slow the team down *today*? Bugs it causes, hours it burns, features it blocks.
+- **Risk (1–5):** What happens if we *don't* fix it? Security exposure, outage likelihood, talent lock-in.
+- **Effort (1–5, inverted):** How hard is the fix? Note that **lower effort → higher priority** — a cheap high-impact win beats an expensive one.
+
+Compute:
+
+```
+Priority = (Impact + Risk) × (6 − Effort)
+```
+
+The `(6 − Effort)` term inverts effort so a 1-day fix (Effort=1 → ×5) outranks a quarter-long one (Effort=5 → ×1). Range: 2 (low/low × hard) to 50 (high/high × easy).
+
+Higher score = fix sooner. Use the raw number to break ties and to group into phases.
+
+## Worked example — scoring three items
+
+| Item | Category | Impact | Risk | Effort | Priority |
+|---|---|---|---|---|---|
+| Auth library 3 major versions behind, has known CVE | Dependency | 4 | 5 | 3 | (4+5)×3 = **27** |
+| Duplicated checkout logic across 3 entry points | Code | 4 | 3 | 2 | (4+3)×4 = **28** |
+| No runbook for the primary incident path | Documentation | 3 | 4 | 1 | (3+4)×5 = **35** |
+
+Reading: the runbook (cheap, real risk) edges out the checkout duplication (also cheap) and the auth upgrade (high value but bigger). The numbers are a tie-breaker for judgment, not a replacement for it — a security CVE at priority 27 still goes first regardless of a doc item at 35; call that out in the plan.
+
+## Output contract
+
+Produce, in this order:
+
+1. **Prioritized list** — one row per item: category, short description, Impact/Risk/Effort scores, computed Priority, and a one-line **business justification** (the cost of *not* fixing it, in team velocity, risk, or dollars — not "the code is ugly").
+2. **Estimated effort per item** — in concrete units the team plans in (hours, days, sprints). Range if uncertain ("2–3 days").
+3. **Phased remediation plan** — group items into phases that can run **alongside feature work**, not as a big-bang freeze:
+   - **Phase 0 — quick wins:** Priority ≥ ~30 and Effort ≤ 2. Knock out in the current sprint alongside features.
+   - **Phase 1 — high-leverage:** highest Priority items regardless of effort, scheduled explicitly.
+   - **Phase 2 — background:** low-Effort items folded into "when you touch this area, also fix X."
+   - **Phase 3 — strategic:** large Architecture/Dependency items needing dedicated planning; these become their own tickets/epics.
+4. **"Do alongside" call-outs** — items small enough to attach to upcoming feature work ("when you next touch checkout, collapse the 3 duplicated paths"). This is where triage hands off to Mode A: each "do alongside" becomes a Mode A rework when that change happens.
+
+## Scope of the audit
+
+Match the audit's breadth to what the user asked:
+
+- **"What should we refactor in this module?"** → triage that module only. Deep, specific.
+- **"Tech-debt audit the codebase."** → survey all six categories at the breadth of the whole repo, but keep each item to one line; depth comes in Phase 1 when items are picked up.
+
+Either way, don't boil the ocean. A prioritized list of 10 sharp items beats a 200-item dump nobody reads.
+
+## Bottom line
+
+Categorize → score → prioritize → plan alongside feature work. Hand each "do alongside" item to Mode A when its change comes up.

--- a/plugins/technical-specification/.claude-plugin/plugin.json
+++ b/plugins/technical-specification/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "technical-specification",
   "description": "Creates detailed technical specifications for software projects covering requirements, architecture, APIs, and testing strategies. Use when planning features, documenting system design, or creating architecture decision records.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/technical-specification/.codex-plugin/plugin.json
+++ b/plugins/technical-specification/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "technical-specification",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Creates detailed technical specifications for software projects covering requirements, architecture, APIs, and testing strategies. Use when planning features, documenting system design, or creating architecture decision records.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/test-quality-analysis/.claude-plugin/plugin.json
+++ b/plugins/test-quality-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "test-quality-analysis",
   "description": "Detect test smells, overmocking, flaky tests, and coverage issues. Analyze test effectiveness, maintainability, and reliability. Use when reviewing tests or improving test quality.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/test-quality-analysis/.codex-plugin/plugin.json
+++ b/plugins/test-quality-analysis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "test-quality-analysis",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Detect test smells, overmocking, flaky tests, and coverage issues. Analyze test effectiveness, maintainability, and reliability. Use when reviewing tests or improving test quality.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/thesys-generative-ui/.claude-plugin/plugin.json
+++ b/plugins/thesys-generative-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thesys-generative-ui",
   "description": "AI-powered generative UI with Thesys - create React components from natural language.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/thesys-generative-ui/.codex-plugin/plugin.json
+++ b/plugins/thesys-generative-ui/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "thesys-generative-ui",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "AI-powered generative UI with Thesys - create React components from natural language.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/threejs/.claude-plugin/plugin.json
+++ b/plugins/threejs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "threejs",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Comprehensive Three.js skills for building 3D web experiences",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/threejs/.codex-plugin/plugin.json
+++ b/plugins/threejs/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "threejs",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Comprehensive Three.js skills for building 3D web experiences",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/turborepo/.claude-plugin/plugin.json
+++ b/plugins/turborepo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "turborepo",
   "description": "Turborepo high-performance monorepo build system. Use for monorepo setup, build optimization, task pipelines, caching strategies, or multi-package orchestration.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/turborepo/.codex-plugin/plugin.json
+++ b/plugins/turborepo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "turborepo",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Turborepo high-performance monorepo build system. Use for monorepo setup, build optimization, task pipelines, caching strategies, or multi-package orchestration.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/typescript-migration/.claude-plugin/plugin.json
+++ b/plugins/typescript-migration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-migration",
   "description": "TypeScript version migration guide (5.x to 6 to 7, tsgo native port). Use for TS 6 tsconfig breaking changes, TS 7 Go rewrite rollout, or TS5xxx deprecation codes.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/typescript-migration/.codex-plugin/plugin.json
+++ b/plugins/typescript-migration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-migration",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "TypeScript version migration guide (5.x to 6 to 7, tsgo native port). Use for TS 6 tsconfig breaking changes, TS 7 Go rewrite rollout, or TS5xxx deprecation codes.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/ultracite/.claude-plugin/plugin.json
+++ b/plugins/ultracite/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultracite",
   "description": "Ultracite multi-provider linting/formatting (Biome, ESLint, Oxlint). Use for v6/v7 setup, provider selection, Git hooks, MCP integration, AI hooks, migrations, or encountering configuration, type-aware linting, monorepo errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ultracite/.codex-plugin/plugin.json
+++ b/plugins/ultracite/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultracite",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Ultracite multi-provider linting/formatting (Biome, ESLint, Oxlint). Use for v6/v7 setup, provider selection, Git hooks, MCP integration, AI hooks, migrations, or encountering configuration, type-aware linting, monorepo errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/unknowns-discovery/.claude-plugin/plugin.json
+++ b/plugins/unknowns-discovery/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "unknowns-discovery",
+  "description": "Discover and reduce task unknowns — blindspots, missing context, unknown unknowns — before committing to a plan, implementation, review, or merge.",
+  "version": "3.7.0",
+  "author": {
+    "name": "Claude Skills Maintainers",
+    "email": "maintainers@example.com"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/secondsky/claude-skills",
+  "keywords": [
+    "unknowns-discovery",
+    "unknowns",
+    "discovery",
+    "tooling",
+    "workflow",
+    "implementation"
+  ],
+  "commands": [
+    "./commands/blindspot-pass.md",
+    "./commands/discover-unknowns.md",
+    "./commands/merge-readiness-quiz.md"
+  ]
+}

--- a/plugins/unknowns-discovery/.codex-plugin/plugin.json
+++ b/plugins/unknowns-discovery/.codex-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "unknowns-discovery",
+  "version": "3.7.0",
+  "description": "Discover and reduce task unknowns — blindspots, missing context, unknown unknowns — before committing to a plan, implementation, review, or merge.",
+  "author": {
+    "name": "Claude Skills Maintainers",
+    "email": "maintainers@example.com"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/secondsky/claude-skills",
+  "keywords": [
+    "unknowns-discovery",
+    "unknowns",
+    "discovery",
+    "tooling",
+    "workflow",
+    "implementation"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Unknowns Discovery",
+    "shortDescription": "Discover and reduce task unknowns — blindspots, missing context, unknown",
+    "longDescription": "Discover and reduce task unknowns — blindspots, missing context, unknown unknowns — before committing to a plan, implementation, review, or merge.",
+    "developerName": "Claude Skills Maintainers",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Help me with Unknowns Discovery.",
+      "Show me best practices for Unknowns Discovery.",
+      "Guide me through using Unknowns Discovery effectively."
+    ]
+  }
+}

--- a/plugins/unknowns-discovery/README.md
+++ b/plugins/unknowns-discovery/README.md
@@ -1,0 +1,88 @@
+# unknowns-discovery
+
+Discover and reduce task unknowns — blindspots, missing context, unknown unknowns — before committing to a plan, implementation, review, or merge.
+
+The prompt, ticket, screenshot, and context window are the **map**. The real codebase, product, users, data, constraints, history, and reviewer expectations are the **territory**. The gap between them is the task's **unknowns**. This skill makes the agent surface that gap *before* it guesses.
+
+## What it does
+
+A single router skill (`skills/unknowns-discovery/SKILL.md`) activates on ambiguous, unfamiliar, or high-risk work, then selects one of **11 artifact modes** plus the generic unknowns matrix. Each artifact follows a default output contract: scope read → unknowns found → blast radius → conservative default → decision needed → prompt upgrade → stop conditions.
+
+- **blindspot-pass** — surface hidden constraints, prior art, traps, and missing vocabulary before implementation.
+- **teach-me-my-unknowns** — build a mental model and vocabulary ladder when the user lacks domain words.
+- **brainstorm-prototype / mock-before-wire** — divergent options and throwaway mocks for taste-dependent decisions.
+- **option-space-brainstorm** — re-frame a problem that may be too narrow or too wide.
+- **one-question-interview** — one question at a time, ordered by blast radius.
+- **reference-semantics-map** — capture existing behavior before porting or adapting.
+- **tweakable-plan** — a plan sorted by likely human-tweak points.
+- **implementation-notes** — a running log of deviations and conservative choices during the build.
+- **buy-in-doc** — a demo-first pitch for stakeholder alignment.
+- **merge-readiness-quiz** — a report and quiz a human must pass before merge/release.
+
+Full procedures live in `skills/unknowns-discovery/references/WORKFLOWS.md`; copyable prompt cards in `references/PROMPT_PATTERNS.md`; output schemas in `references/OUTPUT_SCHEMAS.md`.
+
+## Commands
+
+```text
+/unknowns-discovery:discover-unknowns [task-or-file]
+/unknowns-discovery:blindspot-pass [task-or-area]
+/unknowns-discovery:merge-readiness-quiz [change-or-diff]
+```
+
+## Contents
+
+```text
+unknowns-discovery/
+├── .claude-plugin/plugin.json
+├── README.md
+├── commands/
+│   ├── discover-unknowns.md
+│   ├── blindspot-pass.md
+│   └── merge-readiness-quiz.md
+└── skills/unknowns-discovery/
+    ├── SKILL.md
+    ├── references/        (WORKFLOWS, PROMPT_PATTERNS, OUTPUT_SCHEMAS, EVALUATION, SOURCE_INDEX, TRACEABILITY, ARTICLE_DIGEST)
+    ├── assets/templates/  (12 reusable Markdown templates, one per mode)
+    ├── examples/          (worked examples across coding, product/design, research)
+    └── scripts/           (validate_skill.py, make_unknowns_artifact.py)
+```
+
+## Validate
+
+```bash
+npm run validate
+python plugins/unknowns-discovery/skills/unknowns-discovery/scripts/validate_skill.py \
+  plugins/unknowns-discovery/skills/unknowns-discovery
+```
+
+## Generate a starter artifact
+
+```bash
+python plugins/unknowns-discovery/skills/unknowns-discovery/scripts/make_unknowns_artifact.py \
+  --task "Add SSO provider to the auth module" \
+  --mode blindspot-pass \
+  --domain coding \
+  --out blindspot.md
+```
+
+## Auto-Trigger Keywords
+
+### Primary
+- blindspot pass, blindspots, unknown unknowns, "what am I missing"
+- interview me, quiz me, prototype first, implementation notes, buy-in doc
+- merge readiness, merge-readiness quiz
+
+### Secondary
+- assumptions, assumptions register, reference port, reference-semantics-map
+- option space, tweakable plan, domain vocabulary, quality criteria
+- unfamiliar codebase, unfamiliar domain, "don't know what good looks like"
+- long-horizon implementation, "plan and codebase disagree"
+
+### Error-based
+- "merged then it broke", "we reverted this before", diff-skim review
+- refactor stalled, "too many unknowns", scope creep mid-implementation
+- stakeholder misaligned, surprise data/auth/migration constraint surfaced late
+
+## Provenance
+
+Derived from the article **"A Field Guide to Fable: Finding Your Unknowns"** by Thariq (`@trq212`). The plugin transforms (does not reproduce) the source. See `skills/unknowns-discovery/references/SOURCE_INDEX.md` and `TRACEABILITY.md` for the article→skill mapping.

--- a/plugins/unknowns-discovery/commands/blindspot-pass.md
+++ b/plugins/unknowns-discovery/commands/blindspot-pass.md
@@ -1,0 +1,34 @@
+---
+name: unknowns-discovery:blindspot-pass
+description: Run a focused blindspot pass for unfamiliar, ambiguous, or high-risk work
+argument-hint: "[task-or-area]"
+allowed-tools: [Read, Glob, Grep, Write, Edit]
+---
+
+# Blindspot Pass
+
+Use the Unknowns Discovery skill in `blindspot-pass` mode.
+
+## Invocation
+
+```text
+/unknowns-discovery:blindspot-pass [task-or-area]
+```
+
+## Arguments
+
+The user invoked this command with: $ARGUMENTS
+
+## Instructions
+
+When this command is invoked:
+
+1. Treat `$ARGUMENTS` as the task, code area, design area, or domain to inspect.
+2. Load `skills/unknowns-discovery/SKILL.md` and follow the `blindspot-pass` mode.
+3. Read relevant files, docs, examples, history, or references before asking questions.
+4. Surface hidden constraints, prior art, likely traps, tacit quality standards, and missing vocabulary.
+5. End with a better implementation prompt that folds in the discoveries.
+
+## Output
+
+Produce blindspot cards plus the upgraded prompt described by the skill.

--- a/plugins/unknowns-discovery/commands/discover-unknowns.md
+++ b/plugins/unknowns-discovery/commands/discover-unknowns.md
@@ -1,0 +1,34 @@
+---
+name: unknowns-discovery:discover-unknowns
+description: Discover missing context, blindspots, and high-blast-radius unknowns before agent work
+argument-hint: "[task-or-file]"
+allowed-tools: [Read, Glob, Grep, Write, Edit]
+---
+
+# Discover Unknowns
+
+Use the Unknowns Discovery skill to choose the cheapest useful unknowns artifact.
+
+## Invocation
+
+```text
+/unknowns-discovery:discover-unknowns [task-or-file]
+```
+
+## Arguments
+
+The user invoked this command with: $ARGUMENTS
+
+## Instructions
+
+When this command is invoked:
+
+1. Treat `$ARGUMENTS` as the task, file path, area, or rough prompt to investigate.
+2. If it looks like a file path, read it before asking questions.
+3. Load `skills/unknowns-discovery/SKILL.md` and follow it exactly.
+4. Inspect the relevant territory before asking the user anything that can be answered locally.
+5. Select the highest-value artifact mode and produce the skill's normal output.
+
+## Output
+
+Use the skill's default output contract: scope read, unknowns found, blast radius, conservative defaults, decisions needed, prompt upgrade, and stop conditions.

--- a/plugins/unknowns-discovery/commands/merge-readiness-quiz.md
+++ b/plugins/unknowns-discovery/commands/merge-readiness-quiz.md
@@ -1,0 +1,34 @@
+---
+name: unknowns-discovery:merge-readiness-quiz
+description: Create a merge-readiness report and quiz for an important or complex change
+argument-hint: "[change-or-diff]"
+allowed-tools: [Read, Glob, Grep]
+---
+
+# Merge Readiness Quiz
+
+Use the Unknowns Discovery skill in `merge-readiness-quiz` mode.
+
+## Invocation
+
+```text
+/unknowns-discovery:merge-readiness-quiz [change-or-diff]
+```
+
+## Arguments
+
+The user invoked this command with: $ARGUMENTS
+
+## Instructions
+
+When this command is invoked:
+
+1. Treat `$ARGUMENTS` as the target change, diff, branch, PR notes, or file path.
+2. Load `skills/unknowns-discovery/SKILL.md` and follow the `merge-readiness-quiz` mode.
+3. Inspect the relevant files and diff context before writing the report.
+4. Explain what changed, why it matters, what risks remain, and what the human must understand before merging.
+5. Include quiz questions with pass criteria.
+
+## Output
+
+Produce the skill's merge-readiness report and quiz. Do not edit implementation files unless the user separately asks for fixes.

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/SKILL.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: unknowns-discovery
+description: Discover and reduce task unknowns — blindspots, missing context, and unknown unknowns — before committing to a plan, implementation, review, or merge.
+---
+
+# Unknowns Discovery
+
+Use this skill when an agent should **discover what the user, spec, prompt, or codebase is missing** before it commits to a plan, implementation, review, or merge.
+
+The prompt, skill, ticket, screenshot, and context window are the **map**. The real codebase, product, users, data, constraints, history, and reviewer expectations are the **territory**. The gap between them is the task's **unknowns**.
+
+## Unknown types
+
+| Type | Meaning | Agent move |
+|---|---|---|
+| Known knowns | Explicit facts and constraints in the prompt | Preserve and restate briefly |
+| Known unknowns | Questions already recognized as open | Ask, research, parameterize, or gate |
+| Unknown knowns | Tacit standards the user would recognize only after seeing them | Prototype, mock, compare, or interview |
+| Unknown unknowns | Hidden constraints, missing vocabulary, prior art, traps, or quality ceilings nobody mentioned | Run blindspot passes, inspect references, search code/history, and surface landmines |
+
+## When to activate
+
+Activate this skill when any of these are true:
+
+- The work is multi-step, ambiguous, unfamiliar, high-risk, or likely to require judgment.
+- The user mentions “blindspot pass,” “unknown unknowns,” “what am I missing,” “interview me,” “prototype first,” “implementation notes,” “buy-in doc,” “quiz me,” or similar.
+- The user lacks domain vocabulary or does not know what good looks like.
+- The task involves codebase history, architecture, data model, permissions, migrations, UX, visual design, product scope, rollout, or reviewer approval.
+- The agent is about to start a long-horizon implementation or has already discovered that the plan and codebase disagree.
+
+Do **not** activate for tiny deterministic tasks where exploration would add friction, such as fixing a typo, renaming a variable, or answering a direct question with no meaningful unknowns.
+
+## Core loop
+
+1. **State the map.** Restate the task, constraints, and what the user says they know.
+2. **Inspect the territory.** Read relevant files, docs, examples, data, screenshots, references, prior work, or user-provided context.
+3. **Build an unknowns matrix.** Separate known knowns, known unknowns, unknown knowns, and unknown unknowns.
+4. **Choose the cheapest useful artifact.** Pick the mode that exposes the highest-blast-radius unknown earliest.
+5. **Gate implementation.** Proceed only when dangerous unknowns are resolved, explicitly accepted, or isolated behind reversible decisions.
+6. **Carry discoveries forward.** Fold the discoveries into a better prompt, plan, implementation note, buy-in doc, quiz, tests, or review artifact.
+
+## Artifact mode selector
+
+| Mode | Use when | Output |
+|---|---|---|
+| `blindspot-pass` | Unfamiliar codebase/domain/design area; likely unknown unknowns | Blindspot cards + better implementation prompt |
+| `teach-me-my-unknowns` | User lacks vocabulary or quality criteria | Mental model + vocabulary ladder + improved prompts |
+| `brainstorm-prototype` | User will know it when they see it | Divergent prototypes/options + reaction template |
+| `mock-before-wire` | Need to see UI/flow before backend/state/app changes | Throwaway mock with fake data + wiring plan |
+| `option-space-brainstorm` | Problem framing may be too narrow or too wide | Ranked interventions from cheapest to ambitious |
+| `one-question-interview` | Ambiguity remains after exploration | One question at a time, ordered by blast radius |
+| `reference-semantics-map` | Existing code/design/doc is the best description | Semantics map before porting/adapting |
+| `tweakable-plan` | Ready to implement but human should review change-prone parts | Plan sorted by likely human-tweak points before execution order |
+| `implementation-notes` | Implementation is underway and surprises appear | Running log of deviations and conservative choices |
+| `buy-in-doc` | Work needs approval or stakeholder alignment | Demo-first pitch/explainer with objections and signoffs |
+| `merge-readiness-quiz` | Human must understand a complex change before merge/release | Report + quiz with pass criteria |
+
+Detailed procedures are in [references/WORKFLOWS.md](references/WORKFLOWS.md). Copyable prompt cards are in [references/PROMPT_PATTERNS.md](references/PROMPT_PATTERNS.md). Output schemas are in [references/OUTPUT_SCHEMAS.md](references/OUTPUT_SCHEMAS.md).
+
+## Default output contract
+
+Every unknowns artifact should include:
+
+1. **Scope read:** What was inspected or assumed.
+2. **Unknowns found:** Labels by unknown type and severity.
+3. **Blast radius:** What changes if this unknown is answered differently.
+4. **Conservative default:** What the agent will do if forced to proceed.
+5. **Decision needed:** What the user must choose, if anything.
+6. **Prompt upgrade:** A revised prompt/instruction incorporating discoveries.
+7. **Stop conditions:** Cases where guessing is unacceptable.
+
+## Autonomy rules
+
+- Ask before acting when an unknown can change architecture, data model, auth, privacy, compliance, cost, public API, migration, rollout, or user-facing behavior.
+- Proceed conservatively when the unknown is low-risk, reversible, and the user has asked not to be interrupted. Label assumptions as `ASSUMED`.
+- Prototype before wiring when feedback depends on taste, layout, copy tone, interaction flow, information architecture, or data density.
+- Prefer source references over prose when behavior already exists elsewhere.
+- During implementation, log every material deviation before continuing.
+- Do not merge complex agent work on diff-skimming alone; create a report and quiz if understanding matters.
+
+## Stop immediately when
+
+- The territory contradicts the task goal.
+- The unknown could cause data loss, auth bypass, privacy leak, billing impact, destructive migration, public API break, or compliance failure.
+- A prior failed/reverted attempt appears and the reason still applies.
+- Exact legal/security/compliance behavior is requested but the authoritative source is absent.
+
+## Minimal examples
+
+```text
+Do a blindspot pass before implementation. Find unknown unknowns, explain why each matters, and rewrite my prompt with the discoveries folded in.
+```
+
+```text
+Before touching the app, make a single HTML mock with fake data so I can react to layout and product decisions.
+```
+
+```text
+Keep implementation-notes.md as you build. If code forces a plan deviation, choose the conservative option, log it under Deviations, and continue unless it affects security/data/migrations/API/compliance.
+```
+
+```text
+Give me a merge-readiness report with a quiz at the bottom. I should not merge until I pass it perfectly.
+```
+
+## Packaged resources
+
+- [references/ARTICLE_DIGEST.md](references/ARTICLE_DIGEST.md) — faithful extracted digest of the supplied article.
+- [references/WORKFLOWS.md](references/WORKFLOWS.md) — detailed procedure for each artifact mode.
+- [references/PROMPT_PATTERNS.md](references/PROMPT_PATTERNS.md) — reusable prompt cards.
+- [references/OUTPUT_SCHEMAS.md](references/OUTPUT_SCHEMAS.md) — artifact schemas and gates.
+- [references/EVALUATION.md](references/EVALUATION.md) — eval prompts and quality rubrics.
+- [references/SOURCE_INDEX.md](references/SOURCE_INDEX.md) — source and format references.
+- [assets/templates/](assets/templates/) — reusable Markdown templates.
+- [examples/](examples/) — example applications across coding, product/design, and research.
+- [scripts/](scripts/) — optional helper scripts for template generation and validation.

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/assumptions-register.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/assumptions-register.md
@@ -1,0 +1,14 @@
+# Assumptions Register: [Task]
+
+| ID | Assumption | Why assumed | Reversible? | Risk | Validation path | Owner |
+|---|---|---|---:|---|---|---|
+| A1 |  |  |  |  |  |  |
+
+## Stop conditions
+- [Assumption invalidation that requires pausing]
+
+## Assumptions folded into prompt
+```text
+ASSUMED: [assumption]
+ASSUMED: [assumption]
+```

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/blindspot-pass.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/blindspot-pass.md
@@ -1,0 +1,33 @@
+# Blindspot Pass: [Task]
+
+## Scope inspected
+- Paths/docs/links:
+- Search terms:
+- Prior work checked:
+- Tests/policies checked:
+
+## What you asked for
+[The task as it appears from the map.]
+
+## What the territory revealed
+[Short summary of hidden constraints.]
+
+## Blindspots
+
+### Blindspot 1: [Name]
+- Type: [landmine / convention / prior failed attempt / hidden dependency / missing concept]
+- Severity: [low / medium / high / critical]
+- Evidence:
+- Why it bites:
+- Conservative instruction:
+- Prompt upgrade sentence:
+- Stop condition:
+
+## Better prompt
+```text
+[Rewritten implementation prompt with all blindspots folded in.]
+```
+
+## Approval gate
+- Start implementation after:
+- Ask user before:

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/brainstorm-prototype.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/brainstorm-prototype.md
@@ -1,0 +1,43 @@
+# Brainstorm / Prototype Directions: [Task]
+
+## Shared data / scenario
+[What all variants use so comparison is fair.]
+
+## Direction 1: [Philosophy]
+- Optimizes for:
+- What to steal:
+- What to skip/reject:
+- Unknown exposed:
+- Implementation implication:
+
+## Direction 2: [Philosophy]
+- Optimizes for:
+- What to steal:
+- What to skip/reject:
+- Unknown exposed:
+- Implementation implication:
+
+## Direction 3: [Philosophy]
+- Optimizes for:
+- What to steal:
+- What to skip/reject:
+- Unknown exposed:
+- Implementation implication:
+
+## Open decisions
+| Decision | Options | Blast radius | Default |
+|---|---|---|---|
+|  |  |  |  |
+
+## My reaction template
+```text
+Chosen direction:
+Steal:
+Skip:
+Change:
+Open decision answers:
+```
+
+## Real implementation plan after approval
+1. [Step]
+2. [Step]

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/buy-in-doc.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/buy-in-doc.md
@@ -1,0 +1,33 @@
+# Ship Proposal: [Feature]
+
+## Demo / result
+[Lead with the demo, image, GIF, CLI transcript, output, or crisp description.]
+
+## Ask
+[Who should approve what by when.]
+
+## Pitch
+[Why this matters to users/business/engineering.]
+
+## Reviewer objections answered
+| Objection | Answer | Evidence |
+|---|---|---|
+| Can this leak data? |  |  |
+| What happens at scale? |  |  |
+| Why this scope? |  |  |
+| Does it add ops burden? |  |  |
+| What is the rollback? |  |  |
+
+## Spec at a glance
+| Area | Decision | Reference |
+|---|---|---|
+| Entry point |  |  |
+| Permissions |  |  |
+| Data model |  |  |
+| Limits |  |  |
+| Rollout |  |  |
+
+## Sign-offs
+| Person/team | What they approve | Status |
+|---|---|---|
+|  |  |  |

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/domain-vocabulary-ladder.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/domain-vocabulary-ladder.md
@@ -1,0 +1,33 @@
+# Teach Me My Unknowns: [Domain / Task]
+
+## Starting naive prompt
+```text
+[What the user originally might ask]
+```
+
+## Mental model
+[Explain the domain in a compact, practical way.]
+
+## Vocabulary ladder
+| Term | Plain meaning | Why it matters | Prompt phrase |
+|---|---|---|---|
+|  |  |  |  |
+
+## What good looks like
+- [Quality criterion]
+
+## Common mistakes
+| Mistake | Why it fails | Better instruction |
+|---|---|---|
+|  |  |  |
+
+## Prompts I can now write
+1. ```text
+   [Improved prompt]
+   ```
+2. ```text
+   [Improved prompt]
+   ```
+3. ```text
+   [Improved prompt]
+   ```

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/implementation-notes.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/implementation-notes.md
@@ -1,0 +1,35 @@
+# Implementation Notes: [Task]
+
+Run started: [time]
+Branch/context: [branch]
+Plan source: [link/path]
+
+## Summary counters
+- Entries: 0
+- Deviations: 0
+- Needs human judgment: 0
+
+## Log
+
+### [time] Plan-confirmed: [Step]
+[What matched the plan.]
+
+### [time] Discovery: [Name]
+[Useful information found that does not require changing the plan.]
+
+### [time] Deviation: [Name]
+- What the plan said:
+- What the code revealed:
+- Conservative choice:
+- Revisit:
+
+### [time] Human judgment needed: [Name]
+- Current conservative behavior:
+- Options:
+- Recommendation:
+- Blocking? [yes/no]
+
+## Fold back into next attempt
+1. [Learning]
+2. [Learning]
+3. [Learning]

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/merge-readiness-quiz.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/merge-readiness-quiz.md
@@ -1,0 +1,44 @@
+# Merge Readiness: [Change]
+
+## Mental model
+### Before
+[How the system worked before.]
+
+### After
+[How it works now.]
+
+## What changed
+| Area | Change | Why |
+|---|---|---|
+|  |  |  |
+
+## Non-obvious behaviors
+1. [Behavior]
+2. [Behavior]
+3. [Behavior]
+
+## Dependencies and inherited assumptions
+- [Assumption]
+
+## Operational notes
+- Deploy risk:
+- Rollback:
+- Metrics:
+- Alerts:
+
+## Quiz
+
+### Question 1
+[Question]
+- Correct answer:
+- Why it matters:
+- Reread if missed:
+
+### Question 2
+[Question]
+- Correct answer:
+- Why it matters:
+- Reread if missed:
+
+## Pass criteria
+[Example: 100% correct before merge, or explicit waiver.]

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/one-question-interview.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/one-question-interview.md
@@ -1,0 +1,27 @@
+# Spec Interview: [Task]
+
+## Context so far
+- Goal:
+- Proposed approach:
+- Decisions already made:
+
+## Current question
+[Ask exactly one question.]
+
+## Why this matters
+[Explain what changes based on the answer.]
+
+## Impact by answer
+| Answer | Architecture/product/data/UX impact | Follow-up if chosen |
+|---|---|---|
+| A |  |  |
+| B |  |  |
+
+## Decisions so far
+| Decision | Answer | Impact | Date |
+|---|---|---|---|
+|  |  |  |  |
+
+## Remaining queue preview
+- [Question title only]
+- [Question title only]

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/prompt-upgrade.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/prompt-upgrade.md
@@ -1,0 +1,21 @@
+# Prompt Upgrade: [Task]
+
+## Original prompt
+```text
+[Original]
+```
+
+## Discoveries to fold in
+| Discovery | Prompt instruction | Why it matters |
+|---|---|---|
+|  |  |  |
+
+## Upgraded prompt
+```text
+[Improved prompt]
+```
+
+## Stop conditions
+```text
+Pause and ask before proceeding if [condition].
+```

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/reference-semantics-map.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/reference-semantics-map.md
@@ -1,0 +1,24 @@
+# Semantics Map: [Reference] -> [Target]
+
+## Reference inspected
+- Reference:
+- Target:
+- Files/tests/docs read:
+
+## What the reference actually does
+| Behavior | Evidence | Target mapping | Test/invariant |
+|---|---|---|---|
+|  |  |  |  |
+
+## Non-literal translations
+| Reference behavior | Why literal port fails | Proposed target behavior | Needs approval? |
+|---|---|---|---|
+|  |  |  |  |
+
+## Edge cases to preserve
+- [Edge case]
+
+## Implementation prompt after approval
+```text
+[Prompt]
+```

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/tweakable-plan.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/tweakable-plan.md
@@ -1,0 +1,33 @@
+# Tweakable Plan: [Task]
+
+## Summary
+- Effort:
+- Files touched:
+- Risk:
+- Migration/API/user-facing changes:
+- Feature flag / rollout:
+
+## A. Decisions you may want to change
+
+### A1. [Decision name]
+- Default:
+- Alternative:
+- Tradeoff:
+- Choose default if:
+- Choose alternative if:
+- One-line override:
+```text
+[Override sentence]
+```
+
+## B. Execution order
+1. [Step]
+2. [Step]
+3. [Step]
+
+## C. Mechanical work I will handle
+- [Refactor/plumbing]
+- [Tests/fixtures]
+
+## Approval gate
+Implementation can start after the user confirms or edits Section A.

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/unknowns-matrix.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/assets/templates/unknowns-matrix.md
@@ -1,0 +1,40 @@
+# Unknowns Matrix: [Task]
+
+## Task map
+- User goal:
+- User starting point / familiarity:
+- Territory to inspect:
+- Constraints already known:
+
+## Known knowns
+| Fact / requirement | Source | Must preserve? |
+|---|---|---:|
+|  |  |  |
+
+## Known unknowns
+| Question | Why it matters | Resolution path | Owner | Needed before implementation? |
+|---|---|---|---|---:|
+|  |  |  |  |  |
+
+## Unknown knowns
+| Tacit criterion | Artifact to reveal it | Feedback needed |
+|---|---|---|
+|  |  |  |
+
+## Unknown unknown candidates
+| Area | Why hidden risk may exist | Discovery method | Severity guess |
+|---|---|---|---|
+| Code/history | Prior failed/reverted attempts may exist | Search PRs/commits/issues |  |
+| Auth/permissions | Invisible security assumptions may exist | Inspect middleware/tests/policies |  |
+| Data model | Legacy rows/migrations may violate assumptions | Inspect migrations/fixtures/prod notes |  |
+| UX/taste | User may know it only when shown | Prototype/mock directions |  |
+| Stakeholders | Reviewers may raise objections late | Buy-in doc / sign-off map |  |
+
+## Highest-blast-radius unknown
+[One sentence]
+
+## Recommended artifact mode
+[blindspot-pass / teach-me-my-unknowns / brainstorm-prototype / mock-before-wire / option-space-brainstorm / one-question-interview / reference-semantics-map / tweakable-plan / implementation-notes / buy-in-doc / merge-readiness-quiz]
+
+## Stop conditions
+- [security/data-loss/migration/API/compliance/billing condition]

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/examples/coding-auth-provider.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/examples/coding-auth-provider.md
@@ -1,0 +1,41 @@
+# Example: Coding — Add an Auth Provider
+
+## User request
+
+```text
+Add a new enterprise SSO provider to our app. I don't know this auth module.
+```
+
+## Skill activation
+
+Mode: `blindspot-pass`, followed by `tweakable-plan`, then `implementation-notes`.
+
+## Unknowns matrix snapshot
+
+| Bucket | Example |
+|---|---|
+| Known knowns | Need a new provider; must integrate with existing auth module |
+| Known unknowns | Provider protocol, callback URL rules, identity-linking behavior |
+| Unknown knowns | Team conventions for provider templates and middleware mounting |
+| Unknown unknowns | Reverted prior attempts, hidden session rules, logout events, auth edge cases |
+
+## First artifact prompt
+
+```text
+I'm adding a new enterprise SSO provider, but I don't know the auth module.
+Do a blindspot pass over services/auth and related tests before implementation.
+Find unknown unknowns, prior failed attempts, hidden middleware/session/identity-linking constraints, and tell me how to prompt you better.
+Do not modify code yet.
+```
+
+## Follow-up plan prompt
+
+```text
+Now write a tweakable implementation plan. Lead with callback URL strategy, identity-linking behavior, session write path, middleware mount point, provider config shape, and rollout flag. Put mechanical tests/refactors below.
+```
+
+## During implementation instruction
+
+```text
+Keep implementation-notes.md. If code contradicts the plan, choose the conservative option if safe, log it under Deviations, and continue. Pause for auth bypass, data loss, migration, public API, billing, or compliance uncertainty.
+```

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/examples/generated-blindspot-starter.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/examples/generated-blindspot-starter.md
@@ -1,0 +1,19 @@
+# Blindspot Pass: Add SSO provider to auth module
+
+Generated: 2026-07-05T09:38:10.055127+00:00
+Domain: coding
+
+## Scope to inspect
+- Paths/docs/links:
+- Search terms:
+- Prior work:
+
+## Blindspots
+| # | Name | Type | Severity | Evidence | Why it bites | Prompt upgrade |
+|---|---|---|---|---|---|---|
+| 1 |  |  |  |  |  |  |
+
+## Better prompt
+```text
+[Rewrite implementation prompt with blindspots folded in.]
+```

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/examples/product-design-dashboard.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/examples/product-design-dashboard.md
@@ -1,0 +1,32 @@
+# Example: Product/Design — Review Queue Dashboard
+
+## User request
+
+```text
+I need a better review queue dashboard, but I have no visual taste and don't know what's possible.
+```
+
+## Skill activation
+
+Mode: `brainstorm-prototype`, optionally followed by `one-question-interview`.
+
+## Unknowns matrix snapshot
+
+| Bucket | Example |
+|---|---|
+| Known knowns | Need a dashboard for review queue items |
+| Known unknowns | Target user, data density, primary action, device context |
+| Unknown knowns | User taste: dense ops console vs calm editorial vs workflow board |
+| Unknown unknowns | Existing queue status semantics, stale item handling, reviewer mental model |
+
+## First artifact prompt
+
+```text
+Create one standalone HTML prototype with 4 wildly different dashboard directions using the same fake review queue data. Make each design philosophy obvious. Under each direction, include steal/skip notes and open questions. End with a reaction template I can paste back.
+```
+
+## Follow-up interview prompt
+
+```text
+Interview me one question at a time about the remaining dashboard ambiguity. Prioritize questions where my answer changes information architecture or data model.
+```

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/examples/research-project.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/examples/research-project.md
@@ -1,0 +1,32 @@
+# Example: Research — New Domain Literature Review
+
+## User request
+
+```text
+Help me research pay-per-crawl economics. I don't know what I don't know.
+```
+
+## Skill activation
+
+Mode: `teach-me-my-unknowns`, followed by `option-space-brainstorm` and `one-question-interview`.
+
+## Unknowns matrix snapshot
+
+| Bucket | Example |
+|---|---|
+| Known knowns | Need a research overview of pay-per-crawl economics |
+| Known unknowns | Stakeholders, scope, time horizon, output format |
+| Unknown knowns | Desired depth and policy stance may emerge only after seeing frames |
+| Unknown unknowns | Terminology, current proposals, technical enforcement, legal issues, incentives |
+
+## First artifact prompt
+
+```text
+Teach me the domain vocabulary for pay-per-crawl economics well enough that I can ask better research questions. Include the mental model, stakeholder map, essential terms, common misconceptions, and 5 precise research prompts I could use next.
+```
+
+## Option-space prompt
+
+```text
+Brainstorm 10 research angles from fastest desk research to most ambitious original analysis. For each, list data sources, likely unknowns, and what decision it would inform.
+```

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/references/ARTICLE_DIGEST.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/references/ARTICLE_DIGEST.md
@@ -1,0 +1,135 @@
+## Central thesis
+
+Working with strong agentic models makes an old distinction practical: **the map is not the territory**.
+
+- **Map:** prompts, skills, context, specs, artifacts, and the representation of work supplied to the model.
+- **Territory:** the real codebase, production system, real-world constraints, prior work, design taste, and actual implementation environment.
+- **Unknowns:** the gap between the map and the territory. Whenever the agent hits an unknown, it guesses what the user wants.
+
+As models become better, quality becomes bottlenecked less by raw model capability and more by the user’s ability to clarify unknowns. Planning helps, but planning is not enough because new unknowns can appear deep in implementation or reveal that the original problem framing was wrong.
+
+## Unknowns taxonomy
+
+| Category | Extracted meaning | How to reduce it |
+|---|---|---|
+| Known knowns | What the user has explicitly put in the prompt | Preserve, restate, and test against it |
+| Known unknowns | Things the user knows they have not figured out | Ask, research, or parameterize |
+| Unknown knowns | Things too obvious for the user to write down, but recognizable when seen | Brainstorm, prototype, mock, compare, and get reactions |
+| Unknown unknowns | Things the user has not considered at all; missing knowledge or quality standards | Blindspot passes, codebase search, internet/domain research, references, expert-like explainers |
+
+## Operating stance: help the agent help you
+
+The article frames prompting as a balance:
+
+- If too specific, the agent may follow instructions even when a pivot would be better.
+- If too vague, the agent fills gaps with generic best practices that may not fit the task.
+- The solution is to give the agent context about the user’s starting point: experience level, familiarity with the codebase/domain, current thinking, and where help is needed.
+
+The agent should be treated as a thought partner that can search code, search the internet, iterate quickly, and teach missing vocabulary.
+
+## Pre-implementation patterns
+
+### 1. Blind spot pass
+
+Use when entering a new code area, unfamiliar work, or a domain where the user may not know what questions to ask.
+
+Goal: ask the agent to uncover **unknown unknowns**, explain them, and help the user prompt better.
+
+Useful outputs:
+
+- hidden constraints and potholes
+- historical work or prior attempts
+- quality standards the user may not know
+- questions the user did not know to ask
+- a rewritten prompt that incorporates the discoveries
+
+### 2. Brainstorms and prototypes
+
+Use when the user has many **unknown knowns**: criteria they cannot articulate but can recognize when shown.
+
+Goal: make taste, scope, and implementation-shaping preferences visible before real implementation makes them expensive to change.
+
+Typical moves:
+
+- create several divergent design directions
+- mock UI with fake data before wiring real routes/state/backend
+- search the codebase and brainstorm possible interventions from cheap to ambitious
+- use HTML artifacts when visualization helps
+
+### 3. Interviews
+
+Use after brainstorming when unknowns remain.
+
+Goal: have the agent interview the user one question at a time, prioritizing questions whose answers would materially change architecture, implementation, product scope, or UX.
+
+### 4. References
+
+Use when describing the desired result in language would be lossy or inefficient.
+
+Goal: point the agent at a reference implementation, design component, module, library, website section, diagram, or documentation and ask it to understand the semantics before adapting or porting.
+
+The article stresses that source code is often the best reference because it contains richer structure, behavior, and edge cases than a screenshot or prose description.
+
+### 5. Implementation plans
+
+Use when ready to implement.
+
+Goal: ask for an implementation plan that leads with the parts the human is likely to tweak, such as data models, type interfaces, UX flows, or user-facing behavior. Mechanical refactoring can be buried below if the agent can handle it.
+
+## During implementation pattern
+
+### Implementation notes
+
+Planning cannot remove every unknown. The agent may discover edge cases and constraints while building.
+
+Goal: maintain a temporary `implementation-notes.md` or `.html` that records decisions and deviations during the run.
+
+Useful log fields:
+
+- what the plan said
+- what the code revealed
+- conservative choice made
+- why it was safe to continue
+- what to revisit next time
+
+## Post-implementation patterns
+
+### Pitches and explainers
+
+Use after the work exists and needs approval.
+
+Goal: package prototypes, specs, and implementation notes into a doc that accelerates reviewer understanding and approvals. The best doc leads with the demo and pre-answers objections experts are likely to raise.
+
+### Quizzes
+
+Use after long agent sessions where the model may have done more than the human realizes.
+
+Goal: generate an explanatory report and quiz so the human can verify they understand the changes before merge. The article’s standard is to merge only after passing the quiz perfectly.
+
+## End-to-end example extracted from the article
+
+The article describes launching a Fable video edited by an agentic coding tool. The process followed the unknowns loop:
+
+1. Start from knowns: code can edit/transcribe videos, but accuracy is uncertain.
+2. Ask the agent to explain transcription/Whisper and whether cuts like pauses or filler words can be handled with ffmpeg.
+3. Prototype timed UI with Remotion and a transcription to see if the concept works.
+4. Encounter visual quality unknowns around color grading.
+5. First try variations, then realize the deeper unknown is not knowing what good color grading looks like.
+6. Ask the agent to teach color grading vocabulary and quality standards.
+
+## Skill design implications
+
+This package turns the article into an agent skill by making each article pattern operational:
+
+- Article idea: “blindspot pass” → Skill mode with cards, severity, evidence, prompt upgrades.
+- Article idea: prototypes reveal unknown knowns → Skill mode with divergent directions and reaction templates.
+- Article idea: interview after brainstorming → Skill mode that asks one question at a time by blast radius.
+- Article idea: references beat descriptions → Skill mode that requires a semantics map before implementation.
+- Article idea: plans should expose likely changes → Skill mode that sorts plans by human-tweak likelihood.
+- Article idea: unknowns appear during implementation → Skill mode for implementation notes and deviation logs.
+- Article idea: shipping needs buy-in → Skill mode for pitch/explainer docs.
+- Article idea: quiz before merge → Skill mode for merge-readiness reports and quizzes.
+
+## Practical maxim
+
+Every explainer, brainstorm, interview, prototype, reference, implementation note, pitch, and quiz is a cheap way to discover what was missing before that missing context becomes expensive to fix.

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/references/EVALUATION.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/references/EVALUATION.md
@@ -1,0 +1,100 @@
+# Evaluation Guide
+
+## Selection evals
+
+| User request | Should activate? | Expected mode |
+|---|---:|---|
+| “Add a new OAuth provider; I’ve never touched auth here. What am I missing?” | Yes | blindspot-pass |
+| “Make this dashboard look better; I don’t know what style I want.” | Yes | brainstorm-prototype |
+| “Before coding, ask me architecture-changing questions one by one.” | Yes | one-question-interview |
+| “Port this Rust retry behavior into TypeScript, but prove you understand it first.” | Yes | reference-semantics-map |
+| “Keep a log if implementation diverges from the plan.” | Yes | implementation-notes |
+| “Summarize this tiny typo fix.” | No | none |
+| “Rename variable `foo` to `bar`.” | No | none |
+| “Quiz me before I merge this 14-file diff.” | Yes | merge-readiness-quiz |
+
+## Quality rubric
+
+Score 0–3 for each dimension.
+
+### Unknown discovery
+- 0: Repeats the request.
+- 1: Lists generic risks.
+- 2: Finds task-specific unknowns.
+- 3: Finds territory-grounded unknowns with evidence and failure modes.
+
+### Blast-radius prioritization
+- 0: No prioritization.
+- 1: Convenience-based order.
+- 2: Identifies high-risk items.
+- 3: Orders by what would change architecture, UX, data, permissions, rollout, or cost.
+
+### Artifact usefulness
+- 0: Prose only.
+- 1: List without decision support.
+- 2: Structured artifact with decisions.
+- 3: Directly reusable artifact with prompt upgrades and gates.
+
+### Autonomy calibration
+- 0: Blocks unnecessarily or guesses dangerously.
+- 1: Asks too many questions at once.
+- 2: Reasonable ask/proceed behavior.
+- 3: Proceeds conservatively on reversible unknowns and pauses only on high-impact ones.
+
+### Carry-forward discipline
+- 0: Discoveries not reused.
+- 1: Summarized but not actionable.
+- 2: Updates prompt or plan.
+- 3: Becomes implementation prompt, tests, notes, reviewer docs, or quiz.
+
+## Regression tests
+
+### Test A: Blindspot pass should not implement
+
+Prompt:
+
+```text
+I need to add a new SSO provider in an unfamiliar auth module. Do a blindspot pass first.
+```
+
+Pass: agent surfaces unknown unknowns and ends with improved prompt; it does not modify code.
+
+### Test B: Interview should ask one question
+
+Prompt:
+
+```text
+Interview me about this ambiguous export feature. Prioritize architecture-changing questions.
+```
+
+Pass: agent asks exactly one current question, explains why it matters, and maintains a decision table.
+
+### Test C: Tweakable plan should lead with decisions
+
+Prompt:
+
+```text
+Write the plan, but show me the parts I’m likely to tweak first.
+```
+
+Pass: plan starts with data model/interface/UX/security/rollout decisions, not mechanical steps.
+
+### Test D: Implementation notes should choose conservative options
+
+Prompt:
+
+```text
+Implement from this plan and keep notes. If a low-risk edge case appears, choose conservatively and log it.
+```
+
+Pass: deviations are logged with plan said / code revealed / conservative choice / revisit; dangerous unknowns pause.
+
+### Test E: Quiz must test real understanding
+
+Prompt:
+
+```text
+Give me a report and quiz before I merge this feature.
+```
+
+Pass: quiz tests operational and architectural understanding, not trivia.

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/references/OUTPUT_SCHEMAS.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/references/OUTPUT_SCHEMAS.md
@@ -1,0 +1,144 @@
+# Output Schemas
+
+## Unknowns matrix
+
+```markdown
+# Unknowns Matrix: [Task]
+
+## Known knowns
+- [Explicit fact/requirement]
+
+## Known unknowns
+| Question | Why it matters | Resolution path | Owner |
+|---|---|---|---|
+
+## Unknown knowns
+| Tacit criterion | Artifact to reveal it | Feedback needed |
+|---|---|---|
+
+## Unknown unknown candidates
+| Area | Why hidden risk may exist | Discovery method |
+|---|---|---|
+
+## Highest-blast-radius unknown
+[One sentence]
+
+## Recommended artifact mode
+[blindspot-pass / prototype / interview / etc.]
+```
+
+## Blindspot card
+
+```markdown
+## Blindspot [n]: [Name]
+- Type: [landmine / convention / prior failed attempt / missing concept / hidden dependency]
+- Severity: [low / medium / high / critical]
+- Evidence inspected: [files/docs/commits/tests]
+- Map assumption: [what the prompt implied]
+- Territory revealed: [constraint]
+- Why it bites: [failure mode]
+- Conservative instruction: [what to do if proceeding]
+- Prompt upgrade sentence: [copyable sentence]
+- Stop condition: [when to pause]
+```
+
+## Tweakable plan
+
+```markdown
+# Tweakable Plan: [Task]
+
+## Summary
+- Effort:
+- Files touched:
+- Risk:
+- Migration/API/user-facing changes:
+
+## A. Decisions you may want to change
+| Decision | Default | Alternative | Tradeoff | One-line override |
+|---|---|---|---|---|
+
+## B. Execution order
+1. [step]
+2. [step]
+
+## C. Mechanical work I will handle
+- [refactor/plumbing]
+
+## Approval gate
+[What the user must approve before implementation]
+```
+
+## Implementation notes
+
+```markdown
+# Implementation Notes: [Task]
+
+## Summary counters
+- Entries:
+- Deviations:
+- Needs human judgment:
+
+## Log
+
+### [time] Plan-confirmed: [Step]
+[What matched the plan]
+
+### [time] Deviation: [Name]
+- What the plan said:
+- What the code revealed:
+- Conservative choice:
+- Revisit:
+
+## Fold back into next attempt
+1. [learning]
+```
+
+## Buy-in doc
+
+```markdown
+# Ship Proposal: [Feature]
+
+## Demo / result
+[Lead with demo, screenshot, GIF, or crisp description]
+
+## Ask
+[Who should approve what by when]
+
+## Reviewer objections answered
+| Objection | Answer | Evidence |
+|---|---|---|
+
+## Rollout and rollback
+- Rollout:
+- Metrics:
+- Rollback:
+
+## Sign-offs
+| Person/team | What they approve | Status |
+|---|---|---|
+```
+
+## Merge-readiness report and quiz
+
+```markdown
+# Merge Readiness: [Change]
+
+## Mental model
+[Before -> after]
+
+## What changed
+| Area | Change | Why |
+|---|---|---|
+
+## Non-obvious behaviors
+1. [behavior]
+
+## Quiz
+1. [question]
+   - Correct answer:
+   - Why it matters:
+   - Reread if missed:
+
+## Pass criteria
+[Example: all correct before merge]
+```

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/references/PROMPT_PATTERNS.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/references/PROMPT_PATTERNS.md
@@ -1,0 +1,128 @@
+# Prompt Patterns
+
+Copy these cards and replace bracketed placeholders.
+
+## Blindspot pass
+
+```text
+I'm working on [task] in [codebase/domain], and my familiarity is [none/some/high].
+Before implementation, do a blindspot pass:
+- inspect [paths/docs/references]
+- find relevant unknown unknowns, potholes, prior work, missing concepts, and hidden constraints
+- explain why each matters and how it could change the plan
+- help me prompt you better
+- finish with one improved implementation prompt
+Do not change production code yet.
+```
+
+## Teach me my unknowns
+
+```text
+I need to do [domain task], but I don't know the domain vocabulary or what good looks like.
+Teach me enough to prompt like a competent practitioner:
+- mental model
+- essential vocabulary
+- naive phrasing versus precise phrasing
+- common mistakes and quality checks
+- 3-5 improved prompts I can use next
+```
+
+## Brainstorm/prototype directions
+
+```text
+I want [artifact/product/UX/design], but I can't describe the style yet and need to react to options.
+Create [3-5] wildly different directions using the same sample data/context:
+- name each direction by its philosophy
+- make the differences obvious
+- include what to steal/skip/reject from each
+- surface implementation-shaping questions
+- produce a concise reply template from my reactions
+```
+
+## Mock before wire
+
+```text
+Before wiring anything real, create a throwaway [HTML/Markdown/demo/spec] mock of [feature/flow] using fake data.
+I want to react to layout and product choices before you touch [real app/API/database/state].
+Mark every fake assumption clearly, list open decisions, and end with the real wiring plan.
+```
+
+## Option-space brainstorm
+
+```text
+Here's my rough problem: [problem].
+Search/inspect [codebase/docs/context] and brainstorm [8-12] places we could intervene, from cheapest to most ambitious.
+For each option include the existing leverage point, expected impact, effort, risk, reversibility, and the unknown that could change the decision.
+I'll tell you which options resonate before we implement.
+```
+
+## One-question interview
+
+```text
+Interview me one question at a time about anything still ambiguous in [task/feature].
+Prioritize questions where my answer would change architecture, data model, permissions, UX, rollout, or risk.
+For each question, explain why it matters and what changes based on my answer.
+Maintain a decisions table and stop when remaining unknowns are low-risk.
+```
+
+## Reference semantics map
+
+```text
+[Reference path/link] implements the behavior/design I want for [target].
+Read the reference and create a semantics map before implementation:
+- what the reference actually does
+- which parts translate directly
+- which parts cannot be literal and why
+- edge cases, invariants, and tests to preserve
+- open choices I need to approve
+Do not implement until I confirm the map.
+```
+
+## Tweakable plan
+
+```text
+Write an implementation plan for [task], but lead with the decisions I'm most likely to tweak:
+- data model/schema
+- type interfaces or public API
+- UX/user-facing behavior/copy
+- permissions/security/compliance
+- rollout and rollback
+For each decision, show your default, an alternative, the tradeoff, and a one-line instruction I can send to change it.
+Put execution order after those decisions. Put mechanical refactors at the bottom.
+```
+
+## Implementation notes
+
+```text
+Keep an implementation-notes.md file as you build [task].
+If you hit an edge case that forces you to deviate from the plan:
+- pick the conservative option if it is reversible and safe
+- log it under Deviations with plan said / code revealed / conservative choice / revisit
+- keep going only if it does not affect security, data loss, migrations, public API, billing, or compliance
+- pause and ask me if it does
+At the end, add bullets to fold into the next attempt.
+```
+
+## Buy-in doc
+
+```text
+Package [prototype/spec/implementation notes/tests] into a single buy-in doc I can send to [reviewers/channel].
+Lead with the demo/result.
+Then include the ask, why this matters, objections reviewers will raise, evidence, spec/architecture at a glance, risks, rollout, rollback, and exactly who needs to approve what.
+```
+
+## Merge-readiness quiz
+
+```text
+I want to make sure I understand everything that changed in [branch/diff/feature] before I merge.
+Create a merge-readiness report with context, intuition, what was done, non-obvious behaviors, inherited assumptions, operational risks, rollback notes, and a quiz I must pass perfectly.
+Wrong answers should point me back to the section I need to reread.
+```
+
+## Proceed with assumptions
+
+```text
+Proceed with [task] using conservative assumptions.
+Before implementation, list assumptions as ASSUMED, mark which ones are reversible, and identify stop conditions.
+If you encounter a security/data-loss/migration/public-API/billing/compliance unknown, pause. Otherwise log deviations and continue.
+```

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/references/SOURCE_INDEX.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/references/SOURCE_INDEX.md
@@ -1,0 +1,45 @@
+# Source Index
+
+## Primary source used for extraction
+
+- Full article text supplied by the user in this chat on 2026-07-05.
+- Original URL provided by the user: `https://x.com/trq212/status/2073100352921215386`
+- Title from the supplied text/context: **A Field Guide to Fable: Finding Your Unknowns**
+- Author/account from the supplied URL/context: Thariq (`@trq212`)
+
+The package does not reproduce the article verbatim. It converts the article into a reusable agent skill.
+
+## Public companion examples
+
+- Companion index: `https://thariqs.github.io/html-effectiveness/unknowns/`
+- The companion site presents eleven HTML artifacts across pre-implementation, during-implementation, and post-implementation unknown discovery patterns.
+
+## Companion examples mapped to this skill
+
+| Companion example | URL | Skill mode |
+|---|---|---|
+| Blindspot pass | `https://thariqs.github.io/html-effectiveness/unknowns/01-blindspot-pass.html` | `blindspot-pass` |
+| Teach me my unknowns | `https://thariqs.github.io/html-effectiveness/unknowns/02-color-grading-explainer.html` | `teach-me-my-unknowns` |
+| Four design directions | `https://thariqs.github.io/html-effectiveness/unknowns/03-design-directions.html` | `brainstorm-prototype` |
+| Mock before you wire | `https://thariqs.github.io/html-effectiveness/unknowns/04-toolbar-mock.html` | `mock-before-wire` |
+| Brainstorm the intervention | `https://thariqs.github.io/html-effectiveness/unknowns/05-churn-brainstorm.html` | `option-space-brainstorm` |
+| The interview | `https://thariqs.github.io/html-effectiveness/unknowns/06-interview.html` | `one-question-interview` |
+| Point at a reference | `https://thariqs.github.io/html-effectiveness/unknowns/07-reference-port.html` | `reference-semantics-map` |
+| The tweakable plan | `https://thariqs.github.io/html-effectiveness/unknowns/08-implementation-plan.html` | `tweakable-plan` |
+| Implementation notes | `https://thariqs.github.io/html-effectiveness/unknowns/09-implementation-notes.html` | `implementation-notes` |
+| The buy-in doc | `https://thariqs.github.io/html-effectiveness/unknowns/10-pitch-doc.html` | `buy-in-doc` |
+| Quiz me before I merge | `https://thariqs.github.io/html-effectiveness/unknowns/11-change-quiz.html` | `merge-readiness-quiz` |
+
+## Agent Skill format references
+
+- Open Agent Skills specification: `https://agentskills.io/specification`
+- OpenAI Codex Agent Skills docs: `https://developers.openai.com/codex/skills`
+- Anthropic Agent Skills overview: `https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview`
+- Anthropic Skill authoring best practices: `https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices`
+
+## Transformation notes
+
+- The article’s conceptual flow became the skill’s activation rules and artifact selector.
+- The article’s prompts became generalized prompt cards.
+- The companion examples became named skill modes.
+- The output schemas and validation scripts were added to make the skill operational in agent runtimes.

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/references/TRACEABILITY.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/references/TRACEABILITY.md
@@ -1,0 +1,32 @@
+# Article-to-Skill Traceability
+
+This file maps the supplied article sections to the package components that implement them.
+
+| Supplied article section / idea | Skill implementation |
+|---|---|
+| “The map is not the territory” | `SKILL.md` core idea and `ARTICLE_DIGEST.md` central thesis |
+| Unknowns as the gap between prompt/context and real work | `SKILL.md` core loop; `assets/templates/unknowns-matrix.md` |
+| Known knowns, known unknowns, unknown knowns, unknown unknowns | `SKILL.md` unknown types table; `OUTPUT_SCHEMAS.md` unknowns matrix |
+| Balance between too-specific and too-vague instructions | `SKILL.md` autonomy rules; `PROMPT_PATTERNS.md` proceed-with-assumptions card |
+| Give the agent context about your starting point | `WORKFLOWS.md` common setup; all templates include user starting point/scope |
+| Blind Spot Pass | `blindspot-pass` mode; `assets/templates/blindspot-pass.md`; `examples/coding-auth-provider.md` |
+| Teach domain unknowns, e.g. color grading | `teach-me-my-unknowns` mode; `assets/templates/domain-vocabulary-ladder.md` |
+| Brainstorms and prototypes for unknown knowns | `brainstorm-prototype` mode; `assets/templates/brainstorm-prototype.md`; `examples/product-design-dashboard.md` |
+| Mock before wiring backend/app state | `mock-before-wire` mode; prompt card and workflow gate |
+| Search codebase and brainstorm interventions | `option-space-brainstorm` mode; prompt card and workflow |
+| Interviews one question at a time | `one-question-interview` mode; `assets/templates/one-question-interview.md` |
+| References, especially source code, as best descriptions | `reference-semantics-map` mode; `assets/templates/reference-semantics-map.md` |
+| Implementation plans focused on tweakable decisions | `tweakable-plan` mode; `assets/templates/tweakable-plan.md` |
+| Implementation notes during work | `implementation-notes` mode; `assets/templates/implementation-notes.md` |
+| Pitches and explainers for buy-in | `buy-in-doc` mode; `assets/templates/buy-in-doc.md` |
+| Quizzes before merge | `merge-readiness-quiz` mode; `assets/templates/merge-readiness-quiz.md` |
+| Fable launch video as end-to-end example | `ARTICLE_DIGEST.md` end-to-end example extracted from the article |
+| “Every explainer, brainstorm, interview, prototype, and reference is cheap” | `SKILL.md` core loop and default output contract |
+
+## Design choices made while packaging
+
+- The article is transformed into an operational skill rather than copied verbatim.
+- `SKILL.md` is kept as the routing layer; detailed procedures live in `references/`.
+- Reusable work products live in `assets/templates/`.
+- Example applications demonstrate the same patterns in coding, design, and research.
+- Optional scripts are deterministic only; they scaffold artifacts and validate package structure but do not call external services.

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/references/WORKFLOWS.md
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/references/WORKFLOWS.md
@@ -1,0 +1,167 @@
+# Workflows
+
+Use these procedures after `SKILL.md` selects a mode. Keep outputs concrete. The goal is not to write essays; it is to make hidden decisions visible early.
+
+## Common setup
+
+1. Restate the task in one sentence.
+2. List user starting point: experience, familiarity, confidence, known context.
+3. List the territory to inspect: code paths, docs, data, examples, screenshots, references, internet sources, prior work.
+4. Fill a minimal unknowns matrix.
+5. Identify the highest-blast-radius unknown.
+6. Choose the cheapest artifact that can reveal it.
+7. End with either a prompt upgrade, a decision request, or a gated implementation plan.
+
+## Mode: blindspot-pass
+
+**Use when:** Starting unfamiliar work, especially codebase areas, design domains, auth/payments/data, or any task where the user might not know the questions to ask.
+
+**Procedure:**
+
+1. Inspect the named territory before planning implementation.
+2. Search for hidden constraints: prior attempts, tests, feature flags, conventions, migrations, auth/permission paths, data assumptions, stakeholder rules, and quality standards.
+3. Produce blindspot cards with evidence and failure modes.
+4. Explain how each blindspot changes the prompt.
+5. Assemble one improved implementation prompt.
+
+**Gate:** Do not implement until high-severity blindspots are resolved or explicitly accepted.
+
+## Mode: teach-me-my-unknowns
+
+**Use when:** The user lacks vocabulary or does not know what good looks like.
+
+**Procedure:**
+
+1. Teach the minimum useful mental model.
+2. Define essential vocabulary.
+3. Show naive wording vs precise wording.
+4. Explain common mistakes and quality checks.
+5. End with improved prompts the user could not have written before.
+
+**Gate:** Proceed only after the user can choose or accept vocabulary/style/quality defaults.
+
+## Mode: brainstorm-prototype
+
+**Use when:** User criteria are tacit and visual/product/UX/design choices may reshape implementation.
+
+**Procedure:**
+
+1. Hold the core data/scenario constant.
+2. Create several deliberately different directions.
+3. Label the philosophy of each direction.
+4. Include what to steal, skip, or reject.
+5. Expose implementation-shaping decisions.
+6. Provide a reaction template that turns feedback into a prompt.
+
+**Gate:** Do not wire real app/backend/state until the user reacts or accepts assumptions.
+
+## Mode: mock-before-wire
+
+**Use when:** The user needs to see UI or workflow before touching real code.
+
+**Procedure:**
+
+1. Create a throwaway mock, usually standalone HTML or Markdown.
+2. Use fake data and clearly label it.
+3. Include key states and open layout/product questions.
+4. End with the real wiring plan once approved.
+
+**Gate:** Treat the mock as disposable; do not let prototype code leak into production without a deliberate plan.
+
+## Mode: option-space-brainstorm
+
+**Use when:** The problem framing may be too narrow or too broad.
+
+**Procedure:**
+
+1. Search the territory for possible leverage points.
+2. Produce options from cheapest to most ambitious.
+3. For each option, include effort, impact, risk, reversibility, and unknowns.
+4. Ask which options resonate before implementing.
+
+**Gate:** Do not treat the first idea as the plan until the option space is visible.
+
+## Mode: one-question-interview
+
+**Use when:** Ambiguity remains after exploration.
+
+**Procedure:**
+
+1. Internally rank questions by whether the answer changes architecture, UX, data model, permissions, scope, or rollout.
+2. Ask only the top question.
+3. Explain why it matters and what changes based on each answer.
+4. Record the decision.
+5. Ask the next question only after the user answers.
+
+**Gate:** Do not dump a long questionnaire unless the user explicitly asks for one.
+
+## Mode: reference-semantics-map
+
+**Use when:** The desired behavior is better represented by code, component, screenshot, library, or document than by a verbal description.
+
+**Procedure:**
+
+1. Read the reference first.
+2. Extract semantics, not syntax.
+3. Map direct translations and non-literal translations.
+4. Identify edge cases, invariants, tests, and behavior boundaries.
+5. Ask for approval on material differences before implementation.
+
+**Gate:** No port/adaptation until the agent can prove it understood the reference.
+
+## Mode: tweakable-plan
+
+**Use when:** Implementation is close but plan review should surface things the human may alter.
+
+**Procedure:**
+
+1. Sort the plan by likelihood of human tweak, not execution order.
+2. Lead with data model, type interfaces, public API, UX flow, user-facing copy, permissions, rollout, and rollback.
+3. For each tweakable choice, give default, alternative, tradeoff, and one-line override.
+4. Put execution order next.
+5. Collapse mechanical refactors at the bottom.
+
+**Gate:** Start implementation after high-tweak decisions are approved or intentionally assumed.
+
+## Mode: implementation-notes
+
+**Use when:** Implementation is underway and the agent may discover hidden constraints.
+
+**Procedure:**
+
+1. Create/update `implementation-notes.md` or `.html`.
+2. Log plan-confirmed progress briefly.
+3. For deviations, record: plan said / code revealed / conservative choice / revisit.
+4. Continue only for safe reversible deviations.
+5. Pause for security, data loss, migration, public API, billing, or compliance deviations.
+6. End with “fold back into next attempt” bullets.
+
+## Mode: buy-in-doc
+
+**Use when:** The work needs review, approval, alignment, or rollout support.
+
+**Procedure:**
+
+1. Lead with demo/result.
+2. State the ask.
+3. Explain why the work matters.
+4. Pre-answer likely reviewer objections with evidence.
+5. Include spec/architecture at a glance.
+6. Name risk, rollout, rollback, metrics, and signoffs.
+
+**Gate:** A buy-in doc is incomplete if it does not say who needs to approve what.
+
+## Mode: merge-readiness-quiz
+
+**Use when:** The human needs to understand complex agent work before merge/release.
+
+**Procedure:**
+
+1. Explain the mental model before and after.
+2. Summarize what changed and why.
+3. Highlight non-obvious behavior and inherited assumptions.
+4. Include operational risks and rollback.
+5. Write a quiz that tests actual understanding, not trivia.
+6. Include pass criteria and reread sections for wrong answers.
+
+**Gate:** Merge only after the user passes the quiz or explicitly waives the gate.

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/scripts/make_unknowns_artifact.py
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/scripts/make_unknowns_artifact.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Generate a starter Unknowns Discovery artifact.
+
+This helper is deterministic. It does not call an AI model; it creates a Markdown
+scaffold that an agent or human can fill in.
+"""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+
+MODES = [
+    "unknowns-matrix",
+    "blindspot-pass",
+    "teach-me-my-unknowns",
+    "brainstorm-prototype",
+    "mock-before-wire",
+    "option-space-brainstorm",
+    "one-question-interview",
+    "reference-semantics-map",
+    "tweakable-plan",
+    "implementation-notes",
+    "buy-in-doc",
+    "merge-readiness-quiz",
+]
+
+
+def slug(text: str) -> str:
+    out, prev_dash = [], False
+    for ch in text.lower():
+        if ch.isalnum():
+            out.append(ch); prev_dash = False
+        elif not prev_dash:
+            out.append("-"); prev_dash = True
+    return "".join(out).strip("-") or "task"
+
+
+def header(task: str, mode: str, domain: str) -> str:
+    return f"# {mode.replace('-', ' ').title()}: {task}\n\nGenerated: {datetime.now(timezone.utc).isoformat()}\nDomain: {domain}\n\n"
+
+
+def matrix(task: str, domain: str) -> str:
+    return header(task, "unknowns-matrix", domain) + """## Known knowns
+| Fact / requirement | Source | Must preserve? |
+|---|---|---:|
+| {task} | user request | yes |
+
+## Known unknowns
+| Question | Why it matters | Resolution path | Owner | Needed before implementation? |
+|---|---|---|---|---:|
+| What constraints are not in the prompt? | May change approach | blindspot pass / inspect territory | agent | yes |
+
+## Unknown knowns
+| Tacit criterion | How to make it visible | Artifact |
+|---|---|---|
+| What the user will recognize as good | show alternatives | prototype/mock/plan |
+
+## Unknown unknown candidates
+| Area | Why hidden risk may exist | Discovery method | Severity guess |
+|---|---|---|---|
+| Code/history/domain prior art | Prior failed attempts or hidden conventions may exist | search files/docs/issues | medium |
+| Data/permissions/stakeholders | Invisible rules may alter implementation | inspect policies/tests/reviewers | high |
+| UX/taste/output shape | User may need to react, not specify | prototype/interview | medium |
+
+## Highest-blast-radius unknown
+[Fill in after inspection.]
+
+## Recommended artifact mode
+[Choose one: {modes}]
+""".format(task=task, modes=", ".join(MODES))
+
+
+def artifact(task: str, mode: str, domain: str) -> str:
+    if mode == "unknowns-matrix":
+        return matrix(task, domain)
+    h = header(task, mode, domain)
+    if mode == "blindspot-pass":
+        return h + """## Scope to inspect
+- Paths/docs/links:
+- Search terms:
+- Prior work:
+
+## Blindspots
+| # | Name | Type | Severity | Evidence | Why it bites | Prompt upgrade |
+|---|---|---|---|---|---|---|
+| 1 |  |  |  |  |  |  |
+
+## Better prompt
+```text
+[Rewrite implementation prompt with blindspots folded in.]
+```
+"""
+    if mode == "teach-me-my-unknowns":
+        return h + """## Mental model
+[Explain the domain.]
+
+## Vocabulary ladder
+| Term | Plain meaning | Why it matters | Prompt phrase |
+|---|---|---|---|
+|  |  |  |  |
+
+## Prompts I can now write
+1. ```text
+   [Improved prompt]
+   ```
+"""
+    if mode in {"brainstorm-prototype", "mock-before-wire"}:
+        return h + """## Shared data/scenario
+[Hold this constant across variants.]
+
+## Directions / mock states
+| Direction/state | Philosophy | What to steal | What to skip | Unknown exposed |
+|---|---|---|---|---|
+| 1 |  |  |  |  |
+| 2 |  |  |  |  |
+| 3 |  |  |  |  |
+
+## Reaction template
+```text
+Chosen direction:
+Steal:
+Skip:
+Change:
+```
+"""
+    if mode == "option-space-brainstorm":
+        return h + """## Option space
+| # | Intervention | Existing leverage point | Effort | Impact | Risk | Unknown |
+|---|---|---|---|---|---|---|
+| 1 |  |  | XS |  |  |  |
+| 2 |  |  | S |  |  |  |
+| 3 |  |  | M |  |  |  |
+| 4 |  |  | L |  |  |  |
+"""
+    if mode == "one-question-interview":
+        return h + """## Current question
+[Ask exactly one question.]
+
+## Why this matters
+[Explain what changes based on the answer.]
+
+## Decisions so far
+| Decision | Answer | Impact |
+|---|---|---|
+|  |  |  |
+"""
+    if mode == "reference-semantics-map":
+        return h + """## Reference inspected
+- Reference:
+- Target:
+
+## Behavior map
+| Behavior | Reference evidence | Target mapping | Test/invariant |
+|---|---|---|---|
+|  |  |  |  |
+"""
+    if mode == "tweakable-plan":
+        return h + """## A. Decisions you may want to change
+| Decision | Default | Alternative | Tradeoff | One-line override |
+|---|---|---|---|---|
+|  |  |  |  |  |
+
+## B. Execution order
+1. 
+2. 
+
+## C. Mechanical work
+- 
+"""
+    if mode == "implementation-notes":
+        return h + """## Summary counters
+- Entries: 0
+- Deviations: 0
+- Needs human judgment: 0
+
+## Log
+### [time] Deviation: [Name]
+- What the plan said:
+- What the code revealed:
+- Conservative choice:
+- Revisit:
+"""
+    if mode == "buy-in-doc":
+        return h + """## Demo / result
+
+## Ask
+
+## Reviewer objections answered
+| Objection | Answer | Evidence |
+|---|---|---|
+|  |  |  |
+
+## Sign-offs
+| Person/team | What they approve | Status |
+|---|---|---|
+|  |  |  |
+"""
+    if mode == "merge-readiness-quiz":
+        return h + """## Mental model
+### Before
+
+### After
+
+## What changed
+| Area | Change | Why |
+|---|---|---|
+|  |  |  |
+
+## Quiz
+### Question 1
+- Correct answer:
+- Why it matters:
+- Reread if missed:
+
+## Pass criteria
+[Define pass criteria.]
+"""
+    raise ValueError(f"Unknown mode: {mode}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate an Unknowns Discovery Markdown artifact scaffold.")
+    parser.add_argument("--task", required=True, help="Task name or short description")
+    parser.add_argument("--mode", choices=MODES, default="unknowns-matrix")
+    parser.add_argument("--domain", default="general")
+    parser.add_argument("--out", help="Output file path. Defaults to ./<mode>-<task>.md")
+    args = parser.parse_args()
+    out = Path(args.out) if args.out else Path(f"{args.mode}-{slug(args.task)}.md")
+    out.write_text(artifact(args.task, args.mode, args.domain), encoding="utf-8")
+    print(out)
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/unknowns-discovery/skills/unknowns-discovery/scripts/validate_skill.py
+++ b/plugins/unknowns-discovery/skills/unknowns-discovery/scripts/validate_skill.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Validate the basic structure of an Agent Skill directory."""
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    if not text.startswith("---\n"):
+        raise ValueError("SKILL.md must start with YAML frontmatter delimited by ---")
+    end = text.find("\n---", 4)
+    if end == -1:
+        raise ValueError("SKILL.md frontmatter is missing closing ---")
+    raw = text[4:end].strip().splitlines()
+    body = text[end + len("\n---"):]
+    data: dict[str, str] = {}
+    current_key: str | None = None
+    for line in raw:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if not line.startswith(" ") and ":" in line:
+            key, value = line.split(":", 1)
+            current_key = key.strip()
+            data[current_key] = value.strip().strip('"')
+        elif current_key:
+            continue
+    return data, body
+
+
+def validate(skill_dir: Path) -> list[str]:
+    errors: list[str] = []
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        return [f"Missing {skill_md}"]
+    text = skill_md.read_text(encoding="utf-8")
+    try:
+        meta, body = parse_frontmatter(text)
+    except ValueError as exc:
+        return [str(exc)]
+    name = meta.get("name", "")
+    desc = meta.get("description", "")
+    if not name:
+        errors.append("frontmatter.name is required")
+    elif not NAME_RE.match(name):
+        errors.append("frontmatter.name must use lowercase letters, numbers, and single hyphens")
+    elif name != skill_dir.name:
+        errors.append(f"frontmatter.name ({name}) should match parent directory ({skill_dir.name})")
+    if not desc:
+        errors.append("frontmatter.description is required")
+    elif len(desc) > 1024:
+        errors.append(f"frontmatter.description is too long ({len(desc)} > 1024)")
+    if len(body.splitlines()) > 500:
+        errors.append("SKILL.md body should stay under 500 lines for progressive disclosure")
+    for link in LINK_RE.findall(body):
+        if "://" in link or link.startswith("#") or link.startswith("mailto:"):
+            continue
+        target = (skill_dir / link).resolve()
+        try:
+            target.relative_to(skill_dir.resolve())
+        except ValueError:
+            errors.append(f"local link escapes skill directory: {link}")
+            continue
+        if not target.exists():
+            errors.append(f"broken local link in SKILL.md: {link}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate a basic Agent Skill directory.")
+    parser.add_argument("skill_dir", type=Path)
+    args = parser.parse_args()
+    errors = validate(args.skill_dir)
+    if errors:
+        print("Skill validation failed:")
+        for err in errors:
+            print(f"- {err}")
+        return 1
+    print("Skill validation passed")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/vitest-testing/.claude-plugin/plugin.json
+++ b/plugins/vitest-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vitest-testing",
   "description": "Modern TypeScript/JavaScript testing with Vitest. Fast unit and integration tests, native ESM support, Vite-powered HMR, and comprehensive mocking. Use for testing TS/JS projects.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/vitest-testing/.codex-plugin/plugin.json
+++ b/plugins/vitest-testing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-testing",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Modern TypeScript/JavaScript testing with Vitest. Fast unit and integration tests, native ESM support, Vite-powered HMR, and comprehensive mocking. Use for testing TS/JS projects.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/vulnerability-scanning/.claude-plugin/plugin.json
+++ b/plugins/vulnerability-scanning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vulnerability-scanning",
   "description": "Implements automated security scanning for dependencies, code, and containers using tools like Trivy, Snyk, and npm audit. Use when setting up CI/CD security gates, conducting pre-deployment audits, or meeting compliance requirements.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/vulnerability-scanning/.codex-plugin/plugin.json
+++ b/plugins/vulnerability-scanning/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vulnerability-scanning",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Implements automated security scanning for dependencies, code, and containers using tools like Trivy, Snyk, and npm audit. Use when setting up CI/CD security gates, conducting pre-deployment audits, or meeting compliance requirements.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/web-performance-audit/.claude-plugin/plugin.json
+++ b/plugins/web-performance-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "web-performance-audit",
   "description": "Web performance audits with Core Web Vitals, bottleneck identification, optimization recommendations. Use for page load times, performance reviews, UX optimization, or encountering LCP, FID, CLS issues, resource blocking, render delays.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/web-performance-audit/.codex-plugin/plugin.json
+++ b/plugins/web-performance-audit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-performance-audit",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Web performance audits with Core Web Vitals, bottleneck identification, optimization recommendations. Use for page load times, performance reviews, UX optimization, or encountering LCP, FID, CLS issues, resource blocking, render delays.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/web-performance-optimization/.claude-plugin/plugin.json
+++ b/plugins/web-performance-optimization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "web-performance-optimization",
   "description": "Optimizes web application performance through code splitting, lazy loading, caching strategies, and Core Web Vitals monitoring. Use when improving page load times, implementing service workers, or reducing bundle sizes.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/web-performance-optimization/.codex-plugin/plugin.json
+++ b/plugins/web-performance-optimization/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-performance-optimization",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Optimizes web application performance through code splitting, lazy loading, caching strategies, and Core Web Vitals monitoring. Use when improving page load times, implementing service workers, or reducing bundle sizes.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/websocket-implementation/.claude-plugin/plugin.json
+++ b/plugins/websocket-implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "websocket-implementation",
   "description": "Implements real-time WebSocket communication with connection management, room-based messaging, and horizontal scaling. Use when building chat systems, live notifications, collaborative tools, or real-time dashboards.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/websocket-implementation/.codex-plugin/plugin.json
+++ b/plugins/websocket-implementation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "websocket-implementation",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Implements real-time WebSocket communication with connection management, room-based messaging, and horizontal scaling. Use when building chat systems, live notifications, collaborative tools, or real-time dashboards.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/woocommerce-backend-dev/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-backend-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-backend-dev",
   "description": "Add or modify WooCommerce backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code in WooCommerce projects.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-backend-dev/.codex-plugin/plugin.json
+++ b/plugins/woocommerce-backend-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-backend-dev",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Add or modify WooCommerce backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code in WooCommerce projects.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/woocommerce-code-review/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-code-review",
   "description": "Review WooCommerce code changes for coding standards compliance. Use when reviewing code locally, performing automated PR reviews, or checking code quality in WooCommerce projects.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-code-review/.codex-plugin/plugin.json
+++ b/plugins/woocommerce-code-review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-code-review",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Review WooCommerce code changes for coding standards compliance. Use when reviewing code locally, performing automated PR reviews, or checking code quality in WooCommerce projects.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/woocommerce-copy-guidelines/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-copy-guidelines/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-copy-guidelines",
   "description": "Guidelines for UI text and copy in WooCommerce. Use when writing user-facing text, labels, buttons, messages, or documentation in WooCommerce projects.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-copy-guidelines/.codex-plugin/plugin.json
+++ b/plugins/woocommerce-copy-guidelines/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-copy-guidelines",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Guidelines for UI text and copy in WooCommerce. Use when writing user-facing text, labels, buttons, messages, or documentation in WooCommerce projects.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/woocommerce-dev-cycle/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-dev-cycle/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-dev-cycle",
   "description": "Run tests, linting, and quality checks for WooCommerce development. Use when running tests, fixing code style, or following the development workflow in WooCommerce projects.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-dev-cycle/.codex-plugin/plugin.json
+++ b/plugins/woocommerce-dev-cycle/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-dev-cycle",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Run tests, linting, and quality checks for WooCommerce development. Use when running tests, fixing code style, or following the development workflow in WooCommerce projects.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/wordpress-plugin-core/.claude-plugin/plugin.json
+++ b/plugins/wordpress-plugin-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wordpress-plugin-core",
   "description": "WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/wordpress-plugin-core/.codex-plugin/plugin.json
+++ b/plugins/wordpress-plugin-core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wordpress-plugin-core",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/xss-prevention/.claude-plugin/plugin.json
+++ b/plugins/xss-prevention/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xss-prevention",
   "description": "Prevents Cross-Site Scripting attacks through input sanitization, output encoding, and Content Security Policy. Use when handling user-generated content, implementing rich text editors, or securing web applications.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/xss-prevention/.codex-plugin/plugin.json
+++ b/plugins/xss-prevention/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "xss-prevention",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Prevents Cross-Site Scripting attacks through input sanitization, output encoding, and Content Security Policy. Use when handling user-generated content, implementing rich text editors, or securing web applications.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/zod/.claude-plugin/plugin.json
+++ b/plugins/zod/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zod",
   "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies (2kb gzipped).",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/zod/.codex-plugin/plugin.json
+++ b/plugins/zod/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zod",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies (2kb gzipped).",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/zustand-state-management/.claude-plugin/plugin.json
+++ b/plugins/zustand-state-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zustand-state-management",
   "description": "Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loops.",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/zustand-state-management/.codex-plugin/plugin.json
+++ b/plugins/zustand-state-management/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zustand-state-management",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loops.",
   "author": {
     "name": "Claude Skills Maintainers",


### PR DESCRIPTION
## What

Two new plugins on one branch, both held at the global 3.7.0 version.

### 1. `tech-debt` — two-mode router
Routes between two complementary stances on technical debt, picked by one question: *is the user actively making a change right now?*

- **Mode A — Prevent** (from [`jnsahab/zero-tech-debt`](https://github.com/jnsahab/skills/blob/main/skills/zero-tech-debt/SKILL.md)): rework the change in flight toward the intended end state — delete dead compatibility paths instead of preserving them; prefer one clear component over mode flags.
- **Mode B — Triage** (from [`anthropics/tech-debt`](https://github.com/anthropics/knowledge-work-plugins/blob/main/engineering/skills/tech-debt/SKILL.md)): categorize, score, and prioritize existing debt into a remediation plan that runs alongside feature work.

Router lives in `plugins/tech-debt/skills/tech-debt/SKILL.md`; each mode's full steps/rules/examples live in `references/prevent-during-change.md` and `references/triage-backlog.md`.

### 2. `unknowns-discovery` — Claude port from `suedzucker-codex-plugins`
Single router skill that activates on ambiguous/unfamiliar/high-risk work and selects one of 11 artifact modes (blindspot-pass, teach-me-my-unknowns, brainstorm-prototype, mock-before-wire, option-space-brainstorm, one-question-interview, reference-semantics-map, tweakable-plan, implementation-notes, buy-in-doc, merge-readiness-quiz). Each artifact follows a default output contract: scope read → unknowns found → blast radius → conservative default → decision needed → prompt upgrade → stop conditions.

Adapted from the Codex-native original at `suedzucker-codex-plugins/plugins/unknowns-discovery`:
- **SKILL.md** frontmatter `description` trimmed 341 → 150 chars (the repo's `sync-plugins.sh` hard-skips single-skill plugins whose description exceeds 250 chars).
- **3 slash commands** (`/unknowns-discovery:discover-unknowns`, `:blindspot-pass`, `:merge-readiness-quiz`) get `name:` namespacing and drop the Codex `$unknowns-discovery` token; `$ARGUMENTS` and `allowed-tools` kept.
- **README** rewritten for Claude/Codex install; auto-trigger keywords preserved.
- **7 references, 12 templates, 4 examples, 2 scripts** copied verbatim.
- **Codex-only files dropped**: `.codex-plugin/plugin.json` is regenerated by the repo's scripts; `agents/openai.yaml` and `assets/*.svg` have no Claude-side equivalent (Claude Code's plugin format has no icon/brandColor field today; tracked separately if we want Codex card branding later).

## Cross-runtime

Both plugins authored runtime-agnostic. `sync-plugins.sh` / `generate-marketplace.sh` generated `.claude-plugin/plugin.json` + `.codex-plugin/plugin.json` and registered both in `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json`. Claude manifests are source of truth.

## Version

All at **3.7.0** — no further bump. `package.json` was also synced 3.6.3 → 3.7.0 in the unknowns-discovery commit (the bump scripts don't touch `package.json`; this closes a pre-existing drift).

## Verification

- `npm run validate`: **144/144** plugins pass ajv (Claude manifest, Codex manifest, both marketplaces), 0 failed.
- `validate_skill.py`: unknowns-discovery passes (name matches dir, 116-line body < 500, all relative links resolve).
- Generator: 144 processed, **0 skipped** (no description-length skip).
- Pre-push hook re-validated frontmatter for both skills: ✅ tech-debt, ✅ unknowns-discovery.
- Plugin count: 143 → **144**. Marketplace diff is purely additive (+26 lines across the two marketplace files for the unknowns-discovery entry; tech-debt was already on the branch).

## Files

- `tech-debt`: 7 new files (README, SKILL.md, 2 references, 2 manifests) + version stamps from the prior commit.
- `unknowns-discovery`: 32 new files (manifests, README, 3 commands, SKILL.md, 7 references, 12 templates, 4 examples, 2 scripts) + 3 modified (both marketplaces, package.json).