### PR TITLE
fix(scripts): adversarial audit — 15 bugs across generators, validators, review tooling

### DIFF
--- a/scripts/baseline-audit-all.sh
+++ b/scripts/baseline-audit-all.sh
@@ -75,7 +75,9 @@ echo ""
 
 # Process each skill
 for skill in "${SKILLS[@]}"; do
-  ((COMPLETED++))
+  # `((VAR++))` returns exit status 1 when VAR is 0; under `set -e` this would
+  # abort the audit on the first skill (same bug class fixed in review-skill.sh).
+  ((COMPLETED++)) || true
 
   echo -ne "[$COMPLETED/$TOTAL_SKILLS] Checking $skill..."
 
@@ -93,22 +95,22 @@ for skill in "${SKILLS[@]}"; do
   priority="🟢 Low"
 
   if [ "$critical" -gt 0 ]; then
-    ((CRITICAL_SKILLS++))
+    ((CRITICAL_SKILLS++)) || true
     status="CRITICAL"
     priority="🔴 Critical"
     echo -e " ${RED}CRITICAL${NC} (${critical} critical, ${high} high, ${medium} medium)"
   elif [ "$high" -gt 0 ]; then
-    ((HIGH_SKILLS++))
+    ((HIGH_SKILLS++)) || true
     status="HIGH"
     priority="🟡 High"
     echo -e " ${YELLOW}HIGH${NC} (${high} high, ${medium} medium)"
   elif [ "$medium" -gt 0 ]; then
-    ((MEDIUM_SKILLS++))
+    ((MEDIUM_SKILLS++)) || true
     status="MEDIUM"
     priority="🟠 Medium"
     echo -e " ${BLUE}MEDIUM${NC} (${medium} medium, ${low} low)"
   else
-    ((CLEAN_SKILLS++))
+    ((CLEAN_SKILLS++)) || true
     echo -e " ${GREEN}CLEAN${NC}"
   fi
 
@@ -121,7 +123,10 @@ for skill in "${SKILLS[@]}"; do
     notes="$notes NAME_MISMATCH"
   fi
   if echo "$output" | grep -q "Last verified.*days ago"; then
-    days=$(echo "$output" | grep -o "Last verified [0-9]* days ago" | grep -o "[0-9]*")
+    # Default to 0 so a missing/empty match doesn't make `[ "" -gt 90 ]` throw
+    # "integer expression expected" under set -e/u and abort the audit.
+    days=$(echo "$output" | grep -o "Last verified [0-9]* days ago" | grep -o "[0-9]*" || echo "0")
+    [ -z "$days" ] && days=0
     if [ "$days" -gt 90 ]; then
       notes="$notes STALE_${days}d"
     fi

--- a/scripts/baseline-audit-all.sh
+++ b/scripts/baseline-audit-all.sh
@@ -52,6 +52,11 @@ echo "Starting baseline audit..."
 echo "Output will be saved to: $OUTPUT_FILE"
 echo ""
 
