### PR TITLE
fix(scripts): CodeRabbit PR #85 followup — pipefail regression + 3 hardening fixes

### DIFF
--- a/scripts/generate-marketplace.sh
+++ b/scripts/generate-marketplace.sh
@@ -143,8 +143,11 @@ while IFS= read -r plugin_dir; do
   # Track category count
   echo "$plugin_name" >> "$TEMP_DIR/$category"
 
-  # Count skills in this plugin (for info only, not included in marketplace)
-  skill_count=$(find "$plugin_dir/skills" -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' ')
+  # Count skills in this plugin (for info only, not included in marketplace).
+  # `find` exits non-zero if the directory doesn't exist; under `set -o pipefail`
+  # that would abort the whole generator. Append `|| true` so a plugin lacking a
+  # skills/ subdir simply reports count 0 instead of crashing the run.
+  skill_count=$(find "$plugin_dir/skills" -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' ' || true)
 
   # Add comma before each entry except the first
   if [ "$first" = true ]; then
@@ -204,6 +207,15 @@ if command -v jq &> /dev/null; then
   echo "Validating JSON..."
   if jq empty "$MARKETPLACE_JSON" 2>/dev/null; then
     plugin_count=$(jq '.plugins | length' "$MARKETPLACE_JSON")
+
+    # Reject an empty marketplace before doing anything else. If every plugin
+    # was skipped (misconfigured PLUGINS_DIR, all plugin.json invalid, etc.)
+    # the file would contain `"plugins": []`, violating the marketplace schema
+    # (minItems) and silently publishing a broken artifact. Fail loudly instead.
+    if [ "$plugin_count" -eq 0 ]; then
+      echo "❌ ERROR: Generated marketplace has 0 plugins (all skipped?). Aborting; $MARKETPLACE_JSON left as-is or empty." >&2
+      exit 1
+    fi
 
     # Sync top-level metadata.version from plugin entries and ENFORCE lockstep.
     # Previously this read `.plugins[0].version` (always the alphabetically-first

--- a/scripts/review-skill.sh
+++ b/scripts/review-skill.sh
@@ -212,11 +212,13 @@ check_yaml_frontmatter() {
     # Check for last_verified
     if echo "$frontmatter" | grep -q "last_verified:"; then
       local last_verified=$(echo "$frontmatter" | grep "last_verified:" | sed 's/.*last_verified:[[:space:]]*//')
-      # Strip surrounding quotes / whitespace so a YAML-quoted scalar like
-      # `last_verified: "2024-01-15"` parses cleanly.
+      # Strip trailing YAML comments / whitespace FIRST, then surrounding quotes,
+      # so values like `last_verified: "2024-01-15" # comment` or
+      # `'2024-01-15' # note` reduce to a parseable date. Stripping quotes before
+      # the comment left a stray closing quote in single-quoted-with-comment cases.
+      last_verified="${last_verified%% *}"
       last_verified="${last_verified#\"}"; last_verified="${last_verified%\"}"
       last_verified="${last_verified#\'}"; last_verified="${last_verified%\'}"
-      last_verified="${last_verified%% *}"
       # Parse the YYYY-MM-DD date to epoch seconds portably. `date -d` is
       # GNU-only and errors on macOS/BSD (silently yielding epoch 0, which
       # flagged every skill as ~56 years stale). Use BSD's `date -jf` when on

--- a/scripts/sync-plugins.sh
+++ b/scripts/sync-plugins.sh
@@ -728,13 +728,13 @@ while IFS= read -r codex_json; do
   fi
   codex_count=$((codex_count + 1))
   if [ "$DRY_RUN" = false ]; then
-    # Write to .tmp, VALIDATE with jq, then promote. Previously a failed jq
-    # left a .tmp behind and still incremented the updated counter (reporting
-    # "N/N synced" when some had failed), and a malformed result could destroy
-    # the original via mv with no validation step in between.
+    # Write to .tmp, VALIDATE with jq, then promote — all in one `&&` chain so
+    # that a failure at ANY step (jq write, jq validate, OR mv) routes to the
+    # else branch for cleanup. Previously `mv` was a standalone command inside
+    # `then`, so an mv failure aborted under set -e instead of being reported.
     if jq --arg v "$GLOBAL_VERSION" '.version = $v' "$codex_json" > "$codex_json.tmp" \
-      && jq '.' "$codex_json.tmp" > /dev/null 2>&1; then
-      mv "$codex_json.tmp" "$codex_json"
+      && jq '.' "$codex_json.tmp" > /dev/null 2>&1 \
+      && mv "$codex_json.tmp" "$codex_json"; then
       codex_updated=$((codex_updated + 1))
     else
       rm -f "$codex_json.tmp"


### PR DESCRIPTION
## Summary
Addresses the 4 CodeRabbit inline review comments from PR #85 that I missed before merging.

## Findings addressed
- **generate-marketplace.sh:19 (Major)** — `set -o pipefail` added in #85 made `find | wc -l` abort the whole generator if any plugin lacks a `skills/` subdir (`find` exits non-zero on missing dir). Latent today (0 plugins affected) but a hard crash the moment one appears. Fix: `|| true`.
- **generate-marketplace.sh:221 (Major)** — empty marketplace (`plugin_count=0`, all plugins skipped) produced `{\"plugins\":[]}` violating the schema minItems, silently publishing a broken artifact. Now exits 1.
- **review-skill.sh:219 (Minor)** — quote-strip order left a stray closing quote on single-quoted-with-comment values (`'2024-01-15' # note`). Strip comment/whitespace before quotes.
- **sync-plugins.sh:741 (Major)** — `mv` was a standalone command inside `then`; an mv failure aborted under `set -e` instead of routing to cleanup. Folded into the `&&` chain.

## Verification
- `find | wc` on missing dir survives (count=0).
- Empty-marketplace guard fires (plugin_count=0 → exit 1).
- Quote-strip handles all 5 forms (double/unquoted/single × with/without comment).
- sync-plugins dry-run green; regenerate marketplace OK (144 plugins); validators green.

🤖 Generated by ZCode