+# Ensure the output directory exists (planning/ is not guaranteed to be
+# present; without this the `cat >` below fails under `set -e` before any
+# skill is processed).
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
 # Initialize output file
 cat > "$OUTPUT_FILE" << 'EOF'
 # Baseline Audit Results

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -37,9 +37,11 @@ check_package_json() {
 
     echo -e "${BLUE}Checking: $skill_name${NC}"
 
-    # Extract dependencies
-    local deps=$(cat "$file" | grep -A 999 '"dependencies"' | grep -B 999 '}' | head -n -1 | tail -n +2 || true)
-    local devDeps=$(cat "$file" | grep -A 999 '"devDependencies"' | grep -B 999 '}' | head -n -1 | tail -n +2 || true)
+    # Extract dependencies. `head -n -1` is GNU-only and errors on macOS/BSD
+    # (silently zeroing the dep list under `|| true`); use `sed '$d'` to drop
+    # the closing brace line, which is portable across BSD and GNU sed.
+    local deps=$(cat "$file" | grep -A 999 '"dependencies"' | grep -B 999 '}' | sed '$d' | tail -n +2 || true)
+    local devDeps=$(cat "$file" | grep -A 999 '"devDependencies"' | grep -B 999 '}' | sed '$d' | tail -n +2 || true)
 
     # Combine all deps
     local all_deps="$deps"$'\n'"$devDeps"

--- a/scripts/fix-frontmatter.mjs
+++ b/scripts/fix-frontmatter.mjs
@@ -74,11 +74,17 @@ function fixDescriptionBlock(lines) {
     if (m) {
       const firstValue = m[1]; // text after "description: "
 
-      // Idempotency: if the description is already a YAML block scalar
-      // (`>-`, `|-`, `>`, `|`) it has already been normalized — leave it
-      // untouched. Without this guard the script re-processed already-folded
-      // descriptions on every run, churning valid frontmatter.
-      if (/^[>|][-+]?$/.test(firstValue.trim())) {
+      // Idempotency: if the description is already a YAML block scalar header
+      // (`>`, `|`, `>-`, `|2`, `>3-`, `| # comment`, etc.) it has already been
+      // normalized — leave it untouched. A block-scalar header is `>` or `|`
+      // followed by an optional indentation indicator (digit 1-9) and/or a
+      // chomping indicator (`-`/`+`) in any order, then an optional comment.
+      // Match the header token (before any comment) then allow trailing space
+      // + `# ...`.
+      const headerCore = /^[>|]([1-9][-+]?|[-+]?[1-9]?|[-+]?)$/;
+      const fv = firstValue.trim();
+      const headerToken = fv.split(/\s+#/)[0];
+      if (headerCore.test(headerToken)) {
         out.push(line);
         i++;
         continue;
@@ -177,19 +183,21 @@ function fixListIndentation(lines) {
       // collector consumed every consecutive `^\s+-\s` line regardless of
       // indentation, which merged separately-indented lists and corrupted
       // nested-list semantics. A list item at a different indentation ends the
-      // block (it is a different list).
-      let sawBlank = false;
+      // block (it is a different list). Buffer blank lines so that when the
+      // block breaks on a non-matching line, the trailing blanks are preserved
+      // in the output rather than silently dropped.
+      let pendingBlanks = [];
       while (j < lines.length) {
         const next = lines[j];
         if (next.trim() === '') {
-          sawBlank = true;
+          pendingBlanks.push(next);
           j++;
           continue;
         }
         const nextMatch = next.match(/^(\s+)-\s/);
         if (nextMatch && nextMatch[1] === blockIndent) {
-          if (sawBlank) block.push(''); // preserve a single separating blank
-          sawBlank = false;
+          if (pendingBlanks.length) block.push(''); // single separating blank
+          pendingBlanks = [];
           block.push(next);
           j++;
           continue;
@@ -210,6 +218,7 @@ function fixListIndentation(lines) {
       });
 
       out.push(...normalised);
+      out.push(...pendingBlanks);
       i = j;
       continue;
     }

--- a/scripts/fix-frontmatter.mjs
+++ b/scripts/fix-frontmatter.mjs
@@ -54,6 +54,10 @@ function extractFrontmatter(content) {
  * that top-level key pattern.
  */
 function isTopLevelKey(line) {
+  // The closing frontmatter delimiter ends the YAML block — it must not be
+  // folded into a description value. Without this, a description that is the
+  // last frontmatter field swallowed the trailing `---` and corrupted the file.
+  if (/^---\s*$/.test(line)) return true;
   // Match YAML keys at column 0: "key: value" or "key:" (no value on same line)
   return /^[a-z][a-z0-9-]*:(\s|$)/.test(line);
 }
@@ -70,6 +74,16 @@ function fixDescriptionBlock(lines) {
     if (m) {
       const firstValue = m[1]; // text after "description: "
 
+      // Idempotency: if the description is already a YAML block scalar
+      // (`>-`, `|-`, `>`, `|`) it has already been normalized — leave it
+      // untouched. Without this guard the script re-processed already-folded
+      // descriptions on every run, churning valid frontmatter.
+      if (/^[>|][-+]?$/.test(firstValue.trim())) {
+        out.push(line);
+        i++;
+        continue;
+      }
+
       // Gather continuation lines: everything that is NOT a top-level key
       const continuations = [];
       let j = i + 1;
@@ -82,7 +96,14 @@ function fixDescriptionBlock(lines) {
         j++;
       }
 
-      if (continuations.length > 0) {
+      // Only fold into a block scalar if there is non-blank continuation
+      // content. A description followed only by blank line(s) and then the next
+      // key (or the closing ---) is already valid and must NOT be rewritten —
+      // previously such lines were falsely converted to `>-`, corrupting
+      // already-correct quoted descriptions.
+      const hasNonBlankContinuation = continuations.some(l => l.trim() !== '');
+
+      if (continuations.length > 0 && hasNonBlankContinuation) {
         // ── multiline description → use >- folded block scalar ──
         // All content after >- must be indented by ≥2 spaces
         out.push('description: >-');
@@ -97,15 +118,13 @@ function fixDescriptionBlock(lines) {
             // Blank line: keep as-is (YAML folds these)
             out.push('');
           } else {
-            // Content line: add 2-space indent if not already indented enough
-            // Original lines like "  Keywords: ..." become "    Keywords: ..."
-            if (/^\s{2}/.test(cl)) {
-              out.push('  ' + cl); // add 2 more spaces to existing 2-space indent
-            } else if (/^\s/.test(cl)) {
-              out.push(cl); // already indented enough
-            } else {
-              out.push('  ' + cl); // no indent, add 2 spaces
-            }
+            // Content line: a `>-` folded block scalar requires every content
+            // line indented by ≥2 spaces. Previously a 1-space-indented line
+            // was emitted unchanged (the `/^\s/` branch), producing invalid
+            // YAML. Normalise: strip existing leading whitespace, then apply a
+            // uniform 2-space indent. Deeper relative indentation is not
+            // preserved because the original skill descriptions are flat.
+            out.push('  ' + cl.trimStart());
           }
         }
         changed = true;
@@ -153,14 +172,24 @@ function fixListIndentation(lines) {
       const block = [line];
       let j = i + 1;
 
+      // Consume only the items that belong to THIS list: same indentation as
+      // the first item, optionally separated by blank lines. Previously the
+      // collector consumed every consecutive `^\s+-\s` line regardless of
+      // indentation, which merged separately-indented lists and corrupted
+      // nested-list semantics. A list item at a different indentation ends the
+      // block (it is a different list).
+      let sawBlank = false;
       while (j < lines.length) {
         const next = lines[j];
         if (next.trim() === '') {
-          block.push(next);
+          sawBlank = true;
           j++;
           continue;
         }
-        if (next.match(/^\s+-\s/)) {
+        const nextMatch = next.match(/^(\s+)-\s/);
+        if (nextMatch && nextMatch[1] === blockIndent) {
+          if (sawBlank) block.push(''); // preserve a single separating blank
+          sawBlank = false;
           block.push(next);
           j++;
           continue;

--- a/scripts/generate-codex-manifests.sh
+++ b/scripts/generate-codex-manifests.sh
@@ -22,7 +22,7 @@
 #   ./scripts/generate-codex-manifests.sh --dry-run # Preview without writing
 # =============================================================================
 
-set -e
+set -eo pipefail
 
 command -v jq &>/dev/null || { echo "Error: jq is required but not installed"; exit 1; }
 
@@ -191,7 +191,10 @@ while IFS= read -r plugin_dir; do
 
   # Read fields from Claude manifest
   description=$(jq -r '.description // ""' "$claude_json")
-  version=$(jq -r '.version // "1.0.0"' "$claude_json")
+  # Default version aligned with generate-marketplace.sh (both derive from the
+  # same plugin.json source of truth; divergent defaults — 1.0.0 here vs 3.0.0
+  # there — could mask drift if a manifest ever lacks a version field).
+  version=$(jq -r '.version // "3.0.0"' "$claude_json")
   author=$(jq -c '.author // {"name": "Claude Skills Maintainers", "email": "maintainers@example.com"}' "$claude_json")
   license=$(jq -r '.license // "MIT"' "$claude_json")
   repository=$(jq -r '.repository // "https://github.com/secondsky/claude-skills"' "$claude_json")

--- a/scripts/generate-marketplace.sh
+++ b/scripts/generate-marketplace.sh
@@ -16,7 +16,7 @@
 # - Official docs: https://code.claude.com/docs/en/plugin-marketplaces
 # - Fix for: 3,218 skill count (should be 169)
 
-set -e
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGINS_DIR="$(cd "$SCRIPT_DIR/../plugins" && pwd)"
@@ -153,24 +153,25 @@ while IFS= read -r plugin_dir; do
     echo "," >> "$MARKETPLACE_JSON"
   fi
 
-  # Escape description for JSON (handles all control characters)
-  description_escaped=$(printf '%s' "$description" | jq -Rs . | sed 's/^"//;s/"$//')
-
   # Source path points to plugin directory
   source_path="./plugins/$plugin_name"
 
-  # Write marketplace entry for this PLUGIN
-  # Skills auto-discovered from plugins/$plugin_name/skills/ directory
-  cat >> "$MARKETPLACE_JSON" << EOF
-    {
-      "name": "$plugin_name",
-      "source": "$source_path",
-      "version": "$version",
-      "description": "$description_escaped",
-      "keywords": $keywords,
-      "category": "$category"
-    }
-EOF
+  # Write marketplace entry for this PLUGIN as a single compact JSON object.
+  # Previously this used an unquoted heredoc that interpolated $plugin_name,
+  # $version, and $description_escaped raw into the JSON text — safe only as
+  # long as no value contained a double-quote, backslash, or newline. Building
+  # the object with `jq -nc --arg` escapes all values correctly (the same safe
+  # pattern generate-codex-manifests.sh uses).
+  # Skills auto-discovered from plugins/$plugin_name/skills/ directory.
+  jq -nc \
+    --arg name "$plugin_name" \
+    --arg source "$source_path" \
+    --arg version "$version" \
+    --arg description "$description" \
+    --argjson keywords "$keywords" \
+    --arg category "$category" \
+    '{name:$name, source:$source, version:$version, description:$description, keywords:$keywords, category:$category}' \
+    >> "$MARKETPLACE_JSON"
 
   # Show skill count in progress output
   if [ "$skill_count" -gt 1 ]; then
@@ -204,11 +205,20 @@ if command -v jq &> /dev/null; then
   if jq empty "$MARKETPLACE_JSON" 2>/dev/null; then
     plugin_count=$(jq '.plugins | length' "$MARKETPLACE_JSON")
 
-    # Sync top-level metadata.version from plugin entries (lockstep: all match).
-    # The hardcoded heredoc value drifts; this keeps it consistent without a
-    # manual edit every release.
+    # Sync top-level metadata.version from plugin entries and ENFORCE lockstep.
+    # Previously this read `.plugins[0].version` (always the alphabetically-first
+    # plugin), which silently masked version drift instead of detecting it — the
+    # exact bug the comment claimed to fix. Now: collect the distinct set of
+    # plugin versions; if more than one exists, fail loudly so drift is caught
+    # at generation time rather than shipped.
+    distinct_versions=$(jq -r '[.plugins[].version] | unique | join(",")' "$MARKETPLACE_JSON")
     synced_version=$(jq -r '.plugins[0].version // empty' "$MARKETPLACE_JSON")
     if [ -n "$synced_version" ]; then
+      if [ "$distinct_versions" != "$synced_version" ]; then
+        echo "❌ Version lockstep violated: plugins report versions [$distinct_versions]." >&2
+        echo "   Expected all plugins at a single version. Fix the divergent plugin.json files." >&2
+        exit 1
+      fi
       jq --arg v "$synced_version" '.metadata.version = $v' "$MARKETPLACE_JSON" > "$MARKETPLACE_JSON.tmp" && mv "$MARKETPLACE_JSON.tmp" "$MARKETPLACE_JSON"
     fi
 

--- a/scripts/review-skill.sh
+++ b/scripts/review-skill.sh
@@ -78,12 +78,15 @@ declare -a MEDIUM_LIST
 declare -a LOW_LIST
 declare -a MANUAL_LIST
 
-# Add findings
-add_critical() { CRITICAL_LIST+=("$1"); ((CRITICAL++)); }
-add_high() { HIGH_LIST+=("$1"); ((HIGH++)); }
-add_medium() { MEDIUM_LIST+=("$1"); ((MEDIUM++)); }
-add_low() { LOW_LIST+=("$1"); ((LOW++)); }
-add_manual() { MANUAL_LIST+=("$1"); ((MANUAL_CHECKS++)); }
+# Add findings. NOTE: `((VAR++))` returns exit status 1 when VAR is 0, which
+# under `set -e` would abort the script on the first finding (bug: the entire
+# report was unreachable whenever any issue existed). `|| true` neutralizes the
+# non-zero status while still incrementing.
+add_critical() { CRITICAL_LIST+=("$1"); ((CRITICAL++)) || true; }
+add_high() { HIGH_LIST+=("$1"); ((HIGH++)) || true; }
+add_medium() { MEDIUM_LIST+=("$1"); ((MEDIUM++)) || true; }
+add_low() { LOW_LIST+=("$1"); ((LOW++)) || true; }
+add_manual() { MANUAL_LIST+=("$1"); ((MANUAL_CHECKS++)) || true; }
 
 # Helper functions
 error() { echo -e "${RED}${FAIL} $1${NC}"; }
@@ -209,7 +212,17 @@ check_yaml_frontmatter() {
     # Check for last_verified
     if echo "$frontmatter" | grep -q "last_verified:"; then
       local last_verified=$(echo "$frontmatter" | grep "last_verified:" | sed 's/.*last_verified:[[:space:]]*//')
-      local days_ago=$(( ($(date +%s) - $(date -d "$last_verified" +%s 2>/dev/null || echo 0)) / 86400 ))
+      # Parse the YYYY-MM-DD date to epoch seconds portably. `date -d` is
+      # GNU-only and errors on macOS/BSD (silently yielding epoch 0, which
+      # flagged every skill as ~56 years stale). Use BSD's `date -jf` when on
+      # macOS, falling back to GNU `date -d`.
+      local verified_epoch=0
+      if date -jf "%Y-%m-%d" "$last_verified" +%s >/dev/null 2>&1; then
+        verified_epoch=$(date -jf "%Y-%m-%d" "$last_verified" +%s 2>/dev/null || echo 0)
+      elif date -d "$last_verified" +%s >/dev/null 2>&1; then
+        verified_epoch=$(date -d "$last_verified" +%s 2>/dev/null || echo 0)
+      fi
+      local days_ago=$(( ($(date +%s) - verified_epoch ) / 86400 ))
 
       if [ "$days_ago" -gt 90 ]; then
         warning "Last verified ${days_ago} days ago (>90 days is stale)"

--- a/scripts/review-skill.sh
+++ b/scripts/review-skill.sh
@@ -212,23 +212,36 @@ check_yaml_frontmatter() {
     # Check for last_verified
     if echo "$frontmatter" | grep -q "last_verified:"; then
       local last_verified=$(echo "$frontmatter" | grep "last_verified:" | sed 's/.*last_verified:[[:space:]]*//')
+      # Strip surrounding quotes / whitespace so a YAML-quoted scalar like
+      # `last_verified: "2024-01-15"` parses cleanly.
+      last_verified="${last_verified#\"}"; last_verified="${last_verified%\"}"
+      last_verified="${last_verified#\'}"; last_verified="${last_verified%\'}"
+      last_verified="${last_verified%% *}"
       # Parse the YYYY-MM-DD date to epoch seconds portably. `date -d` is
       # GNU-only and errors on macOS/BSD (silently yielding epoch 0, which
       # flagged every skill as ~56 years stale). Use BSD's `date -jf` when on
-      # macOS, falling back to GNU `date -d`.
+      # macOS, falling back to GNU `date -d`. If neither recognizes the value,
+      # skip the staleness check rather than reporting a bogus ~20,500-day age.
       local verified_epoch=0
+      local parsed=false
       if date -jf "%Y-%m-%d" "$last_verified" +%s >/dev/null 2>&1; then
         verified_epoch=$(date -jf "%Y-%m-%d" "$last_verified" +%s 2>/dev/null || echo 0)
+        parsed=true
       elif date -d "$last_verified" +%s >/dev/null 2>&1; then
         verified_epoch=$(date -d "$last_verified" +%s 2>/dev/null || echo 0)
+        parsed=true
       fi
-      local days_ago=$(( ($(date +%s) - verified_epoch ) / 86400 ))
 
-      if [ "$days_ago" -gt 90 ]; then
-        warning "Last verified ${days_ago} days ago (>90 days is stale)"
-        add_medium "Skill hasn't been verified in ${days_ago} days"
+      if [ "$parsed" = false ]; then
+        info "Metadata: last_verified value '$last_verified' not a recognized date (skipping staleness check)"
       else
-        success "Recently verified (${days_ago} days ago)"
+        local days_ago=$(( ($(date +%s) - verified_epoch ) / 86400 ))
+        if [ "$days_ago" -gt 90 ]; then
+          warning "Last verified ${days_ago} days ago (>90 days is stale)"
+          add_medium "Skill hasn't been verified in ${days_ago} days"
+        else
+          success "Recently verified (${days_ago} days ago)"
+        fi
       fi
     else
       info "Metadata: last_verified field missing (recommended)"

--- a/scripts/sync-plugins.sh
+++ b/scripts/sync-plugins.sh
@@ -713,7 +713,12 @@ echo "Global version: $GLOBAL_VERSION"
 echo ""
 
 # -----------------------------------------------------------------------------
-# Sync .codex-plugin/plugin.json version (lockstep with Claude manifests)
+# Stamp .version into .codex-plugin/plugin.json to match the Claude manifests.
+# NOTE: this only synchronizes the version field. The full codex manifest
+# (description, keywords, interface, etc.) is regenerated downstream by
+# generate-codex-manifests.sh (invoked via generate-marketplace.sh below), which
+# treats the Claude manifests as the source of truth. Do not expect this loop
+# alone to keep codex fields in sync — it is a version lockstep only.
 # -----------------------------------------------------------------------------
 codex_count=0
 codex_updated=0
@@ -723,14 +728,23 @@ while IFS= read -r codex_json; do
   fi
   codex_count=$((codex_count + 1))
   if [ "$DRY_RUN" = false ]; then
-    jq --arg v "$GLOBAL_VERSION" '.version = $v' "$codex_json" > "$codex_json.tmp" \
-      && mv "$codex_json.tmp" "$codex_json"
-    codex_updated=$((codex_updated + 1))
+    # Write to .tmp, VALIDATE with jq, then promote. Previously a failed jq
+    # left a .tmp behind and still incremented the updated counter (reporting
+    # "N/N synced" when some had failed), and a malformed result could destroy
+    # the original via mv with no validation step in between.
+    if jq --arg v "$GLOBAL_VERSION" '.version = $v' "$codex_json" > "$codex_json.tmp" \
+      && jq '.' "$codex_json.tmp" > /dev/null 2>&1; then
+      mv "$codex_json.tmp" "$codex_json"
+      codex_updated=$((codex_updated + 1))
+    else
+      rm -f "$codex_json.tmp"
+      echo "⚠️  Failed to sync version for $(basename "$(dirname "$(dirname "$codex_json")")") — left unchanged" >&2
+    fi
   fi
 done < <(find "$PLUGINS_DIR" -path '*/.codex-plugin/plugin.json' | sort)
 
 if [ "$codex_count" -gt 0 ]; then
-  echo "Codex manifests synced: $codex_updated/$codex_count"
+  echo "Codex version synced: $codex_updated/$codex_count"
 fi
 echo ""
 

--- a/scripts/validate-frontmatter.sh
+++ b/scripts/validate-frontmatter.sh
@@ -296,7 +296,7 @@ if [ -n "$TARGET_DIR" ]; then
 
   while IFS= read -r file; do
     [ -z "$file" ] && continue
-    validate_skill "$file"
+    validate_skill "$file" || true
   done <<< "$skill_files"
 else
   skill_files=$(find "$REPO_ROOT/plugins" -name 'SKILL.md' 2>/dev/null | sort || true)
@@ -308,7 +308,7 @@ else
 
   while IFS= read -r file; do
     [ -z "$file" ] && continue
-    validate_skill "$file"
+    validate_skill "$file" || true
   done <<< "$skill_files"
 fi
 

--- a/scripts/validate-json-schemas.sh
+++ b/scripts/validate-json-schemas.sh
@@ -67,7 +67,13 @@ echo ""
 # Find all plugin.json files
 echo -e "${BLUE}🔌 Finding plugin.json files...${NC}"
 plugin_files=$(find "$REPO_ROOT/plugins" -name 'plugin.json' -path '*/.claude-plugin/plugin.json' | sort)
-plugin_count=$(echo "$plugin_files" | wc -l | tr -d ' ')
+# `echo "" | wc -l` returns 1 for empty input, so guard explicitly to avoid a
+# misleading "Total: 1, Passed: 0, Failed: 0" report when no files are found.
+if [ -z "$plugin_files" ]; then
+  plugin_count=0
+else
+  plugin_count=$(printf '%s\n' "$plugin_files" | wc -l | tr -d ' ')
+fi
 
 echo -e "Found ${BLUE}$plugin_count${NC} plugin.json files"
 echo ""


### PR DESCRIPTION
## Summary

Multi-round adversarial subagent audit of the plugin-marketplace scripts. 4 parallel round-1 agents → 15 confirmed fixes → 2 round-2 agents found 2 more Important issues → fixed → round-3 confirmed convergence (**0 Critical / 0 Important remaining**).

## Fixes

### Critical
- **`review-skill.sh`**: `((VAR++))` returned exit 1 under `set -e` when counter was 0 → aborted on first finding → entire report unreachable for any non-perfect skill. Added `|| true`.
- **`review-skill.sh`**: `date -d` is GNU-only → on macOS every skill with `last_verified` was falsely flagged ~20,500 days stale. Now uses BSD `date -jf` + GNU fallback, strips quotes, skips on unrecognized format.

### Important
- **`validate-frontmatter.sh`**: `set -e` + `validate_skill "$file"` aborted on first failing skill; summary never printed. Guarded with `|| true` (CRITICAL_COUNT still gates exit).
- **`validate-json-schemas.sh`**: `plugin_count=1` when zero files (`echo "" | wc -l`); false "Total: 1" green report. Explicit empty guard.
- **`generate-marketplace.sh`**: version sync read `.plugins[0]` (always alphabetically-first plugin), masking drift instead of detecting it. Now asserts all plugin versions agree; fails loudly on drift.
- **`baseline-audit-all.sh`**: wrote to `planning/` which doesn't exist → died before processing. `mkdir -p`.
- **`baseline-audit-all.sh`**: same `((VAR++))` bug as review-skill.sh in its own counters (propagated fix) + `days` default.
- **`check-versions.sh`**: `head -n -1` GNU-only → silently zeroed dep list on macOS. Portable `sed '$d'`.
- **`sync-plugins.sh`**: codex loop counted updates even when jq/mv failed, no validation before mv. Now validates + cleans up + counts on success.
- **`generate-marketplace.sh`**: heredoc interpolated raw values into JSON (latent injection). Now builds each entry with `jq -nc --arg`.
- **`fix-frontmatter.mjs`**: closing `---` swallowed when description was last field; 1-space indent invalid; merged unrelated lists; non-idempotent (churned 25 valid files). 5 sub-fixes; now idempotent (0 files changed on clean repo).

### Minor / hygiene
- Aligned divergent version defaults (1.0.0 → 3.0.0) across generators.
- `set -eo pipefail` added to both generators.
- Corrected misleading "lockstep" comment in sync-plugins.sh (version-only).

## Verification
- All syntax checks pass (8 shell + 1 Node).
- `validate-frontmatter.sh`: processes all 185 skills, exit 0.
- `validate-json-schemas.sh`: 144 Claude + 144 Codex plugins pass.
- `generate-marketplace.sh`: regenerates valid JSON, v3.7.0 consensus.
- F5 lockstep assertion proven to fire on injected drift.
- `baseline-audit-all.sh`: runs all 182 skills to completion.
- `fix-frontmatter.mjs`: idempotent (0 files churned on clean repo).

## Test plan
- [ ] CI green (validate-frontmatter, validate-json-schemas, codeql)
- [ ] Code-owner review

🤖 Generated by ZCode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit, validation, and review checks to process all items and report aggregate failures accurately.
  * Fixed compatibility across BSD/macOS and GNU environments, including date and dependency parsing.
  * Corrected frontmatter formatting, date handling, empty-result detection, and nested-list preservation.
  * Prevented inconsistent marketplace and Codex manifest data from being published.
  * Added safer manifest replacement, failure cleanup, and clearer synchronization status reporting.
  * Improved pipeline error detection and ensured required output directories are created automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->