### PR TITLE
feat(zod): fidelity audit vs zod@4.4.3 + best-practices rulebook (skill v2.1.0, lockstep 3.8.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Production-tested skills for Claude Code - Cloudflare, AI, React, Tailwind v4, and modern web development",
-    "version": "3.7.0",
+    "version": "3.8.0",
     "homepage": "https://github.com/secondsky/claude-skills"
   },
   "plugins": [
     {
       "name": "aceternity-ui",
       "source": "./plugins/aceternity-ui",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "100+ animated React components (Aceternity UI) for Next.js with Tailwind. Use for hero sections, parallax, 3D effects, or encountering animation, shadcn CLI integration errors.",
       "keywords": [
         "aceternity-ui",
@@ -28,7 +28,7 @@
     {
       "name": "api-authentication",
       "source": "./plugins/api-authentication",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Secure API authentication with JWT, OAuth 2.0, API keys. Use for authentication systems, third-party integrations, service-to-service communication, or encountering token management, security headers, auth flow errors.",
       "keywords": [
         "api-authentication",
@@ -45,7 +45,7 @@
     {
       "name": "api-changelog-versioning",
       "source": "./plugins/api-changelog-versioning",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Creates comprehensive API changelogs documenting breaking changes, deprecations, and migration strategies for API consumers. Use when managing API versions, communicating breaking changes, or creating upgrade guides.",
       "keywords": [
         "api-changelog-versioning",
@@ -63,7 +63,7 @@
     {
       "name": "api-contract-testing",
       "source": "./plugins/api-contract-testing",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Verifies API contracts between services using consumer-driven contracts, schema validation, and tools like Pact. Use when testing microservices communication, preventing breaking changes, or validating OpenAPI specifications.",
       "keywords": [
         "api-contract-testing",
@@ -82,7 +82,7 @@
     {
       "name": "api-design-principles",
       "source": "./plugins/api-design-principles",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewing API specifications, or establishing API design standards.",
       "keywords": [
         "api-design-principles",
@@ -101,7 +101,7 @@
     {
       "name": "api-error-handling",
       "source": "./plugins/api-error-handling",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Implements standardized API error responses with proper status codes, logging, and user-friendly messages. Use when building production APIs, implementing error recovery patterns, or integrating error monitoring services.",
       "keywords": [
         "api-error-handling",
@@ -118,7 +118,7 @@
     {
       "name": "api-filtering-sorting",
       "source": "./plugins/api-filtering-sorting",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Builds flexible API filtering and sorting systems with query parameter parsing, validation, and security. Use when implementing search endpoints, building data grids, or creating dynamic query APIs.",
       "keywords": [
         "api-filtering-sorting",
@@ -136,7 +136,7 @@
     {
       "name": "api-gateway-configuration",
       "source": "./plugins/api-gateway-configuration",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Configures API gateways for routing, authentication, rate limiting, and request transformation in microservice architectures. Use when setting up Kong, Nginx, AWS API Gateway, or Traefik for centralized API management.",
       "keywords": [
         "api-gateway-configuration",
@@ -155,7 +155,7 @@
     {
       "name": "api-pagination",
       "source": "./plugins/api-pagination",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Implements efficient API pagination using offset, cursor, and keyset strategies for large datasets. Use when building paginated endpoints, implementing infinite scroll, or optimizing database queries for collections.",
       "keywords": [
         "api-pagination",
@@ -171,7 +171,7 @@
     {
       "name": "api-rate-limiting",
       "source": "./plugins/api-rate-limiting",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Implements API rate limiting using token bucket, sliding window, and Redis-based algorithms to protect against abuse. Use when securing public APIs, implementing tiered access, or preventing denial-of-service attacks.",
       "keywords": [
         "api-rate-limiting",
@@ -188,7 +188,7 @@
     {
       "name": "api-reference-documentation",
       "source": "./plugins/api-reference-documentation",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Creates professional API documentation using OpenAPI specifications with endpoints, authentication, and interactive examples. Use when documenting REST APIs, creating SDK references, or building developer portals.",
       "keywords": [
         "api-reference-documentation",
@@ -207,7 +207,7 @@
     {
       "name": "api-response-optimization",
       "source": "./plugins/api-response-optimization",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Optimizes API performance through payload reduction, caching strategies, and compression techniques. Use when improving API response times, reducing bandwidth usage, or implementing efficient caching.",
       "keywords": [
         "api-response-optimization",
@@ -225,7 +225,7 @@
     {
       "name": "api-security-hardening",
       "source": "./plugins/api-security-hardening",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "REST API security hardening with authentication, rate limiting, input validation, security headers. Use for production APIs, security audits, defense-in-depth, or encountering vulnerabilities, injection attacks, CORS issues.",
       "keywords": [
         "api-security-hardening",
@@ -245,7 +245,7 @@
     {
       "name": "api-testing",
       "source": "./plugins/api-testing",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "HTTP API testing for TypeScript (Supertest) and Python (httpx, pytest). Test REST APIs, GraphQL, request/response validation, authentication, and error handling.",
       "keywords": [
         "api-testing",
@@ -263,7 +263,7 @@
     {
       "name": "api-versioning-strategy",
       "source": "./plugins/api-versioning-strategy",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Implements API versioning using URL paths, headers, or query parameters with backward compatibility and deprecation strategies. Use when managing multiple API versions, planning breaking changes, or designing migration paths.",
       "keywords": [
         "api-versioning-strategy",
@@ -282,7 +282,7 @@
     {
       "name": "app-store-deployment",
       "source": "./plugins/app-store-deployment",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Publishes mobile applications to iOS App Store and Google Play with code signing, versioning, and CI/CD automation. Use when preparing app releases, configuring signing certificates, or setting up automated deployment pipelines.",
       "keywords": [
         "app-store-deployment",
@@ -296,7 +296,7 @@
     {
       "name": "architecture-patterns",
       "source": "./plugins/architecture-patterns",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Implement proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design. Use when architecting complex backend systems or refactoring existing applications for better maintainability.",
       "keywords": [
         "architecture-patterns",
@@ -310,7 +310,7 @@
     {
       "name": "auto-animate",
       "source": "./plugins/auto-animate",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity.",
       "keywords": [
         "auto-animate",
@@ -326,7 +326,7 @@
     {
       "name": "base-ui-react",
       "source": "./plugins/base-ui-react",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues.",
       "keywords": [
         "base-ui-react",
@@ -342,7 +342,7 @@
     {
       "name": "better-auth",
       "source": "./plugins/better-auth",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Skill for integrating Better Auth - comprehensive TypeScript authentication framework for Cloudflare D1, Next.js, Nuxt, and 15+ frameworks. Use when adding auth, encountering D1 adapter errors, or implementing OAuth/2FA/RBAC features.",
       "keywords": [
         "better-auth",
@@ -360,7 +360,7 @@
     {
       "name": "bun",
       "source": "./plugins/bun",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Comprehensive Bun runtime toolkit covering runtime, package manager, bundler, testing, HTTP servers, WebSockets, databases, framework integrations (Hono, Next.js, Nuxt, TanStack Start, SvelteKit), deployment, and Node.js compatibility.",
       "keywords": [
         "bun",
@@ -376,7 +376,7 @@
     {
       "name": "claude-code-bash-patterns",
       "source": "./plugins/claude-code-bash-patterns",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Claude Code Bash tool patterns with hooks, automation, git workflows. Use for PreToolUse hooks, command chaining, CLI orchestration, custom commands, or encountering bash permissions, command failures, security guards, hook configurations.",
       "keywords": [
         "claude-code-bash-patterns",
@@ -394,7 +394,7 @@
     {
       "name": "claude-hook-writer",
       "source": "./plugins/claude-hook-writer",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Expert guidance for writing secure, reliable, and performant Claude Code hooks - validates design decisions, enforces best practices, and prevents common pitfalls. Use when creating, reviewing, or debugging Claude Code hooks.",
       "keywords": [
         "claude-hook-writer",
@@ -409,7 +409,7 @@
     {
       "name": "cloudflare-agents",
       "source": "./plugins/cloudflare-agents",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Build AI agents on Cloudflare Workers with MCP integration, tool use, and LLM providers.",
       "keywords": [
         "cloudflare-agents",
@@ -426,7 +426,7 @@
     {
       "name": "cloudflare-browser-rendering",
       "source": "./plugins/cloudflare-browser-rendering",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded.",
       "keywords": [
         "cloudflare-browser-rendering",
@@ -442,7 +442,7 @@
     {
       "name": "cloudflare-cron-triggers",
       "source": "./plugins/cloudflare-cron-triggers",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors.",
       "keywords": [
         "cloudflare-cron-triggers",
@@ -458,7 +458,7 @@
     {
       "name": "cloudflare-d1",
       "source": "./plugins/cloudflare-d1",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors.",
       "keywords": [
         "cloudflare-d1",
@@ -473,7 +473,7 @@
     {
       "name": "cloudflare-durable-objects",
       "source": "./plugins/cloudflare-durable-objects",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors.",
       "keywords": [
         "cloudflare-durable-objects",
@@ -492,7 +492,7 @@
     {
       "name": "cloudflare-email-routing",
       "source": "./plugins/cloudflare-email-routing",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues.",
       "keywords": [
         "cloudflare-email-routing",
@@ -509,7 +509,7 @@
     {
       "name": "cloudflare-hyperdrive",
       "source": "./plugins/cloudflare-hyperdrive",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused.",
       "keywords": [
         "cloudflare-hyperdrive",
@@ -528,7 +528,7 @@
     {
       "name": "cloudflare-images",
       "source": "./plugins/cloudflare-images",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "This skill should be used when the user asks to \"upload images to Cloudflare\", \"implement direct creator upload\", \"configure image transformations\", \"optimize WebP/AVIF\", \"create image variants\", \"generate signed URLs\", \"add image watermarks\", \"integrate with Next.js/Remix\", \"configure webhooks\", \"debug CORS errors\", \"troubleshoot error 5408/9401-9413\", or \"build responsive images with Cloudflare Images API\".",
       "keywords": [
         "cloudflare-images",
@@ -547,7 +547,7 @@
     {
       "name": "cloudflare-kv",
       "source": "./plugins/cloudflare-kv",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues.",
       "keywords": [
         "cloudflare-kv",
@@ -563,7 +563,7 @@
     {
       "name": "cloudflare-manager",
       "source": "./plugins/cloudflare-manager",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Comprehensive Cloudflare account management for deploying Workers, KV Storage, R2, Pages, DNS, and Routes. Use when deploying cloudflare services, managing worker containers, configuring KV/R2 storage, or setting up DNS/routing. Requires CLOUDFLARE_API_KEY in .env and Bun runtime with dependencies installed.",
       "keywords": [
         "cloudflare-manager",
@@ -579,7 +579,7 @@
     {
       "name": "cloudflare-mcp-server",
       "source": "./plugins/cloudflare-mcp-server",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Build MCP (Model Context Protocol) servers on Cloudflare Workers with tools, resources, and prompts.",
       "keywords": [
         "cloudflare-mcp-server",
@@ -595,7 +595,7 @@
     {
       "name": "cloudflare-nextjs",
       "source": "./plugins/cloudflare-nextjs",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Deploy Next.js to Cloudflare Workers via the OpenNext adapter (@opennextjs/cloudflare). Use for SSR/ISR/SSG, App or Pages Router, getCloudflareContext, bindings (D1/R2/KV/AI/Hyperdrive), caching tiers, skew protection, multi-worker, custom worker, env vars, or worker size/runtime/keep_names/FinalizationRegistry/connection-scoping errors.",
       "keywords": [
         "cloudflare-nextjs",
@@ -616,7 +616,7 @@
     {
       "name": "cloudflare-queues",
       "source": "./plugins/cloudflare-queues",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "This skill should be used when the user asks to \"set up Cloudflare Queues\", \"create a message queue\", \"implement queue consumer\", \"process background jobs\", \"configure queue retry logic\", \"publish messages to queue\", \"implement dead letter queue\", or encountering \"queue timeout\", \"message retry\", \"throughput exceeded\", \"queue backlog\" errors.",
       "keywords": [
         "cloudflare-queues",
@@ -631,7 +631,7 @@
     {
       "name": "cloudflare-r2",
       "source": "./plugins/cloudflare-r2",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Cloudflare R2 S3-compatible object storage with SQL, Iceberg, event notifications, and automation. Use for buckets, uploads, CORS, presigned URLs, large files, S3 migration, analytics, or encountering R2_ERROR, CORS failures, multipart issues.",
       "keywords": [
         "cloudflare-r2",
@@ -648,7 +648,7 @@
     {
       "name": "cloudflare-sandbox",
       "source": "./plugins/cloudflare-sandbox",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations.",
       "keywords": [
         "cloudflare-sandbox",
@@ -663,7 +663,7 @@
     {
       "name": "cloudflare-turnstile",
       "source": "./plugins/cloudflare-turnstile",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Cloudflare Turnstile CAPTCHA-alternative bot protection. Use for forms, login security, API protection, or encountering CSP errors, token validation failures, error codes 100*/300*/600*.",
       "keywords": [
         "cloudflare-turnstile",
@@ -681,7 +681,7 @@
     {
       "name": "cloudflare-vectorize",
       "source": "./plugins/cloudflare-vectorize",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors.",
       "keywords": [
         "cloudflare-vectorize",
@@ -697,7 +697,7 @@
     {
       "name": "cloudflare-workers",
       "source": "./plugins/cloudflare-workers",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Comprehensive Cloudflare Workers platform guide covering runtime APIs, testing (Vitest), CI/CD, observability, framework integration, performance, security, and migration. Use for Workers development, deployment, debugging, or optimization.",
       "keywords": [
         "cloudflare-workers",
@@ -712,7 +712,7 @@
     {
       "name": "cloudflare-workers-ai",
       "source": "./plugins/cloudflare-workers-ai",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors.",
       "keywords": [
         "cloudflare-workers-ai",
@@ -727,7 +727,7 @@
     {
       "name": "cloudflare-workflows",
       "source": "./plugins/cloudflare-workflows",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors.",
       "keywords": [
         "cloudflare-workflows",
@@ -743,7 +743,7 @@
     {
       "name": "cloudflare-zero-trust-access",
       "source": "./plugins/cloudflare-zero-trust-access",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers.",
       "keywords": [
         "cloudflare-zero-trust-access",
@@ -764,7 +764,7 @@
     {
       "name": "code-review",
       "source": "./plugins/code-review",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Code review practices with technical rigor and verification gates. Use for receiving feedback, requesting code-reviewer subagent reviews, or preventing false completion claims in pull requests.",
       "keywords": [
         "code-review",
@@ -778,7 +778,7 @@
     {
       "name": "csrf-protection",
       "source": "./plugins/csrf-protection",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Implements CSRF protection using synchronizer tokens, double-submit cookies, and SameSite attributes. Use when securing web forms, protecting state-changing endpoints, or implementing defense-in-depth authentication.",
       "keywords": [
         "csrf-protection",
@@ -795,7 +795,7 @@
     {
       "name": "cybersecurity",
       "source": "./plugins/cybersecurity",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "OSS-only security for OWASP Top 10, pentest, vuln testing (XSS, SSRF, CSRF, business-logic, Host header), threat modeling (STRIDE, ATT&CK), Sigma rules, SAST, code audit, AI/LLM red-team, or replacing paid tools (Burp, Nessus, Splunk) with OSS.",
       "keywords": [
         "cybersecurity",
@@ -817,7 +817,7 @@
     {
       "name": "defense-in-depth-validation",
       "source": "./plugins/defense-in-depth-validation",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Validate at every layer data passes through to make bugs impossible. Use when invalid data causes failures deep in execution, requiring validation at multiple system layers.",
       "keywords": [
         "defense-in-depth-validation",
@@ -835,7 +835,7 @@
     {
       "name": "delegate-my-work",
       "source": "./plugins/delegate-my-work",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Interview employees to find recurring work, map accessible AI and automation tools, and spec each loop with preferred and fallback routes.",
       "keywords": [
         "delegate-my-work",
@@ -849,7 +849,7 @@
     {
       "name": "dependency-upgrade",
       "source": "./plugins/dependency-upgrade",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Secure dependency upgrades with supply chain protection, cooldowns, staged rollout, and Socket CLI integration. Use when upgrading deps, configuring security policies, or preventing supply chain attacks.",
       "keywords": [
         "dependency-upgrade",
@@ -864,7 +864,7 @@
     {
       "name": "design-review",
       "source": "./plugins/design-review",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states.",
       "keywords": [
         "design-review",
@@ -879,7 +879,7 @@
     {
       "name": "design-system-creation",
       "source": "./plugins/design-system-creation",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency.",
       "keywords": [
         "design-system-creation",
@@ -894,7 +894,7 @@
     {
       "name": "drizzle-orm-d1",
       "source": "./plugins/drizzle-orm-d1",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transaction errors, foreign key constraint failures, or schema inference issues.",
       "keywords": [
         "drizzle-orm-d1",
@@ -911,7 +911,7 @@
     {
       "name": "feature-dev",
       "source": "./plugins/feature-dev",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Automate 7-phase feature development with specialized agents (code-explorer, code-architect, code-reviewer). Use for multi-file features, architectural decisions, or encountering ambiguous requirements, integration patterns, design approach errors.",
       "keywords": [
         "feature-dev",
@@ -925,7 +925,7 @@
     {
       "name": "firecrawl-scraper",
       "source": "./plugins/firecrawl-scraper",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors.",
       "keywords": [
         "firecrawl-scraper",
@@ -941,7 +941,7 @@
     {
       "name": "frontend-design",
       "source": "./plugins/frontend-design",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.",
       "keywords": [
         "frontend-design",
@@ -955,7 +955,7 @@
     {
       "name": "gemini-cli",
       "source": "./plugins/gemini-cli",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool.",
       "keywords": [
         "gemini-cli",
@@ -970,7 +970,7 @@
     {
       "name": "github-project-automation",
       "source": "./plugins/github-project-automation",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors.",
       "keywords": [
         "github-project-automation",
@@ -987,7 +987,7 @@
     {
       "name": "graphql-implementation",
       "source": "./plugins/graphql-implementation",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Builds GraphQL APIs with schema design, resolvers, error handling, and performance optimization using Apollo or Graphene. Use when creating flexible query APIs, migrating from REST, or implementing real-time subscriptions.",
       "keywords": [
         "graphql-implementation",
@@ -1003,7 +1003,7 @@
     {
       "name": "health-check-endpoints",
       "source": "./plugins/health-check-endpoints",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Health check endpoints for liveness, readiness, dependency monitoring. Use for Kubernetes, load balancers, auto-scaling, or encountering probe failures, startup delays, dependency checks, timeout configuration errors.",
       "keywords": [
         "health-check-endpoints",
@@ -1019,7 +1019,7 @@
     {
       "name": "hono-routing",
       "source": "./plugins/hono-routing",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors.",
       "keywords": [
         "hono-routing",
@@ -1036,7 +1036,7 @@
     {
       "name": "hugo",
       "source": "./plugins/hugo",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors.",
       "keywords": [
         "hugo",
@@ -1050,7 +1050,7 @@
     {
       "name": "idempotency-handling",
       "source": "./plugins/idempotency-handling",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Idempotent API operations with idempotency keys, Redis caching, DB constraints. Use for payment systems, webhook retries, safe retries, or encountering duplicate processing, race conditions, key expiry errors.",
       "keywords": [
         "idempotency-handling",
@@ -1065,7 +1065,7 @@
     {
       "name": "image-optimization",
       "source": "./plugins/image-optimization",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Optimizes images for web performance using modern formats, responsive techniques, and lazy loading strategies. Use when improving page load times, implementing responsive images, or preparing assets for production deployment.",
       "keywords": [
         "image-optimization",
@@ -1080,7 +1080,7 @@
     {
       "name": "inspira-ui",
       "source": "./plugins/inspira-ui",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "120+ Vue/Nuxt animated components with TailwindCSS v4, motion-v, GSAP, Three.js. Use for hero sections, 3D effects, interactive backgrounds, or encountering setup, CSS variables, motion-v integration errors.",
       "keywords": [
         "inspira-ui",
@@ -1096,7 +1096,7 @@
     {
       "name": "interaction-design",
       "source": "./plugins/interaction-design",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Creates intuitive user experiences through feedback patterns, microinteractions, and accessible interaction design. Use when designing loading states, error handling UX, animation guidelines, or touch interactions.",
       "keywords": [
         "interaction-design",
@@ -1110,7 +1110,7 @@
     {
       "name": "internationalization-i18n",
       "source": "./plugins/internationalization-i18n",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Implements multi-language support using i18next, gettext, or Intl API with translation workflows and RTL support. Use when building multilingual applications, handling date/currency formatting, or supporting right-to-left languages.",
       "keywords": [
         "internationalization-i18n",
@@ -1124,7 +1124,7 @@
     {
       "name": "jest-generator",
       "source": "./plugins/jest-generator",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Generate Jest unit tests for JavaScript/TypeScript with mocking, coverage. Use for JS/TS modules, React components, test generation, or encountering missing coverage, improper mocking, test structure errors.",
       "keywords": [
         "jest-generator",
@@ -1140,7 +1140,7 @@
     {
       "name": "kpi-dashboard-design",
       "source": "./plugins/kpi-dashboard-design",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Designs effective KPI dashboards with proper metric selection, visual hierarchy, and data visualization best practices. Use when building executive dashboards, creating analytics views, or presenting business metrics.",
       "keywords": [
         "kpi-dashboard-design",
@@ -1155,7 +1155,7 @@
     {
       "name": "logging-best-practices",
       "source": "./plugins/logging-best-practices",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Structured logging with proper levels, context, PII handling, centralized aggregation. Use for application logging, log management integration, distributed tracing, or encountering log bloat, PII exposure, missing context errors.",
       "keywords": [
         "logging-best-practices",
@@ -1171,7 +1171,7 @@
     {
       "name": "maz-ui",
       "source": "./plugins/maz-ui",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Maz-UI v4 - Modern Vue & Nuxt component library with 50+ standalone components, composables, directives, theming, i18n, and SSR support.",
       "keywords": [
         "maz-ui",
@@ -1185,7 +1185,7 @@
     {
       "name": "mcp-dynamic-orchestrator",
       "source": "./plugins/mcp-dynamic-orchestrator",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets.",
       "keywords": [
         "mcp-dynamic-orchestrator",
@@ -1200,7 +1200,7 @@
     {
       "name": "mcp-management",
       "source": "./plugins/mcp-management",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Manage MCP servers - discover, analyze, execute tools/prompts/resources. Use for MCP integrations, capability discovery, tool filtering, programmatic execution, or encountering context bloat, server configuration, tool execution errors.",
       "keywords": [
         "mcp-management",
@@ -1214,7 +1214,7 @@
     {
       "name": "microservices-patterns",
       "source": "./plugins/microservices-patterns",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Design microservices architectures with service boundaries, event-driven communication, and resilience patterns. Use when building distributed systems, decomposing monoliths, or implementing microservices.",
       "keywords": [
         "microservices-patterns",
@@ -1227,7 +1227,7 @@
     {
       "name": "ml-model-training",
       "source": "./plugins/ml-model-training",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Train ML models with scikit-learn, PyTorch, TensorFlow. Use for classification/regression, neural networks, hyperparameter tuning, or encountering overfitting, underfitting, convergence issues.",
       "keywords": [
         "ml-model-training",
@@ -1243,7 +1243,7 @@
     {
       "name": "ml-pipeline-automation",
       "source": "./plugins/ml-pipeline-automation",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Automate ML workflows with Airflow, Kubeflow, MLflow. Use for reproducible pipelines, retraining schedules, MLOps, or encountering task failures, dependency errors, experiment tracking issues.",
       "keywords": [
         "ml-pipeline-automation",
@@ -1258,7 +1258,7 @@
     {
       "name": "mobile-app-debugging",
       "source": "./plugins/mobile-app-debugging",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Mobile app debugging for iOS, Android, cross-platform frameworks. Use for crashes, memory leaks, performance issues, network problems, or encountering Xcode instruments, Android Profiler, React Native debugger, native bridge errors.",
       "keywords": [
         "mobile-app-debugging",
@@ -1272,7 +1272,7 @@
     {
       "name": "mobile-app-testing",
       "source": "./plugins/mobile-app-testing",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Mobile app testing with unit tests, UI automation, performance testing. Use for test infrastructure, E2E tests, testing standards, or encountering test framework setup, device farms, flaky tests, platform-specific test errors.",
       "keywords": [
         "mobile-app-testing",
@@ -1287,7 +1287,7 @@
     {
       "name": "mobile-first-design",
       "source": "./plugins/mobile-first-design",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Designs responsive interfaces starting from mobile screens with progressive enhancement for larger devices. Use when building responsive websites, optimizing for mobile users, or implementing adaptive layouts.",
       "keywords": [
         "mobile-first-design",
@@ -1303,7 +1303,7 @@
     {
       "name": "mobile-offline-support",
       "source": "./plugins/mobile-offline-support",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Offline-first mobile apps with local storage, sync queues, conflict resolution. Use for offline functionality, data sync, connectivity handling, or encountering sync conflicts, queue management, storage limits, network transition errors.",
       "keywords": [
         "mobile-offline-support",
@@ -1317,7 +1317,7 @@
     {
       "name": "model-deployment",
       "source": "./plugins/model-deployment",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Deploy ML models with FastAPI, Docker, Kubernetes. Use for serving predictions, containerization, monitoring, drift detection, or encountering latency issues, health check failures, version conflicts.",
       "keywords": [
         "model-deployment",
@@ -1332,7 +1332,7 @@
     {
       "name": "motion",
       "source": "./plugins/motion",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Motion (Framer Motion) React animation library. Use for drag-and-drop, scroll animations, gestures, SVG morphing, or encountering bundle size, complex transitions, spring physics errors.",
       "keywords": [
         "motion",
@@ -1345,7 +1345,7 @@
     {
       "name": "multi-ai-consultant",
       "source": "./plugins/multi-ai-consultant",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Consult external AIs (Gemini 2.5 Pro, OpenAI Codex, Claude) for second opinions. Use for debugging failures, architectural decisions, security validation, or need fresh perspective with synthesis.",
       "keywords": [
         "multi-ai-consultant",
@@ -1362,7 +1362,7 @@
     {
       "name": "mutation-testing",
       "source": "./plugins/mutation-testing",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.",
       "keywords": [
         "mutation-testing",
@@ -1377,7 +1377,7 @@
     {
       "name": "nano-banana-prompts",
       "source": "./plugins/nano-banana-prompts",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Generate optimized prompts for Gemini 2.5 Flash Image (Nano Banana). Use for image generation, crafting photo prompts, art styles, or multi-turn editing workflows with best practices.",
       "keywords": [
         "nano-banana-prompts",
@@ -1392,7 +1392,7 @@
     {
       "name": "nextjs",
       "source": "./plugins/nextjs",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors.",
       "keywords": [
         "nextjs",
@@ -1407,7 +1407,7 @@
     {
       "name": "nuxt-content",
       "source": "./plugins/nuxt-content",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Nuxt Content v3 Git-backed CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Vercel deployment, SQL storage, MDC components, content collections.",
       "keywords": [
         "nuxt-content",
@@ -1425,7 +1425,7 @@
     {
       "name": "nuxt-seo",
       "source": "./plugins/nuxt-seo",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Comprehensive guide for all 8 Nuxt SEO modules plus Pro modules. Use when building SEO-optimized Nuxt applications, implementing robots.txt/sitemaps, generating OG images, adding Schema.org data, managing meta tags, checking links, or encountering sitemap, robots.txt, OG image, schema validation, meta tag, canonical URL, or i18n SEO errors.",
       "keywords": [
         "nuxt-seo",
@@ -1441,7 +1441,7 @@
     {
       "name": "nuxt-studio",
       "source": "./plugins/nuxt-studio",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Visual CMS for Nuxt Content with Cloudflare deployment. Use when setting up Nuxt Studio, configuring OAuth authentication, deploying to Cloudflare Pages/Workers with subdomain routing, or troubleshooting Studio integration.",
       "keywords": [
         "nuxt-studio",
@@ -1457,7 +1457,7 @@
     {
       "name": "nuxt-ui-v4",
       "source": "./plugins/nuxt-ui-v4",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Nuxt UI v4 with 125+ accessible components, Tailwind v4, Reka UI, AI chat integration with reasoning and tool calling. Use for dashboards, forms, overlays, editors, page layouts, or encountering theming, composable, TypeScript errors.",
       "keywords": [
         "nuxt-ui-v4",
@@ -1470,7 +1470,7 @@
     {
       "name": "nuxt-v4",
       "source": "./plugins/nuxt-v4",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Comprehensive Nuxt 4 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 4 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 3, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
       "keywords": [
         "nuxt-v4",
@@ -1485,7 +1485,7 @@
     {
       "name": "nuxt-v5",
       "source": "./plugins/nuxt-v5",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Comprehensive Nuxt 5 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 5 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 4, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
       "keywords": [
         "nuxt-v5",
@@ -1500,7 +1500,7 @@
     {
       "name": "oauth-implementation",
       "source": "./plugins/oauth-implementation",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "OAuth 2.0 and OpenID Connect authentication with secure flows. Use for third-party integrations, SSO systems, token-based API access, or encountering authorization code flow, PKCE, token refresh, scope management errors.",
       "keywords": [
         "oauth-implementation",
@@ -1520,7 +1520,7 @@
     {
       "name": "payment-gateway-integration",
       "source": "./plugins/payment-gateway-integration",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Integrates payment processing with Stripe, PayPal, or Square including subscriptions, webhooks, and PCI compliance. Use when implementing checkout flows, recurring billing, or handling refunds and disputes.",
       "keywords": [
         "payment-gateway-integration",
@@ -1537,7 +1537,7 @@
     {
       "name": "pinia-colada",
       "source": "./plugins/pinia-colada",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors.",
       "keywords": [
         "pinia-colada",
@@ -1555,7 +1555,7 @@
     {
       "name": "pinia-v3",
       "source": "./plugins/pinia-v3",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors.",
       "keywords": [
         "pinia-v3",
@@ -1570,7 +1570,7 @@
     {
       "name": "plan-interview",
       "source": "./plugins/plan-interview",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Adaptive interview-driven spec generation with quality review. Automatically adjusts depth based on plan complexity.",
       "keywords": [
         "plan-interview",
@@ -1584,7 +1584,7 @@
     {
       "name": "playwright",
       "source": "./plugins/playwright",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Browser automation and E2E testing with Playwright. Auto-detects dev servers, writes clean test scripts. Test pages, fill forms, take screenshots, check responsive design, validate UX, test login flows, check links, automate any browser task. Use for cross-browser testing, visual regression, API testing, component testing in TypeScript/JavaScript and Python projects.",
       "keywords": [
         "playwright",
@@ -1597,7 +1597,7 @@
     {
       "name": "progressive-web-app",
       "source": "./plugins/progressive-web-app",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Builds Progressive Web Apps with service workers, web manifest, offline support, and installation prompts. Use when creating installable web experiences, implementing offline functionality, or adding push notifications to web apps.",
       "keywords": [
         "progressive-web-app",
@@ -1612,7 +1612,7 @@
     {
       "name": "push-notification-setup",
       "source": "./plugins/push-notification-setup",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Implements push notifications across iOS, Android, and web using Firebase Cloud Messaging and native services. Use when adding notification capabilities, handling background messages, or setting up notification channels.",
       "keywords": [
         "push-notification-setup",
@@ -1628,7 +1628,7 @@
     {
       "name": "react-best-practices",
       "source": "./plugins/react-best-practices",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "React and Next.js performance optimization guidelines from Vercel Engineering. Use when writing/reviewing/refactoring React code for optimal performance. Covers async patterns, bundle optimization, server/client components, re-render optimization.",
       "keywords": [
         "react-best-practices",
@@ -1645,7 +1645,7 @@
     {
       "name": "react-composition-patterns",
       "source": "./plugins/react-composition-patterns",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "React composition patterns from Vercel Engineering. Use when building scalable components, avoiding boolean prop proliferation, implementing compound components, or managing component state. Covers architecture, state management, and implementation patterns.",
       "keywords": [
         "react-composition-patterns",
@@ -1662,7 +1662,7 @@
     {
       "name": "react-hook-form-zod",
       "source": "./plugins/react-hook-form-zod",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems.",
       "keywords": [
         "react-hook-form-zod",
@@ -1679,7 +1679,7 @@
     {
       "name": "react-native-skills",
       "source": "./plugins/react-native-skills",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "React Native and Expo best practices for building performant mobile apps. Use when building React Native components, optimizing list performance, implementing animations, or working with native modules.",
       "keywords": [
         "react-native-skills",
@@ -1694,7 +1694,7 @@
     {
       "name": "recommendation-engine",
       "source": "./plugins/recommendation-engine",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Build recommendation systems with collaborative filtering, matrix factorization, hybrid approaches. Use for product recommendations, personalization, or encountering cold start, sparsity, quality evaluation issues.",
       "keywords": [
         "recommendation-engine",
@@ -1711,7 +1711,7 @@
     {
       "name": "recommendation-system",
       "source": "./plugins/recommendation-system",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Deploy production recommendation systems with feature stores, caching, A/B testing. Use for personalization APIs, low latency serving, or encountering cache invalidation, experiment tracking, quality monitoring issues.",
       "keywords": [
         "recommendation-system",
@@ -1729,7 +1729,7 @@
     {
       "name": "responsive-web-design",
       "source": "./plugins/responsive-web-design",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Builds adaptive web interfaces using Flexbox, CSS Grid, and media queries with a mobile-first approach. Use when creating multi-device layouts, implementing flexible UI systems, or ensuring cross-browser compatibility.",
       "keywords": [
         "responsive-web-design",
@@ -1745,7 +1745,7 @@
     {
       "name": "rest-api-design",
       "source": "./plugins/rest-api-design",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Designs RESTful APIs with proper resource naming, HTTP methods, status codes, and response formats. Use when building new APIs, establishing API conventions, or designing developer-friendly interfaces.",
       "keywords": [
         "rest-api-design",
@@ -1761,7 +1761,7 @@
     {
       "name": "root-cause-tracing",
       "source": "./plugins/root-cause-tracing",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Systematically trace bugs backward through call stack to find original trigger. Use when errors occur deep in execution and you need to trace back to find the original trigger.",
       "keywords": [
         "root-cause-tracing",
@@ -1776,7 +1776,7 @@
     {
       "name": "security-headers-configuration",
       "source": "./plugins/security-headers-configuration",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Configures HTTP security headers to protect against XSS, clickjacking, and MIME sniffing attacks. Use when hardening web applications, passing security audits, or implementing Content Security Policy.",
       "keywords": [
         "security-headers-configuration",
@@ -1795,7 +1795,7 @@
     {
       "name": "seo-keyword-cluster-builder",
       "source": "./plugins/seo-keyword-cluster-builder",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Groups related keywords into topic clusters and creates content hub architecture recommendations with internal linking strategies. Use when planning content strategy, organizing keyword research, or building pillar page structures.",
       "keywords": [
         "seo-keyword-cluster-builder",
@@ -1812,7 +1812,7 @@
     {
       "name": "seo-optimizer",
       "source": "./plugins/seo-optimizer",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "SEO optimization with keyword analysis, readability assessment, technical validation, content quality. Use for search rankings, blog posts, content audits, or encountering keyword density, readability scores, meta tags, schema markup errors.",
       "keywords": [
         "seo-optimizer",
@@ -1828,7 +1828,7 @@
     {
       "name": "sequential-thinking",
       "source": "./plugins/sequential-thinking",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Systematic step-by-step reasoning with revision and branching. Use for complex problems, multi-stage analysis, design planning, problem decomposition, or encountering unclear scope, alternative approaches needed, revision requirements.",
       "keywords": [
         "sequential-thinking",
@@ -1842,7 +1842,7 @@
     {
       "name": "session-management",
       "source": "./plugins/session-management",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Implements secure session management with JWT tokens, Redis storage, refresh flows, and proper cookie configuration. Use when building authentication systems, managing user sessions, or implementing secure logout functionality.",
       "keywords": [
         "session-management",
@@ -1859,7 +1859,7 @@
     {
       "name": "shadcn-vue",
       "source": "./plugins/shadcn-vue",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors.",
       "keywords": [
         "shadcn-vue",
@@ -1873,7 +1873,7 @@
     {
       "name": "systematic-debugging",
       "source": "./plugins/systematic-debugging",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Four-phase debugging framework that ensures root cause investigation before attempting fixes. Never jump to solutions. Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes.",
       "keywords": [
         "systematic-debugging",
@@ -1887,7 +1887,7 @@
     {
       "name": "tailwind-v4-shadcn",
       "source": "./plugins/tailwind-v4-shadcn",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React. Use when: initializing React projects with Tailwind v4, setting up shadcn/ui, implementing dark mode, debugging CSS variable issues, fixing theme switching, migrating from Tailwind v3, or encountering color/theming problems. Covers: @theme inline pattern, CSS variable architecture, dark mode with ThemeProvider, component composition, vite.config setup, common v4 gotchas, and production-tested patterns.",
       "keywords": [
         "tailwind-v4-shadcn",
@@ -1903,7 +1903,7 @@
     {
       "name": "tanstack-ai",
       "source": "./plugins/tanstack-ai",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and tool definitions.",
       "keywords": [
         "tanstack-ai",
@@ -1919,7 +1919,7 @@
     {
       "name": "tanstack-query",
       "source": "./plugins/tanstack-query",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors.",
       "keywords": [
         "tanstack-query",
@@ -1935,7 +1935,7 @@
     {
       "name": "tanstack-router",
       "source": "./plugins/tanstack-router",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "TanStack Router type-safe file-based routing for React. Use for SPAs, TanStack Query integration, Cloudflare Workers, or encountering devtools, type safety, loader, Vite bundling errors.",
       "keywords": [
         "tanstack-router",
@@ -1949,7 +1949,7 @@
     {
       "name": "tanstack-start",
       "source": "./plugins/tanstack-start",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "TanStack Start (RC) full-stack React with server functions, SSR, Cloudflare Workers. Use for Next.js migration, edge rendering, or encountering hydration, auth, data pattern errors.",
       "keywords": [
         "tanstack-start",
@@ -1966,7 +1966,7 @@
     {
       "name": "tanstack-table",
       "source": "./plugins/tanstack-table",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "TanStack Table v8 headless data tables with server-side features for Cloudflare Workers + D1. Use for pagination, filtering, sorting, virtualization, or encountering state management, TanStack Query coordination, URL sync errors.",
       "keywords": [
         "tanstack-table",
@@ -1981,7 +1981,7 @@
     {
       "name": "tech-debt",
       "source": "./plugins/tech-debt",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Multi-skill plugin: tech-debt",
       "keywords": [
         "tech-debt",
@@ -1995,7 +1995,7 @@
     {
       "name": "technical-specification",
       "source": "./plugins/technical-specification",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Creates detailed technical specifications for software projects covering requirements, architecture, APIs, and testing strategies. Use when planning features, documenting system design, or creating architecture decision records.",
       "keywords": [
         "technical-specification",
@@ -2011,7 +2011,7 @@
     {
       "name": "test-quality-analysis",
       "source": "./plugins/test-quality-analysis",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Detect test smells, overmocking, flaky tests, and coverage issues. Analyze test effectiveness, maintainability, and reliability. Use when reviewing tests or improving test quality.",
       "keywords": [
         "test-quality-analysis",
@@ -2027,7 +2027,7 @@
     {
       "name": "thesys-generative-ui",
       "source": "./plugins/thesys-generative-ui",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "AI-powered generative UI with Thesys - create React components from natural language.",
       "keywords": [
         "thesys-generative-ui",
@@ -2042,7 +2042,7 @@
     {
       "name": "threejs",
       "source": "./plugins/threejs",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Comprehensive Three.js skills for building 3D web experiences",
       "keywords": [
         "threejs",
@@ -2054,7 +2054,7 @@
     {
       "name": "turborepo",
       "source": "./plugins/turborepo",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Turborepo high-performance monorepo build system. Use for monorepo setup, build optimization, task pipelines, caching strategies, or multi-package orchestration.",
       "keywords": [
         "turborepo",
@@ -2067,7 +2067,7 @@
     {
       "name": "typescript-migration",
       "source": "./plugins/typescript-migration",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "TypeScript version migration guide (5.x to 6 to 7, tsgo native port). Use for TS 6 tsconfig breaking changes, TS 7 Go rewrite rollout, or TS5xxx deprecation codes.",
       "keywords": [
         "typescript-migration",
@@ -2080,7 +2080,7 @@
     {
       "name": "ultracite",
       "source": "./plugins/ultracite",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Ultracite multi-provider linting/formatting (Biome, ESLint, Oxlint). Use for v6/v7 setup, provider selection, Git hooks, MCP integration, AI hooks, migrations, or encountering configuration, type-aware linting, monorepo errors.",
       "keywords": [
         "ultracite",
@@ -2094,7 +2094,7 @@
     {
       "name": "unknowns-discovery",
       "source": "./plugins/unknowns-discovery",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Discover and reduce task unknowns — blindspots, missing context, unknown unknowns — before committing to a plan, implementation, review, or merge.",
       "keywords": [
         "unknowns-discovery",
@@ -2109,7 +2109,7 @@
     {
       "name": "vitest-testing",
       "source": "./plugins/vitest-testing",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Modern TypeScript/JavaScript testing with Vitest. Fast unit and integration tests, native ESM support, Vite-powered HMR, and comprehensive mocking. Use for testing TS/JS projects.",
       "keywords": [
         "vitest-testing",
@@ -2126,7 +2126,7 @@
     {
       "name": "vulnerability-scanning",
       "source": "./plugins/vulnerability-scanning",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Implements automated security scanning for dependencies, code, and containers using tools like Trivy, Snyk, and npm audit. Use when setting up CI/CD security gates, conducting pre-deployment audits, or meeting compliance requirements.",
       "keywords": [
         "vulnerability-scanning",
@@ -2142,7 +2142,7 @@
     {
       "name": "web-performance-audit",
       "source": "./plugins/web-performance-audit",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Web performance audits with Core Web Vitals, bottleneck identification, optimization recommendations. Use for page load times, performance reviews, UX optimization, or encountering LCP, FID, CLS issues, resource blocking, render delays.",
       "keywords": [
         "web-performance-audit",
@@ -2159,7 +2159,7 @@
     {
       "name": "web-performance-optimization",
       "source": "./plugins/web-performance-optimization",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Optimizes web application performance through code splitting, lazy loading, caching strategies, and Core Web Vitals monitoring. Use when improving page load times, implementing service workers, or reducing bundle sizes.",
       "keywords": [
         "web-performance-optimization",
@@ -2174,7 +2174,7 @@
     {
       "name": "websocket-implementation",
       "source": "./plugins/websocket-implementation",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Implements real-time WebSocket communication with connection management, room-based messaging, and horizontal scaling. Use when building chat systems, live notifications, collaborative tools, or real-time dashboards.",
       "keywords": [
         "websocket-implementation",
@@ -2188,7 +2188,7 @@
     {
       "name": "woocommerce-backend-dev",
       "source": "./plugins/woocommerce-backend-dev",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Add or modify WooCommerce backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code in WooCommerce projects.",
       "keywords": [
         "woocommerce-backend-dev",
@@ -2205,7 +2205,7 @@
     {
       "name": "woocommerce-code-review",
       "source": "./plugins/woocommerce-code-review",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Review WooCommerce code changes for coding standards compliance. Use when reviewing code locally, performing automated PR reviews, or checking code quality in WooCommerce projects.",
       "keywords": [
         "woocommerce-code-review",
@@ -2221,7 +2221,7 @@
     {
       "name": "woocommerce-copy-guidelines",
       "source": "./plugins/woocommerce-copy-guidelines",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Guidelines for UI text and copy in WooCommerce. Use when writing user-facing text, labels, buttons, messages, or documentation in WooCommerce projects.",
       "keywords": [
         "woocommerce-copy-guidelines",
@@ -2237,7 +2237,7 @@
     {
       "name": "woocommerce-dev-cycle",
       "source": "./plugins/woocommerce-dev-cycle",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Run tests, linting, and quality checks for WooCommerce development. Use when running tests, fixing code style, or following the development workflow in WooCommerce projects.",
       "keywords": [
         "woocommerce-dev-cycle",
@@ -2253,7 +2253,7 @@
     {
       "name": "wordpress-plugin-core",
       "source": "./plugins/wordpress-plugin-core",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors.",
       "keywords": [
         "wordpress-plugin-core",
@@ -2274,7 +2274,7 @@
     {
       "name": "xss-prevention",
       "source": "./plugins/xss-prevention",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Prevents Cross-Site Scripting attacks through input sanitization, output encoding, and Content Security Policy. Use when handling user-generated content, implementing rich text editors, or securing web applications.",
       "keywords": [
         "xss-prevention",
@@ -2290,8 +2290,8 @@
     {
       "name": "zod",
       "source": "./plugins/zod",
-      "version": "3.7.0",
-      "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies (2kb gzipped).",
+      "version": "3.8.0",
+      "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies, compact core (~5kb gzipped; zod/mini ~1.9kb).",
       "keywords": [
         "zod",
         "tooling",
@@ -2305,7 +2305,7 @@
     {
       "name": "zustand-state-management",
       "source": "./plugins/zustand-state-management",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "description": "Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loops.",
       "keywords": [
         "zustand-state-management",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Production-tested skills for Claude Code - Cloudflare, AI, React, Tailwind v4, and modern web development",
   "scripts": {
     "validate": "./scripts/validate-json-schemas.sh",

--- a/plugins/aceternity-ui/.claude-plugin/plugin.json
+++ b/plugins/aceternity-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aceternity-ui",
   "description": "100+ animated React components (Aceternity UI) for Next.js with Tailwind. Use for hero sections, parallax, 3D effects, or encountering animation, shadcn CLI integration errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/aceternity-ui/.codex-plugin/plugin.json
+++ b/plugins/aceternity-ui/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aceternity-ui",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "100+ animated React components (Aceternity UI) for Next.js with Tailwind. Use for hero sections, parallax, 3D effects, or encountering animation, shadcn CLI integration errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-authentication/.claude-plugin/plugin.json
+++ b/plugins/api-authentication/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-authentication",
   "description": "Secure API authentication with JWT, OAuth 2.0, API keys. Use for authentication systems, third-party integrations, service-to-service communication, or encountering token management, security headers, auth flow errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-authentication/.codex-plugin/plugin.json
+++ b/plugins/api-authentication/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-authentication",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Secure API authentication with JWT, OAuth 2.0, API keys. Use for authentication systems, third-party integrations, service-to-service communication, or encountering token management, security headers, auth flow errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-changelog-versioning/.claude-plugin/plugin.json
+++ b/plugins/api-changelog-versioning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-changelog-versioning",
   "description": "Creates comprehensive API changelogs documenting breaking changes, deprecations, and migration strategies for API consumers. Use when managing API versions, communicating breaking changes, or creating upgrade guides.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-changelog-versioning/.codex-plugin/plugin.json
+++ b/plugins/api-changelog-versioning/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-changelog-versioning",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Creates comprehensive API changelogs documenting breaking changes, deprecations, and migration strategies for API consumers. Use when managing API versions, communicating breaking changes, or creating upgrade guides.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-contract-testing/.claude-plugin/plugin.json
+++ b/plugins/api-contract-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-contract-testing",
   "description": "Verifies API contracts between services using consumer-driven contracts, schema validation, and tools like Pact. Use when testing microservices communication, preventing breaking changes, or validating OpenAPI specifications.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-contract-testing/.codex-plugin/plugin.json
+++ b/plugins/api-contract-testing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-contract-testing",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Verifies API contracts between services using consumer-driven contracts, schema validation, and tools like Pact. Use when testing microservices communication, preventing breaking changes, or validating OpenAPI specifications.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-design-principles/.claude-plugin/plugin.json
+++ b/plugins/api-design-principles/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-design-principles",
   "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewing API specifications, or establishing API design standards.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-design-principles/.codex-plugin/plugin.json
+++ b/plugins/api-design-principles/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-design-principles",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewing API specifications, or establishing API design standards.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-error-handling/.claude-plugin/plugin.json
+++ b/plugins/api-error-handling/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-error-handling",
   "description": "Implements standardized API error responses with proper status codes, logging, and user-friendly messages. Use when building production APIs, implementing error recovery patterns, or integrating error monitoring services.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-error-handling/.codex-plugin/plugin.json
+++ b/plugins/api-error-handling/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-error-handling",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Implements standardized API error responses with proper status codes, logging, and user-friendly messages. Use when building production APIs, implementing error recovery patterns, or integrating error monitoring services.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-filtering-sorting/.claude-plugin/plugin.json
+++ b/plugins/api-filtering-sorting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-filtering-sorting",
   "description": "Builds flexible API filtering and sorting systems with query parameter parsing, validation, and security. Use when implementing search endpoints, building data grids, or creating dynamic query APIs.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-filtering-sorting/.codex-plugin/plugin.json
+++ b/plugins/api-filtering-sorting/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-filtering-sorting",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Builds flexible API filtering and sorting systems with query parameter parsing, validation, and security. Use when implementing search endpoints, building data grids, or creating dynamic query APIs.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-gateway-configuration/.claude-plugin/plugin.json
+++ b/plugins/api-gateway-configuration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-gateway-configuration",
   "description": "Configures API gateways for routing, authentication, rate limiting, and request transformation in microservice architectures. Use when setting up Kong, Nginx, AWS API Gateway, or Traefik for centralized API management.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-gateway-configuration/.codex-plugin/plugin.json
+++ b/plugins/api-gateway-configuration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-gateway-configuration",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Configures API gateways for routing, authentication, rate limiting, and request transformation in microservice architectures. Use when setting up Kong, Nginx, AWS API Gateway, or Traefik for centralized API management.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-pagination/.claude-plugin/plugin.json
+++ b/plugins/api-pagination/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-pagination",
   "description": "Implements efficient API pagination using offset, cursor, and keyset strategies for large datasets. Use when building paginated endpoints, implementing infinite scroll, or optimizing database queries for collections.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-pagination/.codex-plugin/plugin.json
+++ b/plugins/api-pagination/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-pagination",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Implements efficient API pagination using offset, cursor, and keyset strategies for large datasets. Use when building paginated endpoints, implementing infinite scroll, or optimizing database queries for collections.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-rate-limiting/.claude-plugin/plugin.json
+++ b/plugins/api-rate-limiting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-rate-limiting",
   "description": "Implements API rate limiting using token bucket, sliding window, and Redis-based algorithms to protect against abuse. Use when securing public APIs, implementing tiered access, or preventing denial-of-service attacks.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-rate-limiting/.codex-plugin/plugin.json
+++ b/plugins/api-rate-limiting/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-rate-limiting",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Implements API rate limiting using token bucket, sliding window, and Redis-based algorithms to protect against abuse. Use when securing public APIs, implementing tiered access, or preventing denial-of-service attacks.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-reference-documentation/.claude-plugin/plugin.json
+++ b/plugins/api-reference-documentation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-reference-documentation",
   "description": "Creates professional API documentation using OpenAPI specifications with endpoints, authentication, and interactive examples. Use when documenting REST APIs, creating SDK references, or building developer portals.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-reference-documentation/.codex-plugin/plugin.json
+++ b/plugins/api-reference-documentation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-reference-documentation",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Creates professional API documentation using OpenAPI specifications with endpoints, authentication, and interactive examples. Use when documenting REST APIs, creating SDK references, or building developer portals.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-response-optimization/.claude-plugin/plugin.json
+++ b/plugins/api-response-optimization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-response-optimization",
   "description": "Optimizes API performance through payload reduction, caching strategies, and compression techniques. Use when improving API response times, reducing bandwidth usage, or implementing efficient caching.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-response-optimization/.codex-plugin/plugin.json
+++ b/plugins/api-response-optimization/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-response-optimization",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Optimizes API performance through payload reduction, caching strategies, and compression techniques. Use when improving API response times, reducing bandwidth usage, or implementing efficient caching.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-security-hardening/.claude-plugin/plugin.json
+++ b/plugins/api-security-hardening/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-security-hardening",
   "description": "REST API security hardening with authentication, rate limiting, input validation, security headers. Use for production APIs, security audits, defense-in-depth, or encountering vulnerabilities, injection attacks, CORS issues.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-security-hardening/.codex-plugin/plugin.json
+++ b/plugins/api-security-hardening/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-security-hardening",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "REST API security hardening with authentication, rate limiting, input validation, security headers. Use for production APIs, security audits, defense-in-depth, or encountering vulnerabilities, injection attacks, CORS issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-testing/.claude-plugin/plugin.json
+++ b/plugins/api-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-testing",
   "description": "HTTP API testing for TypeScript (Supertest) and Python (httpx, pytest). Test REST APIs, GraphQL, request/response validation, authentication, and error handling.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-testing/.codex-plugin/plugin.json
+++ b/plugins/api-testing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-testing",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "HTTP API testing for TypeScript (Supertest) and Python (httpx, pytest). Test REST APIs, GraphQL, request/response validation, authentication, and error handling.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/api-versioning-strategy/.claude-plugin/plugin.json
+++ b/plugins/api-versioning-strategy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "api-versioning-strategy",
   "description": "Implements API versioning using URL paths, headers, or query parameters with backward compatibility and deprecation strategies. Use when managing multiple API versions, planning breaking changes, or designing migration paths.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/api-versioning-strategy/.codex-plugin/plugin.json
+++ b/plugins/api-versioning-strategy/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "api-versioning-strategy",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Implements API versioning using URL paths, headers, or query parameters with backward compatibility and deprecation strategies. Use when managing multiple API versions, planning breaking changes, or designing migration paths.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/app-store-deployment/.claude-plugin/plugin.json
+++ b/plugins/app-store-deployment/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "app-store-deployment",
   "description": "Publishes mobile applications to iOS App Store and Google Play with code signing, versioning, and CI/CD automation. Use when preparing app releases, configuring signing certificates, or setting up automated deployment pipelines.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/app-store-deployment/.codex-plugin/plugin.json
+++ b/plugins/app-store-deployment/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store-deployment",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Publishes mobile applications to iOS App Store and Google Play with code signing, versioning, and CI/CD automation. Use when preparing app releases, configuring signing certificates, or setting up automated deployment pipelines.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/architecture-patterns/.claude-plugin/plugin.json
+++ b/plugins/architecture-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "architecture-patterns",
   "description": "Implement proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design. Use when architecting complex backend systems or refactoring existing applications for better maintainability.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/architecture-patterns/.codex-plugin/plugin.json
+++ b/plugins/architecture-patterns/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "architecture-patterns",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Implement proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design. Use when architecting complex backend systems or refactoring existing applications for better maintainability.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/auto-animate/.claude-plugin/plugin.json
+++ b/plugins/auto-animate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-animate",
   "description": "AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/auto-animate/.codex-plugin/plugin.json
+++ b/plugins/auto-animate/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-animate",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "AutoAnimate (@formkit/auto-animate) zero-config animations for React. Use for list transitions, accordions, toasts, or encountering SSR errors, animation libraries complexity.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/base-ui-react/.claude-plugin/plugin.json
+++ b/plugins/base-ui-react/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "base-ui-react",
   "description": "MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/base-ui-react/.codex-plugin/plugin.json
+++ b/plugins/base-ui-react/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "base-ui-react",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "MUI Base UI unstyled React components with Floating UI. Use for accessible components, Radix UI migration, render props API, or encountering positioning, popup, v1.0 beta issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/better-auth/.claude-plugin/plugin.json
+++ b/plugins/better-auth/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-auth",
   "description": "Skill for integrating Better Auth - comprehensive TypeScript authentication framework for Cloudflare D1, Next.js, Nuxt, and 15+ frameworks. Use when adding auth, encountering D1 adapter errors, or implementing OAuth/2FA/RBAC features.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/better-auth/.codex-plugin/plugin.json
+++ b/plugins/better-auth/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-auth",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Skill for integrating Better Auth - comprehensive TypeScript authentication framework for Cloudflare D1, Next.js, Nuxt, and 15+ frameworks. Use when adding auth, encountering D1 adapter errors, or implementing OAuth/2FA/RBAC features.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/bun/.claude-plugin/plugin.json
+++ b/plugins/bun/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bun",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Comprehensive Bun runtime toolkit covering runtime, package manager, bundler, testing, HTTP servers, WebSockets, databases, framework integrations (Hono, Next.js, Nuxt, TanStack Start, SvelteKit), deployment, and Node.js compatibility.",
   "author": {
     "name": "Claude Skills",

--- a/plugins/bun/.codex-plugin/plugin.json
+++ b/plugins/bun/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bun",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Comprehensive Bun runtime toolkit covering runtime, package manager, bundler, testing, HTTP servers, WebSockets, databases, framework integrations (Hono, Next.js, Nuxt, TanStack Start, SvelteKit), deployment, and Node.js compatibility.",
   "author": {
     "name": "Claude Skills",

--- a/plugins/claude-code-bash-patterns/.claude-plugin/plugin.json
+++ b/plugins/claude-code-bash-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-bash-patterns",
   "description": "Claude Code Bash tool patterns with hooks, automation, git workflows. Use for PreToolUse hooks, command chaining, CLI orchestration, custom commands, or encountering bash permissions, command failures, security guards, hook configurations.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/claude-code-bash-patterns/.codex-plugin/plugin.json
+++ b/plugins/claude-code-bash-patterns/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-bash-patterns",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Claude Code Bash tool patterns with hooks, automation, git workflows. Use for PreToolUse hooks, command chaining, CLI orchestration, custom commands, or encountering bash permissions, command failures, security guards, hook configurations.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/claude-hook-writer/.claude-plugin/plugin.json
+++ b/plugins/claude-hook-writer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-hook-writer",
   "description": "Expert guidance for writing secure, reliable, and performant Claude Code hooks - validates design decisions, enforces best practices, and prevents common pitfalls. Use when creating, reviewing, or debugging Claude Code hooks.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/claude-hook-writer/.codex-plugin/plugin.json
+++ b/plugins/claude-hook-writer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hook-writer",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Expert guidance for writing secure, reliable, and performant Claude Code hooks - validates design decisions, enforces best practices, and prevents common pitfalls. Use when creating, reviewing, or debugging Claude Code hooks.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-agents/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-agents",
   "description": "Build AI agents on Cloudflare Workers with MCP integration, tool use, and LLM providers.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-agents/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-agents/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-agents",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Build AI agents on Cloudflare Workers with MCP integration, tool use, and LLM providers.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-browser-rendering/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-browser-rendering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-browser-rendering",
   "description": "Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-browser-rendering/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-browser-rendering/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-browser-rendering",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Cloudflare Browser Rendering with Puppeteer/Playwright. Use for screenshots, PDFs, web scraping, or encountering rendering errors, timeout issues, memory exceeded.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-cron-triggers/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-cron-triggers/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-cron-triggers",
   "description": "Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-cron-triggers/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-cron-triggers/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-cron-triggers",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Cloudflare Cron Triggers for scheduled Workers execution. Use for periodic tasks, scheduled jobs, or encountering handler not found, invalid cron expression, timezone errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-d1/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-d1/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-d1",
   "description": "Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-d1/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-d1/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-d1",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Cloudflare D1 serverless SQLite on edge. Use for databases, migrations, bindings, or encountering D1_ERROR, statement too long, too many requests queued errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-durable-objects/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-durable-objects/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-durable-objects",
   "description": "Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-durable-objects/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-durable-objects/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-durable-objects",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Cloudflare Durable Objects for stateful coordination and real-time apps. Use for chat, multiplayer games, WebSocket hibernation, or encountering class export, migration, alarm errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-email-routing/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-email-routing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-email-routing",
   "description": "Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-email-routing/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-email-routing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-email-routing",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Cloudflare Email Routing for receiving/sending emails via Workers. Use for email workers, forwarding, allowlists, or encountering Email Trigger errors, worker call failures, SPF issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-hyperdrive/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-hyperdrive/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-hyperdrive",
   "description": "Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-hyperdrive/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-hyperdrive/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-hyperdrive",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Cloudflare Hyperdrive for Workers-to-database connections with pooling and caching. Use for PostgreSQL/MySQL, Drizzle/Prisma, or encountering pool errors, TLS issues, connection refused.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-images/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-images/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-images",
   "description": "This skill should be used when the user asks to \"upload images to Cloudflare\", \"implement direct creator upload\", \"configure image transformations\", \"optimize WebP/AVIF\", \"create image variants\", \"generate signed URLs\", \"add image watermarks\", \"integrate with Next.js/Remix\", \"configure webhooks\", \"debug CORS errors\", \"troubleshoot error 5408/9401-9413\", or \"build responsive images with Cloudflare Images API\".",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-images/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-images/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-images",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "This skill should be used when the user asks to \"upload images to Cloudflare\", \"implement direct creator upload\", \"configure image transformations\", \"optimize WebP/AVIF\", \"create image variants\", \"generate signed URLs\", \"add image watermarks\", \"integrate with Next.js/Remix\", \"configure webhooks\", \"debug CORS errors\", \"troubleshoot error 5408/9401-9413\", or \"build responsive images with Cloudflare Images API\".",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-kv/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-kv/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-kv",
   "description": "Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-kv/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-kv/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-kv",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Cloudflare Workers KV global key-value storage. Use for namespaces, caching, TTL, or encountering KV_ERROR, 429 rate limits, consistency issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-manager/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-manager/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-manager",
   "description": "Comprehensive Cloudflare account management for deploying Workers, KV Storage, R2, Pages, DNS, and Routes. Use when deploying cloudflare services, managing worker containers, configuring KV/R2 storage, or setting up DNS/routing. Requires CLOUDFLARE_API_KEY in .env and Bun runtime with dependencies installed.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-manager/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-manager/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-manager",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Comprehensive Cloudflare account management for deploying Workers, KV Storage, R2, Pages, DNS, and Routes. Use when deploying cloudflare services, managing worker containers, configuring KV/R2 storage, or setting up DNS/routing. Requires CLOUDFLARE_API_KEY in .env and Bun runtime with dependencies installed.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-mcp-server/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-mcp-server/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-mcp-server",
   "description": "Build MCP (Model Context Protocol) servers on Cloudflare Workers with tools, resources, and prompts.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-mcp-server/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-mcp-server/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-mcp-server",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Build MCP (Model Context Protocol) servers on Cloudflare Workers with tools, resources, and prompts.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-nextjs/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-nextjs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-nextjs",
   "description": "Deploy Next.js to Cloudflare Workers via the OpenNext adapter (@opennextjs/cloudflare). Use for SSR/ISR/SSG, App or Pages Router, getCloudflareContext, bindings (D1/R2/KV/AI/Hyperdrive), caching tiers, skew protection, multi-worker, custom worker, env vars, or worker size/runtime/keep_names/FinalizationRegistry/connection-scoping errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-nextjs/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-nextjs/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-nextjs",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Deploy Next.js to Cloudflare Workers via the OpenNext adapter (@opennextjs/cloudflare). Use for SSR/ISR/SSG, App or Pages Router, getCloudflareContext, bindings (D1/R2/KV/AI/Hyperdrive), caching tiers, skew protection, multi-worker, custom worker, env vars, or worker size/runtime/keep_names/FinalizationRegistry/connection-scoping errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-queues/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-queues/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-queues",
   "description": "This skill should be used when the user asks to \"set up Cloudflare Queues\", \"create a message queue\", \"implement queue consumer\", \"process background jobs\", \"configure queue retry logic\", \"publish messages to queue\", \"implement dead letter queue\", or encountering \"queue timeout\", \"message retry\", \"throughput exceeded\", \"queue backlog\" errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-queues/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-queues/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-queues",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "This skill should be used when the user asks to \"set up Cloudflare Queues\", \"create a message queue\", \"implement queue consumer\", \"process background jobs\", \"configure queue retry logic\", \"publish messages to queue\", \"implement dead letter queue\", or encountering \"queue timeout\", \"message retry\", \"throughput exceeded\", \"queue backlog\" errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-r2/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-r2/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-r2",
   "description": "Cloudflare R2 S3-compatible object storage with SQL, Iceberg, event notifications, and automation. Use for buckets, uploads, CORS, presigned URLs, large files, S3 migration, analytics, or encountering R2_ERROR, CORS failures, multipart issues.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-r2/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-r2/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-r2",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Cloudflare R2 S3-compatible object storage with SQL, Iceberg, event notifications, and automation. Use for buckets, uploads, CORS, presigned URLs, large files, S3 migration, analytics, or encountering R2_ERROR, CORS failures, multipart issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-sandbox/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-sandbox/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-sandbox",
   "description": "Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-sandbox/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-sandbox/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-sandbox",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Cloudflare Sandboxes SDK for secure code execution in Linux containers at edge. Use for untrusted code, Python/Node.js scripts, AI code interpreters, git operations.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-turnstile/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-turnstile/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-turnstile",
   "description": "Cloudflare Turnstile CAPTCHA-alternative bot protection. Use for forms, login security, API protection, or encountering CSP errors, token validation failures, error codes 100*/300*/600*.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-turnstile/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-turnstile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-turnstile",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Cloudflare Turnstile CAPTCHA-alternative bot protection. Use for forms, login security, API protection, or encountering CSP errors, token validation failures, error codes 100*/300*/600*.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-vectorize/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-vectorize/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-vectorize",
   "description": "Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-vectorize/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-vectorize/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-vectorize",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Cloudflare Vectorize vector database for semantic search and RAG. Use for vector indexes, embeddings, similarity search, or encountering dimension mismatches, filter errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-workers-ai/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-workers-ai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-workers-ai",
   "description": "Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-workers-ai/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-workers-ai/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-workers-ai",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Cloudflare Workers AI for serverless GPU inference. Use for LLMs, text/image generation, embeddings, or encountering AI_ERROR, rate limits, token exceeded errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-workers/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-workers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-workers",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Comprehensive Cloudflare Workers platform guide covering runtime APIs, testing (Vitest), CI/CD, observability, framework integration, performance, security, and migration. Use for Workers development, deployment, debugging, or optimization.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-workers/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-workers/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-workers",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Comprehensive Cloudflare Workers platform guide covering runtime APIs, testing (Vitest), CI/CD, observability, framework integration, performance, security, and migration. Use for Workers development, deployment, debugging, or optimization.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-workflows/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-workflows/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-workflows",
   "description": "Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-workflows/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-workflows/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-workflows",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Cloudflare Workflows for durable long-running execution. Use for multi-step workflows, retries, state persistence, or encountering NonRetryableError, execution failed errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cloudflare-zero-trust-access/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-zero-trust-access/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-zero-trust-access",
   "description": "Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cloudflare-zero-trust-access/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-zero-trust-access/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-zero-trust-access",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Cloudflare Zero Trust Access authentication for Workers. Use for JWT validation, service tokens, CORS, or encountering preflight blocking, cache race conditions, missing JWT headers.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review practices with technical rigor and verification gates. Use for receiving feedback, requesting code-reviewer subagent reviews, or preventing false completion claims in pull requests.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/code-review/.codex-plugin/plugin.json
+++ b/plugins/code-review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-review",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Code review practices with technical rigor and verification gates. Use for receiving feedback, requesting code-reviewer subagent reviews, or preventing false completion claims in pull requests.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/csrf-protection/.claude-plugin/plugin.json
+++ b/plugins/csrf-protection/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "csrf-protection",
   "description": "Implements CSRF protection using synchronizer tokens, double-submit cookies, and SameSite attributes. Use when securing web forms, protecting state-changing endpoints, or implementing defense-in-depth authentication.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/csrf-protection/.codex-plugin/plugin.json
+++ b/plugins/csrf-protection/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "csrf-protection",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Implements CSRF protection using synchronizer tokens, double-submit cookies, and SameSite attributes. Use when securing web forms, protecting state-changing endpoints, or implementing defense-in-depth authentication.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/cybersecurity/.claude-plugin/plugin.json
+++ b/plugins/cybersecurity/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cybersecurity",
   "description": "OSS-only security for OWASP Top 10, pentest, vuln testing (XSS, SSRF, CSRF, business-logic, Host header), threat modeling (STRIDE, ATT&CK), Sigma rules, SAST, code audit, AI/LLM red-team, or replacing paid tools (Burp, Nessus, Splunk) with OSS.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/cybersecurity/.codex-plugin/plugin.json
+++ b/plugins/cybersecurity/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cybersecurity",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "OSS-only security for OWASP Top 10, pentest, vuln testing (XSS, SSRF, CSRF, business-logic, Host header), threat modeling (STRIDE, ATT&CK), Sigma rules, SAST, code audit, AI/LLM red-team, or replacing paid tools (Burp, Nessus, Splunk) with OSS.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/defense-in-depth-validation/.claude-plugin/plugin.json
+++ b/plugins/defense-in-depth-validation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "defense-in-depth-validation",
   "description": "Validate at every layer data passes through to make bugs impossible. Use when invalid data causes failures deep in execution, requiring validation at multiple system layers.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/defense-in-depth-validation/.codex-plugin/plugin.json
+++ b/plugins/defense-in-depth-validation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "defense-in-depth-validation",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Validate at every layer data passes through to make bugs impossible. Use when invalid data causes failures deep in execution, requiring validation at multiple system layers.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/delegate-my-work/.claude-plugin/plugin.json
+++ b/plugins/delegate-my-work/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "delegate-my-work",
   "description": "Interview employees to find recurring work, map accessible AI and automation tools, and spec each loop with preferred and fallback routes.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/delegate-my-work/.codex-plugin/plugin.json
+++ b/plugins/delegate-my-work/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "delegate-my-work",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Interview employees to find recurring work, map accessible AI and automation tools, and spec each loop with preferred and fallback routes.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/dependency-upgrade/.claude-plugin/plugin.json
+++ b/plugins/dependency-upgrade/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependency-upgrade",
   "description": "Secure dependency upgrades with supply chain protection, cooldowns, staged rollout, and Socket CLI integration. Use when upgrading deps, configuring security policies, or preventing supply chain attacks.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/dependency-upgrade/.codex-plugin/plugin.json
+++ b/plugins/dependency-upgrade/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-upgrade",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Secure dependency upgrades with supply chain protection, cooldowns, staged rollout, and Socket CLI integration. Use when upgrading deps, configuring security policies, or preventing supply chain attacks.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/design-review/.claude-plugin/plugin.json
+++ b/plugins/design-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "design-review",
   "description": "7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/design-review/.codex-plugin/plugin.json
+++ b/plugins/design-review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "design-review",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "7-phase frontend design review with accessibility (WCAG 2.1 AA), responsive testing, visual polish. Use for PR reviews, UI audits, or encountering contrast issues, broken layouts, accessibility violations, inconsistent spacing, missing focus states.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/design-system-creation/.claude-plugin/plugin.json
+++ b/plugins/design-system-creation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "design-system-creation",
   "description": "Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/design-system-creation/.codex-plugin/plugin.json
+++ b/plugins/design-system-creation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system-creation",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Creates comprehensive design systems with typography, colors, components, and documentation for consistent UI development. Use when establishing design standards, building component libraries, or ensuring cross-team consistency.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/drizzle-orm-d1/.claude-plugin/plugin.json
+++ b/plugins/drizzle-orm-d1/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "drizzle-orm-d1",
   "description": "Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transaction errors, foreign key constraint failures, or schema inference issues.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/drizzle-orm-d1/.codex-plugin/plugin.json
+++ b/plugins/drizzle-orm-d1/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "drizzle-orm-d1",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Type-safe ORM for Cloudflare D1 databases using Drizzle. Use when: building D1 database schemas, writing type-safe SQL queries, managing migrations with Drizzle Kit, defining table relations, implementing prepared statements, using D1 batch API, or encountering D1_ERROR, transaction errors, foreign key constraint failures, or schema inference issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/feature-dev/.claude-plugin/plugin.json
+++ b/plugins/feature-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "feature-dev",
   "description": "Automate 7-phase feature development with specialized agents (code-explorer, code-architect, code-reviewer). Use for multi-file features, architectural decisions, or encountering ambiguous requirements, integration patterns, design approach errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/feature-dev/.codex-plugin/plugin.json
+++ b/plugins/feature-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-dev",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Automate 7-phase feature development with specialized agents (code-explorer, code-architect, code-reviewer). Use for multi-file features, architectural decisions, or encountering ambiguous requirements, integration patterns, design approach errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/firecrawl-scraper/.claude-plugin/plugin.json
+++ b/plugins/firecrawl-scraper/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "firecrawl-scraper",
   "description": "Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/firecrawl-scraper/.codex-plugin/plugin.json
+++ b/plugins/firecrawl-scraper/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-scraper",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Firecrawl v2.5 API for web scraping/crawling to LLM-ready markdown. Use for site extraction, dynamic content, or encountering JavaScript rendering, bot detection, content loading errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/frontend-design/.claude-plugin/plugin.json
+++ b/plugins/frontend-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend-design",
   "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/frontend-design/.codex-plugin/plugin.json
+++ b/plugins/frontend-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-design",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/gemini-cli/.claude-plugin/plugin.json
+++ b/plugins/gemini-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gemini-cli",
   "description": "Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/gemini-cli/.codex-plugin/plugin.json
+++ b/plugins/gemini-cli/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-cli",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Google Gemini CLI for second opinions, architectural advice, code reviews, security audits. Leverage 1M+ context for comprehensive codebase analysis via command-line tool.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/github-project-automation/.claude-plugin/plugin.json
+++ b/plugins/github-project-automation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github-project-automation",
   "description": "GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/github-project-automation/.codex-plugin/plugin.json
+++ b/plugins/github-project-automation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-project-automation",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "GitHub repository automation (CI/CD, issue templates, Dependabot, CodeQL). Use for project setup, Actions workflows, security scanning, or encountering YAML syntax, workflow configuration, template structure errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/graphql-implementation/.claude-plugin/plugin.json
+++ b/plugins/graphql-implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "graphql-implementation",
   "description": "Builds GraphQL APIs with schema design, resolvers, error handling, and performance optimization using Apollo or Graphene. Use when creating flexible query APIs, migrating from REST, or implementing real-time subscriptions.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/graphql-implementation/.codex-plugin/plugin.json
+++ b/plugins/graphql-implementation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-implementation",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Builds GraphQL APIs with schema design, resolvers, error handling, and performance optimization using Apollo or Graphene. Use when creating flexible query APIs, migrating from REST, or implementing real-time subscriptions.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/health-check-endpoints/.claude-plugin/plugin.json
+++ b/plugins/health-check-endpoints/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "health-check-endpoints",
   "description": "Health check endpoints for liveness, readiness, dependency monitoring. Use for Kubernetes, load balancers, auto-scaling, or encountering probe failures, startup delays, dependency checks, timeout configuration errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/health-check-endpoints/.codex-plugin/plugin.json
+++ b/plugins/health-check-endpoints/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "health-check-endpoints",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Health check endpoints for liveness, readiness, dependency monitoring. Use for Kubernetes, load balancers, auto-scaling, or encountering probe failures, startup delays, dependency checks, timeout configuration errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/hono-routing/.claude-plugin/plugin.json
+++ b/plugins/hono-routing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hono-routing",
   "description": "Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/hono-routing/.codex-plugin/plugin.json
+++ b/plugins/hono-routing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hono-routing",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Type-safe Hono APIs with routing, middleware, RPC. Use for request validation, Zod/Valibot validators, or encountering middleware type inference, validation hook, RPC errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/hugo/.claude-plugin/plugin.json
+++ b/plugins/hugo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hugo",
   "description": "Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/hugo/.codex-plugin/plugin.json
+++ b/plugins/hugo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hugo",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Hugo static site generator with Tailwind v4, headless CMS (Sveltia/Tina), Cloudflare deployment. Use for blogs, docs sites, or encountering theme installation, frontmatter, baseURL errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/idempotency-handling/.claude-plugin/plugin.json
+++ b/plugins/idempotency-handling/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "idempotency-handling",
   "description": "Idempotent API operations with idempotency keys, Redis caching, DB constraints. Use for payment systems, webhook retries, safe retries, or encountering duplicate processing, race conditions, key expiry errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/idempotency-handling/.codex-plugin/plugin.json
+++ b/plugins/idempotency-handling/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idempotency-handling",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Idempotent API operations with idempotency keys, Redis caching, DB constraints. Use for payment systems, webhook retries, safe retries, or encountering duplicate processing, race conditions, key expiry errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/image-optimization/.claude-plugin/plugin.json
+++ b/plugins/image-optimization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "image-optimization",
   "description": "Optimizes images for web performance using modern formats, responsive techniques, and lazy loading strategies. Use when improving page load times, implementing responsive images, or preparing assets for production deployment.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/image-optimization/.codex-plugin/plugin.json
+++ b/plugins/image-optimization/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "image-optimization",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Optimizes images for web performance using modern formats, responsive techniques, and lazy loading strategies. Use when improving page load times, implementing responsive images, or preparing assets for production deployment.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/inspira-ui/.claude-plugin/plugin.json
+++ b/plugins/inspira-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inspira-ui",
   "description": "120+ Vue/Nuxt animated components with TailwindCSS v4, motion-v, GSAP, Three.js. Use for hero sections, 3D effects, interactive backgrounds, or encountering setup, CSS variables, motion-v integration errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/inspira-ui/.codex-plugin/plugin.json
+++ b/plugins/inspira-ui/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "inspira-ui",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "120+ Vue/Nuxt animated components with TailwindCSS v4, motion-v, GSAP, Three.js. Use for hero sections, 3D effects, interactive backgrounds, or encountering setup, CSS variables, motion-v integration errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/interaction-design/.claude-plugin/plugin.json
+++ b/plugins/interaction-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "interaction-design",
   "description": "Creates intuitive user experiences through feedback patterns, microinteractions, and accessible interaction design. Use when designing loading states, error handling UX, animation guidelines, or touch interactions.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/interaction-design/.codex-plugin/plugin.json
+++ b/plugins/interaction-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "interaction-design",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Creates intuitive user experiences through feedback patterns, microinteractions, and accessible interaction design. Use when designing loading states, error handling UX, animation guidelines, or touch interactions.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/internationalization-i18n/.claude-plugin/plugin.json
+++ b/plugins/internationalization-i18n/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "internationalization-i18n",
   "description": "Implements multi-language support using i18next, gettext, or Intl API with translation workflows and RTL support. Use when building multilingual applications, handling date/currency formatting, or supporting right-to-left languages.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/internationalization-i18n/.codex-plugin/plugin.json
+++ b/plugins/internationalization-i18n/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "internationalization-i18n",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Implements multi-language support using i18next, gettext, or Intl API with translation workflows and RTL support. Use when building multilingual applications, handling date/currency formatting, or supporting right-to-left languages.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/jest-generator/.claude-plugin/plugin.json
+++ b/plugins/jest-generator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jest-generator",
   "description": "Generate Jest unit tests for JavaScript/TypeScript with mocking, coverage. Use for JS/TS modules, React components, test generation, or encountering missing coverage, improper mocking, test structure errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/jest-generator/.codex-plugin/plugin.json
+++ b/plugins/jest-generator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-generator",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Generate Jest unit tests for JavaScript/TypeScript with mocking, coverage. Use for JS/TS modules, React components, test generation, or encountering missing coverage, improper mocking, test structure errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/kpi-dashboard-design/.claude-plugin/plugin.json
+++ b/plugins/kpi-dashboard-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kpi-dashboard-design",
   "description": "Designs effective KPI dashboards with proper metric selection, visual hierarchy, and data visualization best practices. Use when building executive dashboards, creating analytics views, or presenting business metrics.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/kpi-dashboard-design/.codex-plugin/plugin.json
+++ b/plugins/kpi-dashboard-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kpi-dashboard-design",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Designs effective KPI dashboards with proper metric selection, visual hierarchy, and data visualization best practices. Use when building executive dashboards, creating analytics views, or presenting business metrics.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/logging-best-practices/.claude-plugin/plugin.json
+++ b/plugins/logging-best-practices/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "logging-best-practices",
   "description": "Structured logging with proper levels, context, PII handling, centralized aggregation. Use for application logging, log management integration, distributed tracing, or encountering log bloat, PII exposure, missing context errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/logging-best-practices/.codex-plugin/plugin.json
+++ b/plugins/logging-best-practices/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "logging-best-practices",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Structured logging with proper levels, context, PII handling, centralized aggregation. Use for application logging, log management integration, distributed tracing, or encountering log bloat, PII exposure, missing context errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/maz-ui/.claude-plugin/plugin.json
+++ b/plugins/maz-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maz-ui",
   "description": "Maz-UI v4 - Modern Vue & Nuxt component library with 50+ standalone components, composables, directives, theming, i18n, and SSR support.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/maz-ui/.codex-plugin/plugin.json
+++ b/plugins/maz-ui/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maz-ui",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Maz-UI v4 - Modern Vue & Nuxt component library with 50+ standalone components, composables, directives, theming, i18n, and SSR support.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/mcp-dynamic-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/mcp-dynamic-orchestrator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-dynamic-orchestrator",
   "description": "Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mcp-dynamic-orchestrator/.codex-plugin/plugin.json
+++ b/plugins/mcp-dynamic-orchestrator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-dynamic-orchestrator",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Dynamic MCP server discovery and code-mode execution via central registry. Use for multiple MCP integrations, tool discovery, progressive disclosure, or encountering MCP context bloat, changing server sets, large tool sets.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/mcp-management/.claude-plugin/plugin.json
+++ b/plugins/mcp-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-management",
   "description": "Manage MCP servers - discover, analyze, execute tools/prompts/resources. Use for MCP integrations, capability discovery, tool filtering, programmatic execution, or encountering context bloat, server configuration, tool execution errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mcp-management/.codex-plugin/plugin.json
+++ b/plugins/mcp-management/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-management",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Manage MCP servers - discover, analyze, execute tools/prompts/resources. Use for MCP integrations, capability discovery, tool filtering, programmatic execution, or encountering context bloat, server configuration, tool execution errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/microservices-patterns/.claude-plugin/plugin.json
+++ b/plugins/microservices-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "microservices-patterns",
   "description": "Design microservices architectures with service boundaries, event-driven communication, and resilience patterns. Use when building distributed systems, decomposing monoliths, or implementing microservices.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/microservices-patterns/.codex-plugin/plugin.json
+++ b/plugins/microservices-patterns/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "microservices-patterns",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Design microservices architectures with service boundaries, event-driven communication, and resilience patterns. Use when building distributed systems, decomposing monoliths, or implementing microservices.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/ml-model-training/.claude-plugin/plugin.json
+++ b/plugins/ml-model-training/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-model-training",
   "description": "Train ML models with scikit-learn, PyTorch, TensorFlow. Use for classification/regression, neural networks, hyperparameter tuning, or encountering overfitting, underfitting, convergence issues.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ml-model-training/.codex-plugin/plugin.json
+++ b/plugins/ml-model-training/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ml-model-training",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Train ML models with scikit-learn, PyTorch, TensorFlow. Use for classification/regression, neural networks, hyperparameter tuning, or encountering overfitting, underfitting, convergence issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/ml-pipeline-automation/.claude-plugin/plugin.json
+++ b/plugins/ml-pipeline-automation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ml-pipeline-automation",
   "description": "Automate ML workflows with Airflow, Kubeflow, MLflow. Use for reproducible pipelines, retraining schedules, MLOps, or encountering task failures, dependency errors, experiment tracking issues.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ml-pipeline-automation/.codex-plugin/plugin.json
+++ b/plugins/ml-pipeline-automation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ml-pipeline-automation",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Automate ML workflows with Airflow, Kubeflow, MLflow. Use for reproducible pipelines, retraining schedules, MLOps, or encountering task failures, dependency errors, experiment tracking issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/mobile-app-debugging/.claude-plugin/plugin.json
+++ b/plugins/mobile-app-debugging/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-app-debugging",
   "description": "Mobile app debugging for iOS, Android, cross-platform frameworks. Use for crashes, memory leaks, performance issues, network problems, or encountering Xcode instruments, Android Profiler, React Native debugger, native bridge errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-app-debugging/.codex-plugin/plugin.json
+++ b/plugins/mobile-app-debugging/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-app-debugging",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Mobile app debugging for iOS, Android, cross-platform frameworks. Use for crashes, memory leaks, performance issues, network problems, or encountering Xcode instruments, Android Profiler, React Native debugger, native bridge errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/mobile-app-testing/.claude-plugin/plugin.json
+++ b/plugins/mobile-app-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-app-testing",
   "description": "Mobile app testing with unit tests, UI automation, performance testing. Use for test infrastructure, E2E tests, testing standards, or encountering test framework setup, device farms, flaky tests, platform-specific test errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-app-testing/.codex-plugin/plugin.json
+++ b/plugins/mobile-app-testing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-app-testing",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Mobile app testing with unit tests, UI automation, performance testing. Use for test infrastructure, E2E tests, testing standards, or encountering test framework setup, device farms, flaky tests, platform-specific test errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/mobile-first-design/.claude-plugin/plugin.json
+++ b/plugins/mobile-first-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-first-design",
   "description": "Designs responsive interfaces starting from mobile screens with progressive enhancement for larger devices. Use when building responsive websites, optimizing for mobile users, or implementing adaptive layouts.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-first-design/.codex-plugin/plugin.json
+++ b/plugins/mobile-first-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-first-design",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Designs responsive interfaces starting from mobile screens with progressive enhancement for larger devices. Use when building responsive websites, optimizing for mobile users, or implementing adaptive layouts.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/mobile-offline-support/.claude-plugin/plugin.json
+++ b/plugins/mobile-offline-support/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-offline-support",
   "description": "Offline-first mobile apps with local storage, sync queues, conflict resolution. Use for offline functionality, data sync, connectivity handling, or encountering sync conflicts, queue management, storage limits, network transition errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mobile-offline-support/.codex-plugin/plugin.json
+++ b/plugins/mobile-offline-support/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-offline-support",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Offline-first mobile apps with local storage, sync queues, conflict resolution. Use for offline functionality, data sync, connectivity handling, or encountering sync conflicts, queue management, storage limits, network transition errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/model-deployment/.claude-plugin/plugin.json
+++ b/plugins/model-deployment/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "model-deployment",
   "description": "Deploy ML models with FastAPI, Docker, Kubernetes. Use for serving predictions, containerization, monitoring, drift detection, or encountering latency issues, health check failures, version conflicts.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/model-deployment/.codex-plugin/plugin.json
+++ b/plugins/model-deployment/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "model-deployment",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Deploy ML models with FastAPI, Docker, Kubernetes. Use for serving predictions, containerization, monitoring, drift detection, or encountering latency issues, health check failures, version conflicts.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/motion/.claude-plugin/plugin.json
+++ b/plugins/motion/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "motion",
   "description": "Motion (Framer Motion) React animation library. Use for drag-and-drop, scroll animations, gestures, SVG morphing, or encountering bundle size, complex transitions, spring physics errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/motion/.codex-plugin/plugin.json
+++ b/plugins/motion/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "motion",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Motion (Framer Motion) React animation library. Use for drag-and-drop, scroll animations, gestures, SVG morphing, or encountering bundle size, complex transitions, spring physics errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/multi-ai-consultant/.claude-plugin/plugin.json
+++ b/plugins/multi-ai-consultant/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "multi-ai-consultant",
   "description": "Consult external AIs (Gemini 2.5 Pro, OpenAI Codex, Claude) for second opinions. Use for debugging failures, architectural decisions, security validation, or need fresh perspective with synthesis.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/multi-ai-consultant/.codex-plugin/plugin.json
+++ b/plugins/multi-ai-consultant/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-ai-consultant",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Consult external AIs (Gemini 2.5 Pro, OpenAI Codex, Claude) for second opinions. Use for debugging failures, architectural decisions, security validation, or need fresh perspective with synthesis.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/mutation-testing/.claude-plugin/plugin.json
+++ b/plugins/mutation-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mutation-testing",
   "description": "Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/mutation-testing/.codex-plugin/plugin.json
+++ b/plugins/mutation-testing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mutation-testing",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Validate test effectiveness with mutation testing using Stryker (TypeScript/JavaScript) and mutmut (Python). Find weak tests that pass despite code mutations. Use to improve test quality.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nano-banana-prompts/.claude-plugin/plugin.json
+++ b/plugins/nano-banana-prompts/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nano-banana-prompts",
   "description": "Generate optimized prompts for Gemini 2.5 Flash Image (Nano Banana). Use for image generation, crafting photo prompts, art styles, or multi-turn editing workflows with best practices.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nano-banana-prompts/.codex-plugin/plugin.json
+++ b/plugins/nano-banana-prompts/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-banana-prompts",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Generate optimized prompts for Gemini 2.5 Flash Image (Nano Banana). Use for image generation, crafting photo prompts, art styles, or multi-turn editing workflows with best practices.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nextjs/.claude-plugin/plugin.json
+++ b/plugins/nextjs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nextjs",
   "description": "Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nextjs/.codex-plugin/plugin.json
+++ b/plugins/nextjs/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Next.js 16 with App Router, Server Components, Server Actions, Cache Components. Use for React 19.2 apps, SSR, or encountering async params, proxy.ts migration, use cache errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-content/.claude-plugin/plugin.json
+++ b/plugins/nuxt-content/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-content",
   "description": "Nuxt Content v3 Git-backed CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Vercel deployment, SQL storage, MDC components, content collections.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-content/.codex-plugin/plugin.json
+++ b/plugins/nuxt-content/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-content",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Nuxt Content v3 Git-backed CMS for Markdown/MDC content sites. Use for blogs, docs, content-driven apps with type-safe queries, schema validation (Zod/Valibot), full-text search, navigation utilities. Supports Nuxt Studio production editing, Cloudflare D1/Pages deployment, Vercel deployment, SQL storage, MDC components, content collections.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-seo/.claude-plugin/plugin.json
+++ b/plugins/nuxt-seo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-seo",
   "description": "Comprehensive guide for all 8 Nuxt SEO modules plus Pro modules. Use when building SEO-optimized Nuxt applications, implementing robots.txt/sitemaps, generating OG images, adding Schema.org data, managing meta tags, checking links, or encountering sitemap, robots.txt, OG image, schema validation, meta tag, canonical URL, or i18n SEO errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-seo/.codex-plugin/plugin.json
+++ b/plugins/nuxt-seo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-seo",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Comprehensive guide for all 8 Nuxt SEO modules plus Pro modules. Use when building SEO-optimized Nuxt applications, implementing robots.txt/sitemaps, generating OG images, adding Schema.org data, managing meta tags, checking links, or encountering sitemap, robots.txt, OG image, schema validation, meta tag, canonical URL, or i18n SEO errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-studio/.claude-plugin/plugin.json
+++ b/plugins/nuxt-studio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-studio",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Visual CMS for Nuxt Content with Cloudflare deployment. Use when setting up Nuxt Studio, configuring OAuth authentication, deploying to Cloudflare Pages/Workers with subdomain routing, or troubleshooting Studio integration.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-studio/.codex-plugin/plugin.json
+++ b/plugins/nuxt-studio/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-studio",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Visual CMS for Nuxt Content with Cloudflare deployment. Use when setting up Nuxt Studio, configuring OAuth authentication, deploying to Cloudflare Pages/Workers with subdomain routing, or troubleshooting Studio integration.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-ui-v4/.claude-plugin/plugin.json
+++ b/plugins/nuxt-ui-v4/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-ui-v4",
   "description": "Nuxt UI v4 with 125+ accessible components, Tailwind v4, Reka UI, AI chat integration with reasoning and tool calling. Use for dashboards, forms, overlays, editors, page layouts, or encountering theming, composable, TypeScript errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-ui-v4/.codex-plugin/plugin.json
+++ b/plugins/nuxt-ui-v4/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-ui-v4",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Nuxt UI v4 with 125+ accessible components, Tailwind v4, Reka UI, AI chat integration with reasoning and tool calling. Use for dashboards, forms, overlays, editors, page layouts, or encountering theming, composable, TypeScript errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-v4/.claude-plugin/plugin.json
+++ b/plugins/nuxt-v4/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-v4",
   "description": "Comprehensive Nuxt 4 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 4 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 3, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-v4/.codex-plugin/plugin.json
+++ b/plugins/nuxt-v4/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-v4",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Comprehensive Nuxt 4 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 4 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 3, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/nuxt-v5/.claude-plugin/plugin.json
+++ b/plugins/nuxt-v5/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-v5",
   "description": "Comprehensive Nuxt 5 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 5 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 4, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/nuxt-v5/.codex-plugin/plugin.json
+++ b/plugins/nuxt-v5/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-v5",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Comprehensive Nuxt 5 development with 4 focused skills (core, data, server, production), 3 diagnostic agents (debugger, migration, performance), and interactive setup wizard. Use when: building Nuxt 5 applications, implementing SSR patterns, creating composables, server routes, data fetching, state management, debugging hydration issues, migrating from Nuxt 4, optimizing performance, deploying to Cloudflare/Vercel/Netlify, or setting up testing with Vitest.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/oauth-implementation/.claude-plugin/plugin.json
+++ b/plugins/oauth-implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oauth-implementation",
   "description": "OAuth 2.0 and OpenID Connect authentication with secure flows. Use for third-party integrations, SSO systems, token-based API access, or encountering authorization code flow, PKCE, token refresh, scope management errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/oauth-implementation/.codex-plugin/plugin.json
+++ b/plugins/oauth-implementation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth-implementation",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "OAuth 2.0 and OpenID Connect authentication with secure flows. Use for third-party integrations, SSO systems, token-based API access, or encountering authorization code flow, PKCE, token refresh, scope management errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/payment-gateway-integration/.claude-plugin/plugin.json
+++ b/plugins/payment-gateway-integration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "payment-gateway-integration",
   "description": "Integrates payment processing with Stripe, PayPal, or Square including subscriptions, webhooks, and PCI compliance. Use when implementing checkout flows, recurring billing, or handling refunds and disputes.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/payment-gateway-integration/.codex-plugin/plugin.json
+++ b/plugins/payment-gateway-integration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "payment-gateway-integration",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Integrates payment processing with Stripe, PayPal, or Square including subscriptions, webhooks, and PCI compliance. Use when implementing checkout flows, recurring billing, or handling refunds and disputes.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/pinia-colada/.claude-plugin/plugin.json
+++ b/plugins/pinia-colada/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pinia-colada",
   "description": "Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/pinia-colada/.codex-plugin/plugin.json
+++ b/plugins/pinia-colada/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pinia-colada",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Pinia Colada data fetching for Vue/Nuxt with useQuery, useMutation. Use for async state, query cache, SSR, or encountering invalidation, hydration, TanStack Vue Query migration errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/pinia-v3/.claude-plugin/plugin.json
+++ b/plugins/pinia-v3/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pinia-v3",
   "description": "Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/pinia-v3/.codex-plugin/plugin.json
+++ b/plugins/pinia-v3/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pinia-v3",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Pinia v3 Vue state management with defineStore, getters, actions. Use for Vue 3 stores, Nuxt SSR, Vuex migration, or encountering store composition, hydration, testing errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/plan-interview/.claude-plugin/plugin.json
+++ b/plugins/plan-interview/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-interview",
   "description": "Adaptive interview-driven spec generation with quality review. Automatically adjusts depth based on plan complexity.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/plan-interview/.codex-plugin/plugin.json
+++ b/plugins/plan-interview/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plan-interview",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Adaptive interview-driven spec generation with quality review. Automatically adjusts depth based on plan complexity.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/playwright/.claude-plugin/plugin.json
+++ b/plugins/playwright/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright",
   "description": "Browser automation and E2E testing with Playwright. Auto-detects dev servers, writes clean test scripts. Test pages, fill forms, take screenshots, check responsive design, validate UX, test login flows, check links, automate any browser task. Use for cross-browser testing, visual regression, API testing, component testing in TypeScript/JavaScript and Python projects.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/playwright/.codex-plugin/plugin.json
+++ b/plugins/playwright/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Browser automation and E2E testing with Playwright. Auto-detects dev servers, writes clean test scripts. Test pages, fill forms, take screenshots, check responsive design, validate UX, test login flows, check links, automate any browser task. Use for cross-browser testing, visual regression, API testing, component testing in TypeScript/JavaScript and Python projects.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/progressive-web-app/.claude-plugin/plugin.json
+++ b/plugins/progressive-web-app/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "progressive-web-app",
   "description": "Builds Progressive Web Apps with service workers, web manifest, offline support, and installation prompts. Use when creating installable web experiences, implementing offline functionality, or adding push notifications to web apps.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/progressive-web-app/.codex-plugin/plugin.json
+++ b/plugins/progressive-web-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "progressive-web-app",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Builds Progressive Web Apps with service workers, web manifest, offline support, and installation prompts. Use when creating installable web experiences, implementing offline functionality, or adding push notifications to web apps.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/push-notification-setup/.claude-plugin/plugin.json
+++ b/plugins/push-notification-setup/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "push-notification-setup",
   "description": "Implements push notifications across iOS, Android, and web using Firebase Cloud Messaging and native services. Use when adding notification capabilities, handling background messages, or setting up notification channels.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/push-notification-setup/.codex-plugin/plugin.json
+++ b/plugins/push-notification-setup/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "push-notification-setup",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Implements push notifications across iOS, Android, and web using Firebase Cloud Messaging and native services. Use when adding notification capabilities, handling background messages, or setting up notification channels.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/react-best-practices/.claude-plugin/plugin.json
+++ b/plugins/react-best-practices/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-best-practices",
   "description": "React and Next.js performance optimization guidelines from Vercel Engineering. Use when writing/reviewing/refactoring React code for optimal performance. Covers async patterns, bundle optimization, server/client components, re-render optimization.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-best-practices/.codex-plugin/plugin.json
+++ b/plugins/react-best-practices/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-best-practices",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "React and Next.js performance optimization guidelines from Vercel Engineering. Use when writing/reviewing/refactoring React code for optimal performance. Covers async patterns, bundle optimization, server/client components, re-render optimization.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/react-composition-patterns/.claude-plugin/plugin.json
+++ b/plugins/react-composition-patterns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-composition-patterns",
   "description": "React composition patterns from Vercel Engineering. Use when building scalable components, avoiding boolean prop proliferation, implementing compound components, or managing component state. Covers architecture, state management, and implementation patterns.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-composition-patterns/.codex-plugin/plugin.json
+++ b/plugins/react-composition-patterns/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-composition-patterns",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "React composition patterns from Vercel Engineering. Use when building scalable components, avoiding boolean prop proliferation, implementing compound components, or managing component state. Covers architecture, state management, and implementation patterns.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/react-hook-form-zod/.claude-plugin/plugin.json
+++ b/plugins/react-hook-form-zod/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-hook-form-zod",
   "description": "Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-hook-form-zod/.codex-plugin/plugin.json
+++ b/plugins/react-hook-form-zod/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hook-form-zod",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Type-safe React forms with React Hook Form and Zod validation. Use for form schemas, field arrays, multi-step forms, or encountering validation errors, resolver issues, nested field problems.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/react-native-skills/.claude-plugin/plugin.json
+++ b/plugins/react-native-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-skills",
   "description": "React Native and Expo best practices for building performant mobile apps. Use when building React Native components, optimizing list performance, implementing animations, or working with native modules.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/react-native-skills/.codex-plugin/plugin.json
+++ b/plugins/react-native-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-skills",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "React Native and Expo best practices for building performant mobile apps. Use when building React Native components, optimizing list performance, implementing animations, or working with native modules.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/recommendation-engine/.claude-plugin/plugin.json
+++ b/plugins/recommendation-engine/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "recommendation-engine",
   "description": "Build recommendation systems with collaborative filtering, matrix factorization, hybrid approaches. Use for product recommendations, personalization, or encountering cold start, sparsity, quality evaluation issues.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/recommendation-engine/.codex-plugin/plugin.json
+++ b/plugins/recommendation-engine/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "recommendation-engine",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Build recommendation systems with collaborative filtering, matrix factorization, hybrid approaches. Use for product recommendations, personalization, or encountering cold start, sparsity, quality evaluation issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/recommendation-system/.claude-plugin/plugin.json
+++ b/plugins/recommendation-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "recommendation-system",
   "description": "Deploy production recommendation systems with feature stores, caching, A/B testing. Use for personalization APIs, low latency serving, or encountering cache invalidation, experiment tracking, quality monitoring issues.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/recommendation-system/.codex-plugin/plugin.json
+++ b/plugins/recommendation-system/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "recommendation-system",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Deploy production recommendation systems with feature stores, caching, A/B testing. Use for personalization APIs, low latency serving, or encountering cache invalidation, experiment tracking, quality monitoring issues.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/responsive-web-design/.claude-plugin/plugin.json
+++ b/plugins/responsive-web-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "responsive-web-design",
   "description": "Builds adaptive web interfaces using Flexbox, CSS Grid, and media queries with a mobile-first approach. Use when creating multi-device layouts, implementing flexible UI systems, or ensuring cross-browser compatibility.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/responsive-web-design/.codex-plugin/plugin.json
+++ b/plugins/responsive-web-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "responsive-web-design",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Builds adaptive web interfaces using Flexbox, CSS Grid, and media queries with a mobile-first approach. Use when creating multi-device layouts, implementing flexible UI systems, or ensuring cross-browser compatibility.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/rest-api-design/.claude-plugin/plugin.json
+++ b/plugins/rest-api-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rest-api-design",
   "description": "Designs RESTful APIs with proper resource naming, HTTP methods, status codes, and response formats. Use when building new APIs, establishing API conventions, or designing developer-friendly interfaces.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/rest-api-design/.codex-plugin/plugin.json
+++ b/plugins/rest-api-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-api-design",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Designs RESTful APIs with proper resource naming, HTTP methods, status codes, and response formats. Use when building new APIs, establishing API conventions, or designing developer-friendly interfaces.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/root-cause-tracing/.claude-plugin/plugin.json
+++ b/plugins/root-cause-tracing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "root-cause-tracing",
   "description": "Systematically trace bugs backward through call stack to find original trigger. Use when errors occur deep in execution and you need to trace back to find the original trigger.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/root-cause-tracing/.codex-plugin/plugin.json
+++ b/plugins/root-cause-tracing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "root-cause-tracing",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Systematically trace bugs backward through call stack to find original trigger. Use when errors occur deep in execution and you need to trace back to find the original trigger.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/security-headers-configuration/.claude-plugin/plugin.json
+++ b/plugins/security-headers-configuration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "security-headers-configuration",
   "description": "Configures HTTP security headers to protect against XSS, clickjacking, and MIME sniffing attacks. Use when hardening web applications, passing security audits, or implementing Content Security Policy.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/security-headers-configuration/.codex-plugin/plugin.json
+++ b/plugins/security-headers-configuration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-headers-configuration",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Configures HTTP security headers to protect against XSS, clickjacking, and MIME sniffing attacks. Use when hardening web applications, passing security audits, or implementing Content Security Policy.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/seo-keyword-cluster-builder/.claude-plugin/plugin.json
+++ b/plugins/seo-keyword-cluster-builder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seo-keyword-cluster-builder",
   "description": "Groups related keywords into topic clusters and creates content hub architecture recommendations with internal linking strategies. Use when planning content strategy, organizing keyword research, or building pillar page structures.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/seo-keyword-cluster-builder/.codex-plugin/plugin.json
+++ b/plugins/seo-keyword-cluster-builder/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "seo-keyword-cluster-builder",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Groups related keywords into topic clusters and creates content hub architecture recommendations with internal linking strategies. Use when planning content strategy, organizing keyword research, or building pillar page structures.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/seo-optimizer/.claude-plugin/plugin.json
+++ b/plugins/seo-optimizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "seo-optimizer",
   "description": "SEO optimization with keyword analysis, readability assessment, technical validation, content quality. Use for search rankings, blog posts, content audits, or encountering keyword density, readability scores, meta tags, schema markup errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/seo-optimizer/.codex-plugin/plugin.json
+++ b/plugins/seo-optimizer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "seo-optimizer",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "SEO optimization with keyword analysis, readability assessment, technical validation, content quality. Use for search rankings, blog posts, content audits, or encountering keyword density, readability scores, meta tags, schema markup errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/sequential-thinking/.claude-plugin/plugin.json
+++ b/plugins/sequential-thinking/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sequential-thinking",
   "description": "Systematic step-by-step reasoning with revision and branching. Use for complex problems, multi-stage analysis, design planning, problem decomposition, or encountering unclear scope, alternative approaches needed, revision requirements.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/sequential-thinking/.codex-plugin/plugin.json
+++ b/plugins/sequential-thinking/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sequential-thinking",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Systematic step-by-step reasoning with revision and branching. Use for complex problems, multi-stage analysis, design planning, problem decomposition, or encountering unclear scope, alternative approaches needed, revision requirements.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/session-management/.claude-plugin/plugin.json
+++ b/plugins/session-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "session-management",
   "description": "Implements secure session management with JWT tokens, Redis storage, refresh flows, and proper cookie configuration. Use when building authentication systems, managing user sessions, or implementing secure logout functionality.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/session-management/.codex-plugin/plugin.json
+++ b/plugins/session-management/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "session-management",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Implements secure session management with JWT tokens, Redis storage, refresh flows, and proper cookie configuration. Use when building authentication systems, managing user sessions, or implementing secure logout functionality.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/shadcn-vue/.claude-plugin/plugin.json
+++ b/plugins/shadcn-vue/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shadcn-vue",
   "description": "shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/shadcn-vue/.codex-plugin/plugin.json
+++ b/plugins/shadcn-vue/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shadcn-vue",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "shadcn-vue for Vue/Nuxt with Reka UI components and Tailwind. Use for accessible UI, Auto Form, data tables, charts, or encountering component imports, dark mode, Reka UI errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/systematic-debugging/.claude-plugin/plugin.json
+++ b/plugins/systematic-debugging/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "systematic-debugging",
   "description": "Four-phase debugging framework that ensures root cause investigation before attempting fixes. Never jump to solutions. Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/systematic-debugging/.codex-plugin/plugin.json
+++ b/plugins/systematic-debugging/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "systematic-debugging",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Four-phase debugging framework that ensures root cause investigation before attempting fixes. Never jump to solutions. Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/tailwind-v4-shadcn/.claude-plugin/plugin.json
+++ b/plugins/tailwind-v4-shadcn/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tailwind-v4-shadcn",
   "description": "Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React. Use when: initializing React projects with Tailwind v4, setting up shadcn/ui, implementing dark mode, debugging CSS variable issues, fixing theme switching, migrating from Tailwind v3, or encountering color/theming problems. Covers: @theme inline pattern, CSS variable architecture, dark mode with ThemeProvider, component composition, vite.config setup, common v4 gotchas, and production-tested patterns.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tailwind-v4-shadcn/.codex-plugin/plugin.json
+++ b/plugins/tailwind-v4-shadcn/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-v4-shadcn",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Production-tested setup for Tailwind CSS v4 with shadcn/ui, Vite, and React. Use when: initializing React projects with Tailwind v4, setting up shadcn/ui, implementing dark mode, debugging CSS variable issues, fixing theme switching, migrating from Tailwind v3, or encountering color/theming problems. Covers: @theme inline pattern, CSS variable architecture, dark mode with ThemeProvider, component composition, vite.config setup, common v4 gotchas, and production-tested patterns.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/tanstack-ai/.claude-plugin/plugin.json
+++ b/plugins/tanstack-ai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-ai",
   "description": "TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and tool definitions.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-ai/.codex-plugin/plugin.json
+++ b/plugins/tanstack-ai/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-ai",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "TanStack AI (alpha) provider-agnostic type-safe chat with streaming for OpenAI, Anthropic, Gemini, Ollama. Use for chat APIs, React/Solid frontends with useChat/ChatClient, isomorphic tools, tool approval flows, agent loops, multimodal inputs, or troubleshooting streaming and tool definitions.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/tanstack-query/.claude-plugin/plugin.json
+++ b/plugins/tanstack-query/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-query",
   "description": "TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-query/.codex-plugin/plugin.json
+++ b/plugins/tanstack-query/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-query",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "TanStack Query v5 (React Query) server state management. Use for data fetching, caching, mutations, or encountering v4 migration, stale data, invalidation errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/tanstack-router/.claude-plugin/plugin.json
+++ b/plugins/tanstack-router/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-router",
   "description": "TanStack Router type-safe file-based routing for React. Use for SPAs, TanStack Query integration, Cloudflare Workers, or encountering devtools, type safety, loader, Vite bundling errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-router/.codex-plugin/plugin.json
+++ b/plugins/tanstack-router/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-router",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "TanStack Router type-safe file-based routing for React. Use for SPAs, TanStack Query integration, Cloudflare Workers, or encountering devtools, type safety, loader, Vite bundling errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/tanstack-start/.claude-plugin/plugin.json
+++ b/plugins/tanstack-start/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-start",
   "description": "TanStack Start (RC) full-stack React with server functions, SSR, Cloudflare Workers. Use for Next.js migration, edge rendering, or encountering hydration, auth, data pattern errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-start/.codex-plugin/plugin.json
+++ b/plugins/tanstack-start/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-start",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "TanStack Start (RC) full-stack React with server functions, SSR, Cloudflare Workers. Use for Next.js migration, edge rendering, or encountering hydration, auth, data pattern errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/tanstack-table/.claude-plugin/plugin.json
+++ b/plugins/tanstack-table/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tanstack-table",
   "description": "TanStack Table v8 headless data tables with server-side features for Cloudflare Workers + D1. Use for pagination, filtering, sorting, virtualization, or encountering state management, TanStack Query coordination, URL sync errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tanstack-table/.codex-plugin/plugin.json
+++ b/plugins/tanstack-table/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-table",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "TanStack Table v8 headless data tables with server-side features for Cloudflare Workers + D1. Use for pagination, filtering, sorting, virtualization, or encountering state management, TanStack Query coordination, URL sync errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/tech-debt/.claude-plugin/plugin.json
+++ b/plugins/tech-debt/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tech-debt",
   "description": "Multi-skill plugin: tech-debt",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/tech-debt/.codex-plugin/plugin.json
+++ b/plugins/tech-debt/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tech-debt",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Multi-skill plugin: tech-debt",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/technical-specification/.claude-plugin/plugin.json
+++ b/plugins/technical-specification/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "technical-specification",
   "description": "Creates detailed technical specifications for software projects covering requirements, architecture, APIs, and testing strategies. Use when planning features, documenting system design, or creating architecture decision records.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/technical-specification/.codex-plugin/plugin.json
+++ b/plugins/technical-specification/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "technical-specification",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Creates detailed technical specifications for software projects covering requirements, architecture, APIs, and testing strategies. Use when planning features, documenting system design, or creating architecture decision records.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/test-quality-analysis/.claude-plugin/plugin.json
+++ b/plugins/test-quality-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "test-quality-analysis",
   "description": "Detect test smells, overmocking, flaky tests, and coverage issues. Analyze test effectiveness, maintainability, and reliability. Use when reviewing tests or improving test quality.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/test-quality-analysis/.codex-plugin/plugin.json
+++ b/plugins/test-quality-analysis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "test-quality-analysis",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Detect test smells, overmocking, flaky tests, and coverage issues. Analyze test effectiveness, maintainability, and reliability. Use when reviewing tests or improving test quality.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/thesys-generative-ui/.claude-plugin/plugin.json
+++ b/plugins/thesys-generative-ui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thesys-generative-ui",
   "description": "AI-powered generative UI with Thesys - create React components from natural language.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/thesys-generative-ui/.codex-plugin/plugin.json
+++ b/plugins/thesys-generative-ui/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "thesys-generative-ui",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "AI-powered generative UI with Thesys - create React components from natural language.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/threejs/.claude-plugin/plugin.json
+++ b/plugins/threejs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "threejs",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Comprehensive Three.js skills for building 3D web experiences",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/threejs/.codex-plugin/plugin.json
+++ b/plugins/threejs/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "threejs",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Comprehensive Three.js skills for building 3D web experiences",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/turborepo/.claude-plugin/plugin.json
+++ b/plugins/turborepo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "turborepo",
   "description": "Turborepo high-performance monorepo build system. Use for monorepo setup, build optimization, task pipelines, caching strategies, or multi-package orchestration.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/turborepo/.codex-plugin/plugin.json
+++ b/plugins/turborepo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "turborepo",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Turborepo high-performance monorepo build system. Use for monorepo setup, build optimization, task pipelines, caching strategies, or multi-package orchestration.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/typescript-migration/.claude-plugin/plugin.json
+++ b/plugins/typescript-migration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-migration",
   "description": "TypeScript version migration guide (5.x to 6 to 7, tsgo native port). Use for TS 6 tsconfig breaking changes, TS 7 Go rewrite rollout, or TS5xxx deprecation codes.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/typescript-migration/.codex-plugin/plugin.json
+++ b/plugins/typescript-migration/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-migration",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "TypeScript version migration guide (5.x to 6 to 7, tsgo native port). Use for TS 6 tsconfig breaking changes, TS 7 Go rewrite rollout, or TS5xxx deprecation codes.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/ultracite/.claude-plugin/plugin.json
+++ b/plugins/ultracite/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultracite",
   "description": "Ultracite multi-provider linting/formatting (Biome, ESLint, Oxlint). Use for v6/v7 setup, provider selection, Git hooks, MCP integration, AI hooks, migrations, or encountering configuration, type-aware linting, monorepo errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/ultracite/.codex-plugin/plugin.json
+++ b/plugins/ultracite/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultracite",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Ultracite multi-provider linting/formatting (Biome, ESLint, Oxlint). Use for v6/v7 setup, provider selection, Git hooks, MCP integration, AI hooks, migrations, or encountering configuration, type-aware linting, monorepo errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/unknowns-discovery/.claude-plugin/plugin.json
+++ b/plugins/unknowns-discovery/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "unknowns-discovery",
   "description": "Discover and reduce task unknowns — blindspots, missing context, unknown unknowns — before committing to a plan, implementation, review, or merge.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/unknowns-discovery/.codex-plugin/plugin.json
+++ b/plugins/unknowns-discovery/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unknowns-discovery",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Discover and reduce task unknowns — blindspots, missing context, unknown unknowns — before committing to a plan, implementation, review, or merge.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/vitest-testing/.claude-plugin/plugin.json
+++ b/plugins/vitest-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vitest-testing",
   "description": "Modern TypeScript/JavaScript testing with Vitest. Fast unit and integration tests, native ESM support, Vite-powered HMR, and comprehensive mocking. Use for testing TS/JS projects.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/vitest-testing/.codex-plugin/plugin.json
+++ b/plugins/vitest-testing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-testing",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Modern TypeScript/JavaScript testing with Vitest. Fast unit and integration tests, native ESM support, Vite-powered HMR, and comprehensive mocking. Use for testing TS/JS projects.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/vulnerability-scanning/.claude-plugin/plugin.json
+++ b/plugins/vulnerability-scanning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vulnerability-scanning",
   "description": "Implements automated security scanning for dependencies, code, and containers using tools like Trivy, Snyk, and npm audit. Use when setting up CI/CD security gates, conducting pre-deployment audits, or meeting compliance requirements.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/vulnerability-scanning/.codex-plugin/plugin.json
+++ b/plugins/vulnerability-scanning/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vulnerability-scanning",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Implements automated security scanning for dependencies, code, and containers using tools like Trivy, Snyk, and npm audit. Use when setting up CI/CD security gates, conducting pre-deployment audits, or meeting compliance requirements.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/web-performance-audit/.claude-plugin/plugin.json
+++ b/plugins/web-performance-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "web-performance-audit",
   "description": "Web performance audits with Core Web Vitals, bottleneck identification, optimization recommendations. Use for page load times, performance reviews, UX optimization, or encountering LCP, FID, CLS issues, resource blocking, render delays.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/web-performance-audit/.codex-plugin/plugin.json
+++ b/plugins/web-performance-audit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-performance-audit",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Web performance audits with Core Web Vitals, bottleneck identification, optimization recommendations. Use for page load times, performance reviews, UX optimization, or encountering LCP, FID, CLS issues, resource blocking, render delays.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/web-performance-optimization/.claude-plugin/plugin.json
+++ b/plugins/web-performance-optimization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "web-performance-optimization",
   "description": "Optimizes web application performance through code splitting, lazy loading, caching strategies, and Core Web Vitals monitoring. Use when improving page load times, implementing service workers, or reducing bundle sizes.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/web-performance-optimization/.codex-plugin/plugin.json
+++ b/plugins/web-performance-optimization/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-performance-optimization",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Optimizes web application performance through code splitting, lazy loading, caching strategies, and Core Web Vitals monitoring. Use when improving page load times, implementing service workers, or reducing bundle sizes.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/websocket-implementation/.claude-plugin/plugin.json
+++ b/plugins/websocket-implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "websocket-implementation",
   "description": "Implements real-time WebSocket communication with connection management, room-based messaging, and horizontal scaling. Use when building chat systems, live notifications, collaborative tools, or real-time dashboards.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/websocket-implementation/.codex-plugin/plugin.json
+++ b/plugins/websocket-implementation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "websocket-implementation",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Implements real-time WebSocket communication with connection management, room-based messaging, and horizontal scaling. Use when building chat systems, live notifications, collaborative tools, or real-time dashboards.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/woocommerce-backend-dev/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-backend-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-backend-dev",
   "description": "Add or modify WooCommerce backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code in WooCommerce projects.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-backend-dev/.codex-plugin/plugin.json
+++ b/plugins/woocommerce-backend-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-backend-dev",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Add or modify WooCommerce backend PHP code following project conventions. Use when creating new classes, methods, hooks, or modifying existing backend code in WooCommerce projects.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/woocommerce-code-review/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-code-review",
   "description": "Review WooCommerce code changes for coding standards compliance. Use when reviewing code locally, performing automated PR reviews, or checking code quality in WooCommerce projects.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-code-review/.codex-plugin/plugin.json
+++ b/plugins/woocommerce-code-review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-code-review",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Review WooCommerce code changes for coding standards compliance. Use when reviewing code locally, performing automated PR reviews, or checking code quality in WooCommerce projects.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/woocommerce-copy-guidelines/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-copy-guidelines/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-copy-guidelines",
   "description": "Guidelines for UI text and copy in WooCommerce. Use when writing user-facing text, labels, buttons, messages, or documentation in WooCommerce projects.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-copy-guidelines/.codex-plugin/plugin.json
+++ b/plugins/woocommerce-copy-guidelines/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-copy-guidelines",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Guidelines for UI text and copy in WooCommerce. Use when writing user-facing text, labels, buttons, messages, or documentation in WooCommerce projects.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/woocommerce-dev-cycle/.claude-plugin/plugin.json
+++ b/plugins/woocommerce-dev-cycle/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-dev-cycle",
   "description": "Run tests, linting, and quality checks for WooCommerce development. Use when running tests, fixing code style, or following the development workflow in WooCommerce projects.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/woocommerce-dev-cycle/.codex-plugin/plugin.json
+++ b/plugins/woocommerce-dev-cycle/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-dev-cycle",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Run tests, linting, and quality checks for WooCommerce development. Use when running tests, fixing code style, or following the development workflow in WooCommerce projects.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/wordpress-plugin-core/.claude-plugin/plugin.json
+++ b/plugins/wordpress-plugin-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wordpress-plugin-core",
   "description": "WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/wordpress-plugin-core/.codex-plugin/plugin.json
+++ b/plugins/wordpress-plugin-core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wordpress-plugin-core",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "WordPress plugin development with hooks, security, REST API, custom post types. Use for plugin creation, $wpdb queries, Settings API, or encountering SQL injection, XSS, CSRF, nonce errors.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/xss-prevention/.claude-plugin/plugin.json
+++ b/plugins/xss-prevention/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "xss-prevention",
   "description": "Prevents Cross-Site Scripting attacks through input sanitization, output encoding, and Content Security Policy. Use when handling user-generated content, implementing rich text editors, or securing web applications.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/xss-prevention/.codex-plugin/plugin.json
+++ b/plugins/xss-prevention/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "xss-prevention",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Prevents Cross-Site Scripting attacks through input sanitization, output encoding, and Content Security Policy. Use when handling user-generated content, implementing rich text editors, or securing web applications.",
   "author": {
     "name": "Claude Skills Maintainers",

--- a/plugins/zod/.claude-plugin/plugin.json
+++ b/plugins/zod/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zod",
-  "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies (2kb gzipped).",
-  "version": "3.7.0",
+  "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies, compact core (~5kb gzipped; zod/mini ~1.9kb).",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/zod/.codex-plugin/plugin.json
+++ b/plugins/zod/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zod",
-  "version": "3.7.0",
-  "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies (2kb gzipped).",
+  "version": "3.8.0",
+  "description": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies, compact core (~5kb gzipped; zod/mini ~1.9kb).",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"
@@ -20,7 +20,7 @@
   "interface": {
     "displayName": "Zod",
     "shortDescription": "TypeScript-first schema validation and type inference. Use for validating API",
-    "longDescription": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies (2kb gzipped).",
+    "longDescription": "TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies, compact core (~5kb gzipped; zod/mini ~1.9kb).",
     "developerName": "Claude Skills Maintainers",
     "category": "Developer Tools",
     "capabilities": [

--- a/plugins/zod/README.md
+++ b/plugins/zod/README.md
@@ -19,7 +19,7 @@ Claude will automatically suggest this skill when you're working with:
 
 ## 🚀 What This Skill Provides
 
-### Comprehensive Coverage (v2.0.0 - Updated 2025-11-17)
+### Comprehensive Coverage (v2.1.0 - Updated 2026-08-20)
 
 - ✅ **All primitive types**: strings, numbers, booleans, dates, bigints
 - ✅ **Complex types**: objects, arrays, tuples, enums, unions, intersections
@@ -33,9 +33,12 @@ Claude will automatically suggest this skill when you're working with:
 - ✅ **Localization**: Built-in support for 40+ locales (i18n)
 - ✅ **Migration guide**: Comprehensive v3 to v4 upgrade documentation
 - ✅ **Codecs**: Bidirectional transformations with practical examples
+- ✅ **Best practices rulebook**: Incorrect/Correct patterns with "when NOT to use" guidance
+- ✅ **Zod Mini + z.core**: import paths and bundle guidance
 - ✅ **Ecosystem**: ESLint plugins, tRPC, Prisma, React Hook Form
 - ✅ **Best practices**: performance tips, common patterns
 - ✅ **Known issues**: documented solutions with examples
+- ✅ **Verified**: all documented APIs typechecked + runtime-tested against zod@4.4.3
 
 ### Code Examples
 
@@ -74,15 +77,16 @@ yarn add zod
 
 **Requirements**:
 - TypeScript v5.5+ with `"strict": true` in `tsconfig.json`
-- Zod 4.x (4.1.12+)
+- Zod 4.x (4.4.x recommended; `z.codec()` requires 4.1+)
 
-**⚠️ Important - Zod 4.x Only**: This skill documents **Zod 4.x** features with comprehensive v4.1 enhancements. The following APIs require Zod 4 and are NOT available in Zod 3.x:
+**⚠️ Important - Zod 4.x Only**: This skill documents **Zod 4.x** features (verified against 4.4.3). The following APIs require Zod 4 and are NOT available in Zod 3.x:
 - `z.codec()` - Bidirectional transformations (new in v4.1)
 - `z.iso.date()`, `z.iso.time()`, `z.iso.datetime()`, `z.iso.duration()` - ISO format validators
 - `z.toJSONSchema()` - JSON Schema generation
 - `z.treeifyError()`, `z.prettifyError()`, `z.flattenError()` - New error formatting helpers
 - `.meta()`, `.register()`, `z.registry()` - Enhanced metadata system
 - Unified `error` parameter - Replaces `message`, `invalid_type_error`, `required_error`, `errorMap`
+- `.check()`, `z.file()`, `z.json()`, `z.stringbool()`, `z.xor()`, `z.templateLiteral()` - New v4 APIs
 - Built-in localization support for 40+ languages
 
 **📖 Includes Migration Guide**: Comprehensive v3 to v4 migration documentation with breaking changes, checklist, and upgrade strategies.
@@ -179,10 +183,10 @@ const PasswordSchema = z.string()
 ## 📊 Performance & Quality
 
 - **Zero dependencies**
-- **2kb gzipped** core bundle
+- **~5kb core / ~1.9kb zod/mini** gzipped
 - **~65% token savings** vs. manual documentation lookup
 - **8+ errors prevented** through comprehensive guidance
-- **Production-tested** patterns and examples
+- **API-verified** patterns and examples (typecheck + runtime tests vs 4.4.3)
 
 ## 🏗️ Common Use Cases
 
@@ -201,7 +205,7 @@ const FormSchema = z.object({
 ```typescript
 export const appRouter = t.router({
   getUser: t.procedure
-    .input(z.object({ id: z.string().uuid() }))
+    .input(z.object({ id: z.uuid() }))
     .query(({ input }) => db.user.findUnique({ where: { id: input.id } })),
 });
 ```
@@ -230,7 +234,7 @@ const DateCodec = z.codec(
 ```typescript
 const jsonSchema = z.toJSONSchema(UserSchema, {
   target: "openapi-3.0",
-  metadata: true,
+  // .meta() data is included by default
 });
 ```
 
@@ -339,6 +343,12 @@ MIT License - see [LICENSE](../../LICENSE) for details.
 
 ## 🔄 Version History
 
+- **2.1.0** (2026-08-20) - Fidelity Audit + Best Practices
+  - 🔍 All documented APIs verified against zod@4.4.3 (typecheck + runtime tests)
+  - 📜 New `references/best-practices.md` rulebook (Incorrect/Correct/When-NOT, impact ratings)
+  - ➕ New coverage: `zod/mini`, `.check()`, `catchall`, `z.preprocess`, `z.custom`, `z.templateLiteral`, `z.file`/`z.json`/`z.stringbool`/`z.xor`, `z.exactOptional`, `.safeExtend`, `z.fromJSONSchema`, expanded format validators
+  - 🐛 Fixed: install commands, `z.string().uuid()` → `z.uuid()`, v3 `.merge()`/`z.function()` chains, `.deepPartial()` (removed in v4), single-arg `z.record`, `toJSONSchema` `metadata` option, v3 error codes
+
 - **2.0.0** (2025-11-17) - Major Update: v4.1 Enhancements
   - ✨ Comprehensive v3 to v4 migration guide with breaking changes
   - ✨ Enhanced error customization with three-level system
@@ -361,11 +371,11 @@ MIT License - see [LICENSE](../../LICENSE) for details.
 
 ---
 
-**Skill Version**: 2.0.0
-**Package Version**: 4.1.12+ (Zod 4.x stable)
-**Last Verified**: 2025-11-17
+**Skill Version**: 2.1.0
+**Package Version**: 4.4.x (Zod 4.x stable)
+**Last Verified**: 2026-08-20
 **Token Savings**: ~65%
 **Errors Prevented**: 8+
-**Production Status**: ✅ Tested
+**Verification**: ✅ typecheck + runtime tests vs zod@4.4.3
 
 Made with ❤️ for the Claude Code community

--- a/plugins/zod/skills/zod/SKILL.md
+++ b/plugins/zod/skills/zod/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: zod
-description: TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies (2kb gzipped).
+description: TypeScript-first schema validation and type inference. Use for validating API requests/responses, form data, env vars, configs, defining type-safe schemas with runtime validation, transforming data, generating JSON Schema for OpenAPI/AI, or encountering missing validation errors, type inference issues, validation error handling problems. Zero dependencies, compact core (~5kb gzipped; zod/mini ~1.9kb).
 license: MIT
 metadata:
-  version: 2.0.0
-  last_verified: 2025-11-17
-  package_version: 4.1.12+
+  version: 2.1.0
+  last_verified: 2026-08-20
+  package_version: 4.4.x
   keywords:
     - zod
     - validation
@@ -63,6 +63,22 @@ metadata:
     - dto
     - type-guard
     - runtime-type-checking
+    - zod-mini
+    - z.core
+    - z.preprocess
+    - z.custom
+    - z.templateLiteral
+    - z.catchall
+    - z.check
+    - z.file
+    - z.json
+    - z.stringbool
+    - z.xor
+    - z.exactOptional
+    - z.safeExtend
+    - z.fromJSONSchema
+    - best-practices
+    - performance
   token_savings: 65%
   errors_prevented: 8
   production_tested: true
@@ -74,23 +90,23 @@ metadata:
 
 ## Overview
 
-Zod is a TypeScript-first validation library that enables developers to define schemas for validating data at runtime while automatically inferring static TypeScript types. With zero dependencies and a 2kb core bundle (gzipped), Zod provides immutable, composable validation with comprehensive error handling.
+Zod is a TypeScript-first validation library that enables developers to define schemas for validating data at runtime while automatically inferring static TypeScript types. With zero dependencies and a compact core (~5kb gzipped; ~1.9kb for `zod/mini`), Zod provides immutable, composable validation with comprehensive error handling.
 
 ## Installation
 
 ```bash
 bun add zod
 # or
-bun add zod
+npm install zod
 # or
-bun add zod
+pnpm add zod
 # or
 yarn add zod
 ```
 
 **Requirements**:
 - TypeScript v5.5+ with `"strict": true` in `tsconfig.json`
-- Zod 4.x (4.1.12+)
+- Zod 4.x (4.4.x recommended; `z.codec()` requires 4.1+)
 
 **Important**: This skill documents **Zod 4.x** features. The following APIs require Zod 4 and are NOT available in Zod 3.x:
 - `z.codec()` - Bidirectional transformations
@@ -99,8 +115,17 @@ yarn add zod
 - `z.treeifyError()`, `z.prettifyError()`, `z.flattenError()` - New error formatting helpers
 - `.meta()` - Enhanced metadata (Zod 3.x only has `.describe()`)
 - Unified `error` parameter - Replaces `message`, `invalid_type_error`, `required_error`, `errorMap`
+- `.check()` - Low-level multi-issue validation (composes check factories like `z.minLength(3)`)
+- `z.file()`, `z.json()`, `z.stringbool()`, `z.xor()`, `z.templateLiteral()` - New schema types
+- `z.exactOptional()`, `.prefault()`, `.safeExtend()`, `z.fromJSONSchema()` - New utilities
 
 For Zod 3.x compatibility or migration guidance, see https://zod.dev
+
+**Import paths** (all ship in the `zod` package):
+- `import { z } from "zod"` — standard (v4 since 4.0)
+- `import { z } from "zod/v4"` — pin for libraries supporting both v3 (3.25+) and v4 users
+- `import { z } from "zod/mini"` — functional, tree-shakable API (~1.9kb; checks via `.check(z.minLength(3))`)
+- `import * as core from "zod/v4/core"` — low-level `$`-prefixed internals for library authors
 
 ## Migrating from Zod v3 to v4
 
@@ -112,7 +137,7 @@ Zod v4 introduces breaking changes for better performance:
 
 - **Error customization**: Use unified `error` parameter (replaces `message`, `invalid_type_error`, `required_error`)
 - **Number validation**: Stricter - rejects `Infinity` and unsafe integers
-- **String formats**: Now top-level functions (`z.email()` vs `z.string().email()`)
+- **String formats**: Prefer top-level functions (`z.email()` instead of `z.string().email()`; the method forms still work but are deprecated)
 - **Object defaults**: Applied even in optional fields
 - **Deprecated APIs**: Use `.extend()` (not `.merge()`), `z.treeifyError()` (not `error.format()`)
 - **Function validation**: Use `.implement()` method
@@ -171,7 +196,10 @@ z.string().max(100)          // Maximum length
 z.string().length(10)        // Exact length
 z.email()                    // Email validation (top-level in v4)
 z.url()                      // URL validation (top-level in v4)
-z.string().uuid()            // UUID format
+z.uuid()                     // UUID (RFC 9562; use z.guid() for permissive)
+z.uuidv4()                   // Version-specific UUIDs (also z.uuidv7)
+z.httpUrl()                  // http/https URLs only (rejects ftp:// etc.)
+z.e164()                     // Phone numbers (E.164 format)
 z.string().regex(/^\d+$/)    // Custom pattern
 z.string().startsWith("pre") // Prefix check
 z.string().endsWith("suf")   // Suffix check
@@ -199,6 +227,12 @@ z.cuid2()                    // CUID2
 z.ulid()                     // ULID
 z.base64()                   // Base64 encoded
 z.hex()                      // Hexadecimal
+z.hash("sha256")             // Hash of algorithm-specific length
+z.guid()                     // Permissive UUID/GUID (non-RFC)
+z.hostname()                 // Hostname
+z.mac()                      // MAC address
+z.uuid({ version: "v4" })    // UUID with version constraint
+z.email({ pattern: z.regexes.email }) // Email with explicit pattern
 ```
 
 ### Numbers
@@ -218,7 +252,8 @@ z.number().lt(100)           // Less than
 z.number().lte(100)          // Less than or equal
 z.number().multipleOf(5)     // Must be multiple of 5
 z.int()                      // Shorthand for z.number().int()
-z.int32()                    // 32-bit integer
+z.int32()                    // 32-bit integer (also z.uint32, z.int64, z.uint64)
+z.float32()                  // 32-bit float (also z.float64)
 z.nan()                      // NaN value
 ```
 
@@ -252,6 +287,16 @@ z.symbol()                   // Symbol
 z.null()                     // Null
 z.undefined()                // Undefined
 z.void()                     // Void (undefined)
+
+// File validation (v4) — sizes are bytes
+z.file().min(1).max(5 * 1024 * 1024).mime(["image/png"])
+
+// JSON-representable values (v4) — validates the VALUE is JSON-serializable
+// (recursive union of string | number | boolean | null | array | record)
+z.json()
+
+// Env-style boolean coercion: "true"/"yes"/"1" → true (v4)
+z.stringbool({ truthy: ["true", "yes", "1"], falsy: ["false", "no", "0"] })
 ```
 
 ## Complex Types
@@ -275,16 +320,21 @@ type Person = z.infer<typeof PersonSchema>;
 PersonSchema.shape                 // Access shape
 PersonSchema.keyof()              // Get union of keys
 PersonSchema.extend({ role: z.string() })  // Add fields
+PersonSchema.safeExtend({ role: z.string() }) // Type-safe extend (inherits refinements)
 PersonSchema.pick({ name: true }) // Pick specific fields
 PersonSchema.omit({ age: true })  // Omit fields
 PersonSchema.partial()            // Make all fields optional
+PersonSchema.partial({ age: true }) // Make specific fields optional
 PersonSchema.required()           // Make all fields required
-PersonSchema.deepPartial()        // Recursively optional
+
+// NOTE: .deepPartial() was REMOVED in v4 — build recursive partials manually
+// (top-level z.deepPartial() landed post-4.4.3 and is not yet stable)
 
 // Strict vs loose objects
 z.strictObject({ ... })           // No extra keys allowed (throws)
 z.object({ ... })                 // Strips extra keys (default)
 z.looseObject({ ... })            // Allows extra keys
+z.object({ ... }).catchall(z.number()) // Validate (and keep) unknown keys
 ```
 
 ### Arrays
@@ -346,6 +396,9 @@ const ResponseSchema = z.discriminatedUnion("status", [
 
 type Response = z.infer<typeof ResponseSchema>;
 // { status: "success", data: any } | { status: "error", message: string }
+
+// Exclusive union (v4): must match exactly ONE branch
+z.xor([z.object({ a: z.string() }), z.object({ b: z.number() })])
 ```
 
 ### Intersections
@@ -361,11 +414,11 @@ const Combined = z.intersection(BaseSchema, ExtendedSchema);
 ### Records and Maps
 
 ```typescript
-// Record: object with typed keys and values
-z.record(z.string())             // { [key: string]: string }
-z.record(z.string(), z.number()) // { [key: string]: number }
+// Record: object with typed keys and values (BOTH args required in v4)
+z.record(z.string(), z.number())  // { [key: string]: number }
+z.record(z.enum(["a", "b"]), z.string()) // Exhaustive: both keys REQUIRED
 
-// Partial record (some keys optional)
+// Partial record (enum keys optional)
 z.partialRecord(z.enum(["a", "b"]), z.string())
 
 // Map
@@ -389,6 +442,23 @@ z.object({ password, confirmPassword }).superRefine((data, ctx) => { /* ... */ }
 ```typescript
 z.string().transform((val) => val.trim());
 z.string().pipe(z.coerce.number());
+z.preprocess((v) => (typeof v === "string" ? v.trim() : v), z.string()); // Transform BEFORE parsing
+z.custom<string>((v) => typeof v === "string", { error: "Not a string" }); // Fully custom schema
+```
+
+**Multi-issue validation** (`.check()`, v4):
+```typescript
+z.string().check(z.minLength(3), z.startsWith("a")); // Compose check factories
+z.string().check((payload) => {
+  if (payload.value === "forbidden") {
+    payload.issues.push({ code: "custom", message: "Not allowed", input: payload.value });
+  }
+});
+```
+
+**Template literals** (v4):
+```typescript
+const UserRole = z.templateLiteral(["role-", z.string()]); // "role-admin", "role-editor", ...
 ```
 
 **Codecs** (bidirectional transforms - NEW in v4.1):
@@ -488,7 +558,7 @@ type Output = z.output<typeof TransformSchema>; // number
 ```typescript
 const jsonSchema = z.toJSONSchema(UserSchema, {
   target: "openapi-3.0",
-  metadata: true,
+  // .meta() data from the global registry is included by default
 });
 ```
 
@@ -508,12 +578,13 @@ const formRegistry = z.registry<FormFieldMeta>();
 
 ## Functions
 
-Validate function inputs and outputs:
+Validate function inputs and outputs with the v4 factory signature:
 
 ```typescript
-const AddFunction = z.function()
-  .args(z.number(), z.number())  // Arguments
-  .returns(z.number());           // Return type
+const AddFunction = z.function({
+  input: [z.number(), z.number()], // Arguments
+  output: z.number(),              // Return type
+});
 
 // Implement typed function
 const add = AddFunction.implement((a, b) => {
@@ -521,14 +592,18 @@ const add = AddFunction.implement((a, b) => {
 });
 
 // Async functions
-const FetchFunction = z.function()
-  .args(z.string())
-  .returns(z.promise(z.object({ data: z.any() })))
-  .implementAsync(async (url) => {
-    const response = await fetch(url);
-    return response.json();
-  });
+const FetchFunction = z.function({
+  input: [z.string()],
+  output: z.object({ data: z.any() }),
+});
+
+const fetchJson = FetchFunction.implementAsync(async (url) => {
+  const response = await fetch(url);
+  return response.json();
+});
 ```
+
+**Note**: the v3 chaining style (`z.function().args(...).returns(...)`) was removed in v4.
 
 ## Common Patterns
 
@@ -620,12 +695,12 @@ const AuthorSchema = z.object({
   authorName: z.string(),
 });
 
-// Compose into larger schemas
+// Compose into larger schemas (.merge() is deprecated — use .extend with .shape)
 const PostSchema = z.object({
   id: z.string(),
   title: z.string(),
   content: z.string(),
-}).merge(TimestampSchema).merge(AuthorSchema);
+}).extend(TimestampSchema.shape).extend(AuthorSchema.shape);
 ```
 
 ## Ecosystem Integration
@@ -695,15 +770,21 @@ z.enum(), z.union(), z.discriminatedUnion(), z.intersection()
 z.literal(), z.any(), z.unknown(), z.never()
 
 // Modifiers
-.optional(), .nullable(), .nullish(), .default(), .catch()
-.readonly(), .brand()
+.optional(), .nullable(), .nullish(), .default(), .prefault()
+.catch(), .readonly(), .brand(), .exactOptional()
 
 // Validation
-.min(), .max(), .length(), .regex(), .email(), .url(), .uuid()
-.refine(), .superRefine()
+.min(), .max(), .length(), .regex()
+.refine(), .superRefine(), .check(z.minLength(3))
+
+// Top-level formats (v4)
+z.email(), z.uuid(), z.url(), z.iso.datetime(), z.file(), z.json()
 
 // Transformation
-.transform(), .pipe(), .codec()
+.transform(), .pipe(), .codec(), z.preprocess(), z.custom()
+
+// Composition helpers
+z.strictObject(), z.looseObject(), z.xor(), z.templateLiteral()
 
 // Parsing
 .parse(), .safeParse(), .parseAsync(), .safeParseAsync()
@@ -721,7 +802,8 @@ z.toJSONSchema(schema, options)
 .meta(), .describe()
 
 // Object methods
-.extend(), .pick(), .omit(), .partial(), .required(), .merge()
+.extend(), .safeExtend(), .pick(), .omit(), .partial(), .required()
+.catchall(), .keyof()  // .merge() is deprecated — use .extend(other.shape)
 ```
 
 ## When to Load References
@@ -771,11 +853,19 @@ z.toJSONSchema(schema, options)
 - Need best practices or testing patterns
 - Confusion between `.refine()` and `.transform()`
 
+**Load `references/best-practices.md` when:**
+- Writing production Zod code or reviewing Zod usage
+- Deciding strict vs loose objects, optional vs nullable, `any` vs `unknown`
+- Optimizing hot paths (schema caching, avoiding dynamic schema creation, large arrays)
+- Unsure where to validate (boundaries, `JSON.parse`, double validation)
+- Want Incorrect/Correct examples with "when NOT to use" guidance
+
 ## Additional Resources
 
 - **Official Docs**: https://zod.dev
 - **GitHub**: https://github.com/colinhacks/zod
 - **TypeScript Playground**: https://zod-playground.vercel.app
+- **Zod Mini**: https://zod.dev/packages/mini
 - **ESLint Plugin (Best Practices)**: https://github.com/JoshuaKGoldberg/eslint-plugin-zod-x
 - **tRPC Integration**: https://trpc.io
 - **Ecosystem**: https://zod.dev/ecosystem
@@ -783,15 +873,21 @@ z.toJSONSchema(schema, options)
 ---
 
 **Production Notes**:
-- Package version: 4.1.12+ (Zod 4.x stable)
+- Package version: 4.4.x (all APIs verified against zod@4.4.3)
 - Zero dependencies
-- Bundle size: 2kb (gzipped)
+- Bundle size: ~5kb core / ~1.9kb zod/mini (gzipped)
 - TypeScript 5.5+ required
 - Strict mode required
-- Last verified: 2025-11-17
-- Skill version: 2.0.0 (Updated with v4.1 enhancements)
+- Last verified: 2026-08-20
+- Skill version: 2.1.0 (fidelity audit + best-practices rules)
 
-**What's New in This Version**:
+**What's New in 2.1.0**:
+- 🔍 Fidelity audit: every documented API verified against zod@4.4.3 (typecheck + runtime tests)
+- 📜 New `references/best-practices.md` rulebook (Incorrect/Correct/When-NOT format with impact ratings)
+- ➕ New coverage: `zod/mini`, `.check()`, `catchall`, `z.preprocess`, `z.custom`, `z.templateLiteral`, `z.file`/`z.json`/`z.stringbool`/`z.xor`, `z.exactOptional`, `.safeExtend`, `z.fromJSONSchema`, expanded format validators
+- 🐛 Fixed: install commands, `z.string().uuid()` → `z.uuid()`, v3 `.merge()`/`z.function()` chains, `.deepPartial()` (removed in v4), single-arg `z.record`, `toJSONSchema` `metadata` option
+
+**What's New in 2.0.0**:
 - ✨ Comprehensive v3 to v4 migration guide with breaking changes
 - ✨ Enhanced error customization with three-level system
 - ✨ Expanded metadata API with registry system

--- a/plugins/zod/skills/zod/references/advanced-patterns.md
+++ b/plugins/zod/skills/zod/references/advanced-patterns.md
@@ -2,7 +2,7 @@
 
 Complete guide for advanced Zod validation patterns including refinements, transformations, codecs, and recursive types.
 
-**Last Updated**: 2025-11-17
+**Last Updated**: 2026-08-20 (verified against zod@4.4.3)
 
 ---
 
@@ -15,7 +15,7 @@ Refinements allow you to add custom validation logic beyond Zod's built-in valid
 ```typescript
 const PasswordSchema = z.string().refine(
   (val) => val.length >= 8,
-  { message: "Password must be at least 8 characters" }
+  { error: "Password must be at least 8 characters" }
 );
 ```
 
@@ -36,14 +36,41 @@ const UserSchema = z.object({
   confirmPassword: z.string(),
 }).superRefine((data, ctx) => {
   if (data.password !== data.confirmPassword) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ["confirmPassword"],
+    ctx.issues.push({
+      code: "custom",
       message: "Passwords must match",
+      input: data.confirmPassword,
+      path: ["confirmPassword"],
     });
   }
 });
 ```
+
+### .check() — Low-Level Multi-Issue Validation (v4)
+
+`.refine()` is sugar over `.check()`, which accepts reusable check factories and raw
+payload functions (push multiple issues in one pass):
+
+```typescript
+import { z } from "zod";
+
+// Compose check factories
+const Username = z.string().check(z.minLength(3), z.maxLength(20));
+
+// Raw payload function — { value, issues }
+const NotForbidden = z.string().check((payload) => {
+  if (payload.value === "forbidden") {
+    payload.issues.push({
+      code: "custom",
+      message: "This name is reserved",
+      input: payload.value,
+    });
+  }
+});
+```
+
+**When to use**: multiple issues per field, reusable validation rules, or when you
+need `abort: true` semantics on a specific check (`.refine(fn, { abort: true })`).
 
 ### Async Refinement
 
@@ -53,7 +80,7 @@ const UsernameSchema = z.string().refine(
     const exists = await checkUsernameExists(username);
     return !exists;
   },
-  { message: "Username already taken" }
+  { error: "Username already taken" }
 );
 ```
 
@@ -83,6 +110,47 @@ const TrimAndLowercaseSchema = z.string()
 
 ```typescript
 const NumberStringSchema = z.string().pipe(z.coerce.number());
+```
+
+### Preprocess (Transform BEFORE Parsing)
+
+Use `z.preprocess` when the raw input needs normalization before validation runs
+(unlike `.transform()`, which runs after):
+
+```typescript
+// Trim user input before length validation
+const Name = z.preprocess(
+  (val) => (typeof val === "string" ? val.trim() : val),
+  z.string().min(1, "Name is required")
+);
+
+// Parse JSON strings arriving from query params
+const Filters = z.preprocess(
+  (val) => (typeof val === "string" ? JSON.parse(val) : val),
+  z.record(z.string(), z.unknown())
+);
+```
+
+### Custom Schemas (z.custom)
+
+When no built-in type fits:
+
+```typescript
+const PingSchema = z.custom<{ ping: true }>(
+  (val) => typeof val === "object" && val !== null && "ping" in val,
+  { error: "Expected a ping message" }
+);
+```
+
+### Template Literals (v4)
+
+Validate strings built from parts:
+
+```typescript
+const Permission = z.templateLiteral([
+  "resource:", z.enum(["user", "post"]), ":", z.enum(["read", "write"]),
+]);
+// Matches "resource:user:read", "resource:post:write", ...
 ```
 
 ---
@@ -144,32 +212,23 @@ DateCodec.encode(new Date());
 DateCodec.encode("2024-01-01");
 ```
 
-### Safe Variants (No Exceptions)
+### Async Variants
 
-Codecs provide safe methods that return result objects instead of throwing:
+Codecs validate during conversion and throw `ZodError` on failure. Async variants exist for async decode/encode functions; wrap in try/catch for non-throwing behavior:
 
 ```typescript
-// Safe decode
-const decodeResult = DateCodec.decodeSafe("2024-01-01T00:00:00Z");
-if (decodeResult.success) {
-  console.log(decodeResult.data); // Date object
-} else {
-  console.error(decodeResult.error); // ZodError
-}
+// Async decode/encode
+await DateCodec.decodeAsync("2024-01-01T00:00:00Z");
+await DateCodec.encodeAsync(new Date());
 
-// Safe encode
-const encodeResult = DateCodec.encodeSafe(new Date());
-if (encodeResult.success) {
-  console.log(encodeResult.data); // ISO string
-} else {
-  console.error(encodeResult.error); // ZodError
+// Non-throwing decode (wrap the throw)
+function safeDecode<T>(codec: { decode: (d: T) => unknown }, data: T) {
+  try {
+    return { success: true as const, data: codec.decode(data) };
+  } catch (error) {
+    return { success: false as const, error };
+  }
 }
-
-// Async safe variants
-await DateCodec.decodeAsync(data);
-await DateCodec.decodeSafeAsync(data);
-await DateCodec.encodeAsync(data);
-await DateCodec.encodeSafeAsync(data);
 ```
 
 ### Composability
@@ -178,7 +237,7 @@ Codecs work seamlessly within objects, arrays, and other schemas:
 
 ```typescript
 const EventSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   title: z.string(),
   createdAt: DateCodec,     // Automatically handles conversion
   updatedAt: DateCodec,
@@ -281,7 +340,7 @@ const SecondsCodec = z.codec(
 ```typescript
 // Define API schema with codecs
 const UserAPISchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   email: z.email(),
   createdAt: z.codec(
     z.iso.datetime(),
@@ -336,6 +395,18 @@ const CategorySchema: z.ZodType<Category> = z.lazy(() =>
     subcategories: z.array(CategorySchema),
   })
 );
+```
+
+Zod 4 also supports **getter-based recursion** without `z.lazy` or manual type
+annotations:
+
+```typescript
+const CategorySchema = z.object({
+  name: z.string(),
+  get subcategories() {
+    return z.array(CategorySchema);
+  },
+});
 ```
 
 ---
@@ -416,18 +487,39 @@ type UpdateUser = z.infer<typeof UpdateUserSchema>;
 
 ### Deep Partial (Nested Optional)
 
+`.deepPartial()` was **removed in v4** (a top-level `z.deepPartial()` is landing in
+later releases). Build recursive partials manually:
+
 ```typescript
+import { z } from "zod";
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+
+function deepPartial<T extends z.ZodObject<any>>(
+  schema: T
+): z.ZodType<DeepPartial<z.output<T>>> {
+  const result: Record<string, any> = {};
+  for (const key in schema.shape) {
+    const field = schema.shape[key];
+    if (field instanceof z.ZodObject) {
+      result[key] = deepPartial(field).optional();
+    } else {
+      result[key] = field.optional();
+    }
+  }
+  return z.object(result) as any;
+}
+
 const NestedSchema = z.object({
   user: z.object({
-    profile: z.object({
-      name: z.string(),
-      age: z.number(),
-    }),
+    profile: z.object({ name: z.string(), age: z.number() }),
   }),
 });
 
-const DeepPartialSchema = NestedSchema.deepPartial();
-// All nested fields become optional
+// All nested fields optional — { user?: { profile?: { name?, age? } } }
+const PatchSchema = deepPartial(NestedSchema);
 ```
 
 ### Pick and Omit
@@ -465,12 +557,12 @@ const AuthorSchema = z.object({
   authorName: z.string(),
 });
 
-// Compose into larger schemas
+// Compose into larger schemas (.merge() is deprecated — use .extend with .shape)
 const PostSchema = z.object({
   id: z.string(),
   title: z.string(),
   content: z.string(),
-}).merge(TimestampSchema).merge(AuthorSchema);
+}).extend(TimestampSchema.shape).extend(AuthorSchema.shape);
 ```
 
 ---
@@ -488,15 +580,15 @@ const ConditionalSchema = z.object({
 }).superRefine((data, ctx) => {
   if (data.type === "individual") {
     if (!data.firstName || !data.lastName) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+      ctx.issues.push({
+        code: "custom",
         message: "First and last name required for individuals",
       });
     }
   } else {
     if (!data.companyName) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+      ctx.issues.push({
+        code: "custom",
         message: "Company name required for companies",
       });
     }
@@ -510,9 +602,15 @@ const ConditionalSchema = z.object({
 
 ### Lazy Loading Large Schemas
 
+Use dynamic `import()` for rarely-used schemas (note: `z.lazy` expects a schema,
+not a promise — it's for circular references, not code splitting):
+
 ```typescript
-// Don't load schema until needed
-const HeavySchema = z.lazy(() => import('./schemas/heavy').then(m => m.schema));
+// Don't load the schema module until needed
+async function validateHeavy(data: unknown) {
+  const { HeavySchema } = await import("./schemas/heavy");
+  return HeavySchema.safeParse(data);
+}
 ```
 
 ### Discriminated Unions for Performance

--- a/plugins/zod/skills/zod/references/best-practices.md
+++ b/plugins/zod/skills/zod/references/best-practices.md
@@ -1,0 +1,424 @@
+# Zod Best Practices Rulebook
+
+Actionable rules for production Zod code, prioritized by impact. Each rule shows the
+**incorrect** pattern, the **correct** pattern, and — just as important — **when NOT
+to apply it**. All examples use Zod 4 APIs verified against 4.4.3.
+
+**Last Updated**: 2026-08-20
+
+---
+
+## Rule Index (by priority)
+
+| # | Rule | Impact |
+|---|------|--------|
+| 1 | Validate at system boundaries | CRITICAL |
+| 2 | Use `.safeParse()` for untrusted input | CRITICAL |
+| 3 | Never trust `JSON.parse` output | CRITICAL |
+| 4 | Use `z.unknown()`, not `z.any()` | CRITICAL |
+| 5 | Export schemas, derive types | HIGH |
+| 6 | Define schemas at module level | HIGH |
+| 7 | Pick the right object strictness | MEDIUM |
+| 8 | `optional()` vs `nullable()` vs `default()` discipline | MEDIUM |
+| 9 | Validate once — don't double-parse | MEDIUM |
+| 10 | Avoid dynamic schema creation in hot paths | LOW-MEDIUM |
+| 11 | Batch or stream large array validation | LOW-MEDIUM |
+| 12 | Use `z.input<T>` for form initial values | MEDIUM |
+
+---
+
+## 1. Validate at System Boundaries — CRITICAL
+
+**WHY**: Data crossing a trust boundary (HTTP request, message queue, `localStorage`,
+file, env vars, third-party API) is untrusted. Validate once at entry, then work with
+the inferred type everywhere downstream. Errors caught at the boundary carry the
+request context; errors caught deep in business logic don't.
+
+**Incorrect (what's wrong)**:
+```typescript
+// Assumes req.body is the right shape — crashes later, far from the cause
+app.post("/users", (req, res) => {
+  sendWelcomeEmail(req.body.email.toUpperCase()); // 💥 TypeError: cannot read 'toUpperCase'
+});
+```
+
+**Correct**:
+```typescript
+const CreateUserRequest = z.object({
+  email: z.email(),
+  name: z.string().min(1),
+});
+
+app.post("/users", (req, res) => {
+  const result = CreateUserRequest.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({ errors: z.flattenError(result.error).fieldErrors });
+  }
+  const user = result.data; // typed, trusted from here on
+  sendWelcomeEmail(user.email);
+});
+```
+
+**When NOT to use this pattern**:
+- Pure internal functions already receiving validated data — re-validating is waste (see Rule 9).
+- Hot paths where the boundary already validated (trust the type).
+
+---
+
+## 2. Use `.safeParse()` for Untrusted Input — CRITICAL
+
+**WHY**: `.parse()` throws. On untrusted input that means an exception per bad request,
+500s instead of 422/400s, and try/catch noise. `.safeParse()` returns a discriminated
+union you can branch on.
+
+**Incorrect**:
+```typescript
+try {
+  const user = UserSchema.parse(req.body);
+  res.json(user);
+} catch (error) {
+  // Hopeless: is this a validation error, a DB error, a bug?
+  res.status(500).json({ error: "Something went wrong" });
+}
+```
+
+**Correct**:
+```typescript
+const result = UserSchema.safeParse(req.body);
+if (!result.success) {
+  return res.status(422).json({ errors: z.flattenError(result.error).fieldErrors });
+}
+res.json(await createUser(result.data));
+```
+
+**When NOT to use this pattern**:
+- Trusted, invariant data at startup (env vars, config) where failing fast with a
+  thrown, descriptive error is exactly what you want: `EnvSchema.parse(process.env)`.
+- Test assertions where you *want* the throw: `expect(() => S.parse(bad)).toThrow()`.
+
+---
+
+## 3. Never Trust `JSON.parse` Output — CRITICAL
+
+**WHY**: `JSON.parse` returns `any`. A stored payload from last deploy, another client
+version, or a corrupted cache will silently flow through your app until something
+breaks far away. Validate immediately after parsing.
+
+**Incorrect**:
+```typescript
+const cart = JSON.parse(localStorage.getItem("cart") ?? "{}");
+cart.items.forEach((item) => addToTotal(item.price)); // 💥 crashes on old/corrupt data
+```
+
+**Correct**:
+```typescript
+const CartSchema = z.object({
+  items: z.array(z.object({
+    id: z.uuid(),
+    quantity: z.number().int().positive(),
+  })),
+});
+
+function loadCart(): Cart {
+  const raw = localStorage.getItem("cart");
+  const result = CartSchema.safeParse(raw ? JSON.parse(raw) : { items: [] });
+  return result.success ? result.data : { items: [] }; // corrupted data degrades gracefully
+}
+```
+
+**When NOT to use this pattern**:
+- Never skip this for external data. If parsing huge trusted internal blobs where you
+  control both writer and reader and can afford a crash, `.parse()` (throw) is fine —
+  silent `any` is not.
+
+---
+
+## 4. Use `z.unknown()`, Not `z.any()` — CRITICAL
+
+**WHY**: `z.any()` disables type checking for everything downstream — it's an `any`
+that survived validation. `z.unknown()` forces you to narrow. If you can't articulate
+the shape, at least make consumers validate before use. For values that are one of a
+known set of shapes, model it as a union (or discriminated union) instead.
+
+**Incorrect**:
+```typescript
+const Webhook = z.object({ data: z.any() });
+// data is any — every consumer can misuse it with zero compiler help
+```
+
+**Correct**:
+```typescript
+const Webhook = z.object({
+  event: z.enum(["user.created", "order.paid"]),
+  data: z.unknown(),            // must be narrowed before use
+});
+// ...or better, model the shapes:
+const Payload = z.discriminatedUnion("event", [
+  z.object({ event: z.literal("user.created"), data: z.object({ id: z.uuid() }) }),
+  z.object({ event: z.literal("order.paid"), data: z.object({ total: z.number() }) }),
+]);
+```
+
+**When NOT to use this pattern**:
+- Pass-through proxies that genuinely forward opaque payloads untouched — `z.any()`
+  still isn't right; use `z.unknown()` there too. (There is no good use for `z.any()`.)
+
+---
+
+## 5. Export Schemas, Derive Types — HIGH
+
+**WHY**: Hand-written interfaces drift from the schemas that actually run. The schema
+is the single source of truth; `z.infer` makes the compiler enforce it.
+
+**Incorrect**:
+```typescript
+// Two definitions that WILL drift apart
+export interface User { email: string; age: number; }
+export const UserSchema = z.object({ email: z.email(), age: z.number().int() });
+```
+
+**Correct**:
+```typescript
+export const UserSchema = z.object({ email: z.email(), age: z.number().int() });
+export type User = z.infer<typeof UserSchema>;
+```
+
+**When NOT to use this pattern**:
+- Public library APIs where you want a stable, documented type independent of your
+  validation internals.
+
+---
+
+## 6. Define Schemas at Module Level — HIGH
+
+**WHY**: Zod 4 JIT-compiles schemas: creation costs more than v3, repeated parsing is
+far faster. Recreating a schema per request/hot call pays the creation cost every time
+and throws away the JIT work.
+
+**Incorrect**:
+```typescript
+app.post("/users", (req, res) => {
+  const schema = z.object({ email: z.email() }); // rebuilt on EVERY request
+  const result = schema.safeParse(req.body);
+  // ...
+});
+```
+
+**Correct**:
+```typescript
+const CreateUserSchema = z.object({ email: z.email() }); // created once, JIT pays off
+app.post("/users", (req, res) => {
+  const result = CreateUserSchema.safeParse(req.body);
+  // ...
+});
+```
+
+**When NOT to use this pattern**:
+- Genuinely dynamic shapes (schema driven by per-tenant config) — cache the built
+  schemas in a `Map` keyed by config instead of rebuilding.
+
+---
+
+## 7. Pick the Right Object Strictness — MEDIUM
+
+**WHY**: Default `z.object` silently **strips** unknown keys — convenient, but it can
+mask client bugs (typo'd field is dropped, then "missing" downstream). Strictness is
+a real API contract decision:
+
+| Constructor | Unknown keys | Use when |
+|---|---|---|
+| `z.object({...})` | stripped (default) | Internal normalization, most APIs |
+| `z.strictObject({...})` | rejected (`unrecognized_keys`) | Public APIs — fail loudly on client typos |
+| `z.looseObject({...})` | passed through | Proxies/passthrough that must keep extras |
+| `z.object({...}).catchall(schema)` | validated + kept | Dynamic keys with a known value type |
+
+**Incorrect**:
+```typescript
+// Client sends { "emial": "..." } (typo) → silently dropped, email "missing" later
+const CreateUser = z.object({ email: z.email() });
+```
+
+**Correct**:
+```typescript
+// Client gets an immediate, actionable unrecognized_keys error
+const CreateUser = z.strictObject({ email: z.email() });
+```
+
+**When NOT to use this pattern**:
+- Don't make internal objects strict "for safety" if you routinely forward extra keys
+  (metadata, tracing fields) — use `.catchall()` or `z.looseObject` deliberately.
+- v3 `.passthrough()`/`.strict()` methods still work but are deprecated; use the
+  constructors above.
+
+---
+
+## 8. `optional()` vs `nullable()` vs `default()` Discipline — MEDIUM
+
+**WHY**: These encode different contracts, and mixing them produces `string | null |
+undefined` soup that leaks into UI code.
+
+- `optional()` — the key may be **absent** (input omitted)
+- `nullable()` — the key must be **present**, value may be `null` (DB NULL, JSON null)
+- `default(v)` — absent → filled with `v` **after** parsing (output type has no `| undefined`)
+- `z.coerce...().prefault(v)` — filled **before** parsing (v3-style default semantics)
+
+**Incorrect**:
+```typescript
+const Profile = z.object({
+  nickname: z.string().nullable().optional(), // which is it? both leak to the UI
+});
+```
+
+**Correct**:
+```typescript
+const Profile = z.object({
+  nickname: z.string().nullable(),   // column is NULL-able in DB
+  displayName: z.string().default("Anonymous"), // absent → resolved value
+});
+```
+
+**When NOT to use this pattern**:
+- PATCH endpoints genuinely accept absent-means-don't-change — that's what
+  `.partial()` is for; don't hand-roll optionality there.
+
+---
+
+## 9. Validate Once — Don't Double-Parse — MEDIUM
+
+**WHY**: If a function receives data that's already been validated at the boundary,
+re-parsing wastes cycles and — worse — implies the type is a lie. Let the type system
+carry the proof.
+
+**Incorrect**:
+```typescript
+function handler(req: Request) {
+  const user = CreateUserSchema.parse(await req.json());
+  chargeCard(user); // chargeCard parses AGAIN internally
+}
+function chargeCard(user: unknown) { const u = CreateUserSchema.parse(user); /* ... */ }
+```
+
+**Correct**:
+```typescript
+function handler(req: Request) {
+  const user = CreateUserSchema.parse(await req.json());
+  chargeCard(user);
+}
+function chargeCard(user: User) { /* typed param — trusted, no re-parse */ }
+```
+
+**When NOT to use this pattern**:
+- Library code that can't trust its callers should re-validate — accept `unknown`,
+  parse once at *your* boundary.
+
+---
+
+## 10. Avoid Dynamic Schema Creation in Hot Paths — LOW-MEDIUM
+
+**WHY**: Building a schema (object spread, `.extend`, conditional composition) per
+request costs the JIT setup every call. With Zod 4's JIT the delta is real in
+high-QPS paths (~0.1ms/creation) even when it's invisible in tests.
+
+**Incorrect**:
+```typescript
+function searchParamsSchema(sortableFields: string[]) {
+  return z.object({ sortBy: z.enum(sortableFields as [string, ...string[]]) });
+}
+app.get("/search", (req, res) => {
+  const schema = searchParamsSchema(currentFields()); // rebuilt per request
+  // ...
+});
+```
+
+**Correct**:
+```typescript
+// Compute the (small, finite) set of shapes up front and cache them
+const schemaCache = new Map<string, z.ZodType>();
+
+function getSearchSchema(fields: string[]) {
+  const key = fields.join(",");
+  let schema = schemaCache.get(key);
+  if (!schema) {
+    schema = z.object({ sortBy: z.enum(fields as [string, ...string[]]) });
+    schemaCache.set(key, schema);
+  }
+  return schema;
+}
+```
+
+**When NOT to use this pattern**:
+- Admin/config screens called a few times a day — the cache is complexity for nothing.
+  Prefer the simple code until profiling says otherwise.
+
+---
+
+## 11. Batch or Stream Large Array Validation — LOW-MEDIUM
+
+**WHY**: Validating a 100k-element upload in one `.parse()` blocks the event loop and
+gives you all-or-nothing feedback. Fail fast on garbage, stream for progress.
+
+**Incorrect**:
+```typescript
+const result = z.array(RecordSchema).safeParse(hugeJson); // blocks, all-or-nothing
+```
+
+**Correct**:
+```typescript
+// Fail fast: validate the first N to reject obviously bad payloads cheaply
+const Head = z.array(RecordSchema).min(1);
+await Head.parseAsync(hugeJson.slice(0, 100));
+
+// Then stream the full set with progress and per-item errors
+async function* validateStream(items: unknown[]) {
+  for (let i = 0; i < items.length; i++) {
+    yield { index: i, result: RecordSchema.safeParse(items[i]) };
+  }
+}
+```
+
+**When NOT to use this pattern**:
+- Anything under a few thousand items — a single `safeParse` is faster and simpler.
+- When you genuinely need atomicity (reject the whole batch if any record is bad) —
+  that's exactly what `z.array()` gives you.
+
+---
+
+## 12. Use `z.input<T>` for Form Initial Values — MEDIUM
+
+**WHY**: With transforms/defaults, the data a form produces (`z.input`) differs from
+what parsing returns (`z.output`/`z.infer`). Initializing forms from the output type
+causes subtle type mismatches.
+
+**Incorrect**:
+```typescript
+const PasswordSchema = z.string().min(8).transform((s) => s.trim());
+const Signup = z.object({ password: PasswordSchema });
+
+type Initial = z.infer<typeof Signup>; // string — fine here, but wrong once
+const form: Initial = { password: 42 as never }; // defaults/coercions break this
+```
+
+**Correct**:
+```typescript
+type FormInput = z.input<typeof Signup>;   // what forms/clients send
+type Parsed    = z.output<typeof Signup>;  // what parsing returns
+const emptyForm: FormInput = { password: "" };
+```
+
+**When NOT to use this pattern**:
+- Schemas without transforms/defaults — `z.input` and `z.output` are identical, so
+  just use `z.infer` for readability.
+
+---
+
+## Cross-Cutting: Performance Snapshot (Zod 4)
+
+- Repeated parsing is ~7-14x faster than v3 (JIT), type instantiation ~100x lower.
+- Bundle: core ~5kb / `zod/mini` ~1.9kb (gzipped). Use mini for edge/browser-critical bundles.
+- `z.lazy` is for **circular references**; code splitting is `await import(...)`.
+- Prefer `z.discriminatedUnion` over `z.union` when a literal key distinguishes branches.
+
+**See also:**
+- `troubleshooting.md` for detailed performance solutions
+- `error-handling.md` for formatting parse errors for users
+- `migration-guide.md` when updating v3-era code that violates these rules

--- a/plugins/zod/skills/zod/references/common-patterns.ts
+++ b/plugins/zod/skills/zod/references/common-patterns.ts
@@ -4,7 +4,7 @@
  * This file contains frequently used Zod validation patterns
  * for real-world applications.
  *
- * @requires zod ^4.1.12 (Zod 4.x)
+ * @requires zod ^4.4 (Zod 4.x; APIs verified against 4.4.3)
  * @note Uses Zod 4 APIs: z.codec, z.iso.datetime, z.flattenError, z.prettifyError
  */
 
@@ -47,14 +47,14 @@ export type CreateUserRequest = z.infer<typeof CreateUserRequest>;
 
 // Update User Request (partial)
 export const UpdateUserRequest = CreateUserRequest.partial().extend({
-  id: z.string().uuid(),
+  id: z.uuid(),
 });
 
 export type UpdateUserRequest = z.infer<typeof UpdateUserRequest>;
 
 // User Response
 export const UserResponse = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   username: z.string(),
   email: z.email(),
   firstName: z.string().nullable(),
@@ -101,10 +101,11 @@ export const SignupFormSchema = z
   })
   .superRefine((data, ctx) => {
     if (data.password !== data.confirmPassword) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+      ctx.issues.push({
+        code: "custom",
         path: ["confirmPassword"],
         message: "Passwords do not match",
+        input: data.confirmPassword,
       });
     }
   });
@@ -186,7 +187,7 @@ export const UsernameSchema = z.string().min(3).max(20).refine(
     // return !exists;
     return true; // Replace with actual check
   },
-  { message: "Username is already taken" }
+  { error: "Username is already taken" }
 );
 
 // ============================================================================
@@ -228,22 +229,22 @@ export const TimestampSchema = z.object({
 
 // Base author fields
 export const AuthorSchema = z.object({
-  authorId: z.string().uuid(),
+  authorId: z.uuid(),
   authorName: z.string(),
 });
 
-// Combine into larger schemas
+// Combine into larger schemas (.merge() is deprecated — use .extend with .shape)
 export const PostSchema = z
   .object({
-    id: z.string().uuid(),
+    id: z.uuid(),
     title: z.string().min(1).max(200),
     content: z.string(),
     slug: SlugSchema,
     published: z.boolean().default(false),
     tags: z.array(z.string()).max(10),
   })
-  .merge(TimestampSchema)
-  .merge(AuthorSchema);
+  .extend(TimestampSchema.shape)
+  .extend(AuthorSchema.shape);
 
 export type Post = z.infer<typeof PostSchema>;
 
@@ -259,7 +260,7 @@ interface Category {
 
 export const CategorySchema: z.ZodType<Category> = z.lazy(() =>
   z.object({
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: z.string().min(1).max(100),
     subcategories: z.array(CategorySchema),
   })
@@ -310,7 +311,7 @@ export type SearchQuery = z.infer<typeof SearchQuerySchema>;
 // ============================================================================
 
 export const WebhookPayloadSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   event: z.enum([
     "user.created",
     "user.updated",
@@ -319,7 +320,7 @@ export const WebhookPayloadSchema = z.object({
     "order.fulfilled",
   ]),
   timestamp: DateCodec,
-  data: z.record(z.any()),
+  data: z.record(z.string(), z.any()),
   signature: z.string(),
 });
 
@@ -345,7 +346,7 @@ export const AppConfigSchema = z.object({
     enabled: z.boolean().default(true),
     ttl: z.number().int().positive().default(3600),
   }),
-  features: z.record(z.boolean()).default({}),
+  features: z.record(z.string(), z.boolean()).default({}),
 });
 
 export type AppConfig = z.infer<typeof AppConfigSchema>;

--- a/plugins/zod/skills/zod/references/ecosystem-integrations.md
+++ b/plugins/zod/skills/zod/references/ecosystem-integrations.md
@@ -2,7 +2,7 @@
 
 Complete guide for integrating Zod with popular frameworks, libraries, and tools.
 
-**Last Updated**: 2025-11-17
+**Last Updated**: 2026-08-20 (verified against zod@4.4.3)
 
 ---
 
@@ -201,7 +201,7 @@ model User {
 ```typescript
 // src/zod/user.ts (auto-generated)
 export const UserSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   email: z.email(),
   name: z.string(),
   createdAt: z.date(),

--- a/plugins/zod/skills/zod/references/error-handling.md
+++ b/plugins/zod/skills/zod/references/error-handling.md
@@ -2,7 +2,7 @@
 
 Complete guide for handling, formatting, and customizing Zod validation errors.
 
-**Last Updated**: 2025-11-17
+**Last Updated**: 2026-08-20 (verified against zod@4.4.3)
 
 ---
 
@@ -234,7 +234,7 @@ const NameSchema = z.string({
 
 const EmailSchema = z.email({
   error: (issue) => {
-    if (issue.code === "invalid_string") {
+    if (issue.code === "invalid_format") {
       return "Please provide a valid email address";
     }
   },
@@ -306,7 +306,7 @@ z.string({
       return `Minimum length: ${issue.minimum}`;
     }
     if (issue.code === "invalid_type") {
-      return `Expected string, got ${issue.received}`;
+      return `Expected ${issue.expected}, got ${JSON.stringify(issue.input)}`;
     }
     return undefined; // Use default message
   },
@@ -461,18 +461,20 @@ if (!result.success) {
 
 ## Error Code Reference
 
-Common Zod error codes you'll encounter:
+Common Zod v4 error codes you'll encounter:
 
-| Code | Description | Example |
-|------|-------------|---------|
-| `invalid_type` | Wrong data type | Expected string, got number |
-| `too_small` | Value below minimum | String length < 5 |
-| `too_big` | Value above maximum | Number > 100 |
-| `invalid_string` | String format invalid | Email validation failed |
-| `invalid_enum_value` | Not in enum | Value not in ["a", "b", "c"] |
-| `custom` | Custom refinement failed | Password doesn't match |
-| `invalid_union` | No union branch matched | Neither string nor number |
-| `invalid_date` | Invalid Date object | NaN date |
+| Code | Description | Example / extra fields |
+|------|-------------|-------------------------|
+| `invalid_type` | Wrong data type | `issue.expected` (e.g. "string") |
+| `too_small` | Value below minimum | `issue.minimum`, `issue.inclusive` |
+| `too_big` | Value above maximum | `issue.maximum`, `issue.inclusive` |
+| `invalid_format` | String format invalid (v4; was `invalid_string`) | `issue.format` (e.g. "email", "uuid") |
+| `invalid_value` | Not an allowed value (v4; was `invalid_enum_value`) | `issue.values` |
+| `unrecognized_keys` | Extra keys in strict object | `issue.keys` |
+| `custom` | Custom refinement failed | — |
+| `invalid_union` | No union branch matched | — |
+
+**Note**: v3 codes `invalid_string`, `invalid_enum_value`, and `invalid_date` were renamed/merged in v4 — update any `switch (issue.code)` logic during migration.
 
 ---
 

--- a/plugins/zod/skills/zod/references/migration-guide.md
+++ b/plugins/zod/skills/zod/references/migration-guide.md
@@ -2,7 +2,7 @@
 
 Complete guide for upgrading from Zod v3 to v4, including all breaking changes and migration strategies.
 
-**Last Updated**: 2025-11-17
+**Last Updated**: 2026-08-20 (verified against zod@4.4.3)
 
 ---
 
@@ -31,7 +31,7 @@ z.string({
   error: "Custom message"
 });
 
-z.string().email({
+z.email({
   error: (issue) => "Invalid email"
 });
 ```
@@ -64,25 +64,26 @@ z.number().refine((n) => Number.isFinite(n) || !Number.isNaN(n));
 
 ## 3. String Format Methods Moved to Top-Level
 
-**Breaking Change**: Format validators are now top-level functions, not methods.
+**Behavior Change**: Format validators are now top-level functions. The v3 method forms still work in v4 but are **deprecated and slated for removal**.
 
 ```typescript
-// ❌ Zod v3 (Methods on z.string() — REMOVED in v4)
+// ❌ Zod v3 (Methods on z.string() — deprecated in v4)
 z.string().email();
 z.string().uuid();
 z.string().url();
 z.string().ipv4();
 z.string().ipv6();
 
-// ✅ Zod v4 (Top-level functions — required)
-z.email();        // Shorthand for validated email
-z.uuid();         // Stricter UUID validation (RFC 9562/4122)
+// ✅ Zod v4 (Top-level functions — use these in all new code)
+z.email();        // Validated email
+z.uuid();         // Stricter UUID validation (RFC 9562)
 z.url();
 z.ipv4();
 z.ipv6();
 
-// NOTE: z.string().email() / .url() / .ip() / .cidr() / .datetime() / .base64url()
-// were REMOVED in v4. Use the top-level z.email(), z.url(), etc. instead.
+// NOTE: z.string().email() / .uuid() / .url() / .datetime() etc. still parse
+// successfully in v4 but emit deprecation warnings in tooling. Migrate to the
+// top-level functions (z.email(), z.uuid(), z.iso.datetime(), ...).
 ```
 
 ---
@@ -115,46 +116,50 @@ schema.parse({ age: undefined });
 
 ```typescript
 // ❌ Zod v3 APIs (Deprecated in v4)
-schema1.merge(schema2);           // Use .extend() instead
+schema1.merge(schema2);           // Use .extend(other.shape) instead
 error.format();                   // Use z.treeifyError(error)
 error.flatten();                  // Use z.flattenError(error)
-z.nativeEnum(MyEnum);             // Use z.enum() (now handles both)
-z.promise(schema);                // Deprecated
+z.nativeEnum(MyEnum);             // Use z.enum() (now handles TS enums + const objects)
+z.promise(schema);                // Deprecated — await the value before validating
+
+// ❌ Removed entirely in v4
+schema.deepPartial();             // Build recursive partials manually
+z.record(valueType);              // z.record() now REQUIRES key AND value schemas
+schema.nonstrict();               // Use z.looseObject() or .loose()
+z.function().args(...).returns(...) // Use the object config (see §6)
 
 // ✅ Zod v4 Replacements
-schema1.extend(schema2);          // Preferred way to merge
-z.treeifyError(error);           // New error formatting
-z.flattenError(error);           // New flat error format
-z.enum(MyEnum);                  // Unified enum handling
-// No direct replacement for z.promise() - use async refinements
+schema1.extend(schema2.shape);    // Preferred way to combine object schemas
+z.treeifyError(error);            // New error formatting
+z.flattenError(error);            // New flat error format
+z.enum(MyEnum);                   // Unified enum handling
+
+// Error issue codes renamed in v4:
+// invalid_string    → invalid_format (with issue.format)
+// invalid_enum_value → invalid_value (with issue.values)
+// invalid_date      → folded into invalid_type
 ```
 
 ---
 
 ## 6. Function Validation Redesigned
 
-**Breaking Change**: `z.function()` no longer returns a schema directly.
+**Breaking Change**: `z.function()` now uses an object config instead of the v3 `.args()`/`.returns()` chain (which was removed).
 
 ```typescript
-// ❌ Zod v3
+// ❌ Zod v3 (removed in v4)
 const myFunc = z.function()
   .args(z.string())
   .returns(z.number())
   .parse(someFunction);
 
-// ✅ Zod v4
-const myFunc = z.function()
-  .args(z.string())
-  .returns(z.number())
-  .implement((str) => {
-    return parseInt(str); // Type-checked!
-  });
-
-// Or with new syntax:
+// ✅ Zod v4 (object config — the only supported form)
 const myFunc = z.function({
   input: [z.string()],
   output: z.number()
-}).implement((str) => parseInt(str));
+}).implement((str) => {
+  return parseInt(str); // Type-checked!
+});
 ```
 
 ---
@@ -178,14 +183,16 @@ Use this checklist to systematically upgrade your codebase:
 - [ ] Replace `message`, `invalid_type_error`, `required_error`, `errorMap` with unified `error` parameter
 - [ ] Check for `Infinity` or `-Infinity` in number validations
 - [ ] Update `.int()` usage if relying on unsafe integers
-- [ ] Replace `.merge()` with `.extend()`
+- [ ] Replace `.merge()` with `.extend(other.shape)`
 - [ ] Replace `error.format()` with `z.treeifyError()`
 - [ ] Replace `error.flatten()` with `z.flattenError()`
 - [ ] Update `z.nativeEnum()` to `z.enum()` (or keep for clarity)
-- [ ] Replace `z.promise()` with async refinements
-- [ ] Update function validation to use `.implement()` or new syntax
-- [ ] Consider using top-level format functions (`z.email()` instead of `z.string().email()`)
+- [ ] Replace `.deepPartial()` (removed) with a manual recursive partial
+- [ ] Fix single-arg `z.record(value)` — both key and value schemas are now required
+- [ ] Update function validation to the `z.function({ input, output })` factory
+- [ ] Replace string format methods (`z.string().email()` → `z.email()`)
 - [ ] Test UUID validation if using custom UUID formats
+- [ ] Update error-code switches (`invalid_string` → `invalid_format`, `invalid_enum_value` → `invalid_value`)
 
 ---
 
@@ -269,11 +276,7 @@ const FormSchema = z.object({
 
 // ✅ Zod v4
 const FormSchema = z.object({
-  email: z.string({
-    error: "Email required"
-  }).email({
-    error: "Invalid email"
-  })
+  email: z.email({ error: "Invalid email address" })
 });
 ```
 
@@ -335,7 +338,7 @@ If you need to rollback to Zod v3:
 
 ```bash
 # Install last stable v3 version
-bun add zod@3.23.8
+bun add zod@3.25.76
 ```
 
 Then revert code changes using version control.

--- a/plugins/zod/skills/zod/references/package.json
+++ b/plugins/zod/skills/zod/references/package.json
@@ -22,7 +22,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/plugins/zod/skills/zod/references/quick-reference.md
+++ b/plugins/zod/skills/zod/references/quick-reference.md
@@ -1,6 +1,6 @@
 # Zod Quick Reference Cheat Sheet
 
-> **Version**: Zod 4.x (4.1.12+)
+> **Version**: Zod 4.x (4.4.x)
 > **Note**: Some APIs shown here (z.codec, z.iso.*, error helpers) are Zod 4 only
 
 ## Installation
@@ -99,7 +99,7 @@ if (result.success) {
 | Array | `z.array(z.string())` |
 | Tuple | `z.tuple([z.string(), z.number()])` |
 | Object | `z.object({ name: z.string() })` |
-| Record | `z.record(z.string())` |
+| Record | `z.record(z.string(), z.number())` |
 | Map | `z.map(z.string(), z.number())` |
 | Set | `z.set(z.string())` |
 
@@ -121,6 +121,8 @@ if (result.success) {
 | Nullable | `.nullable()` |
 | Nullish | `.nullish()` |
 | Default | `.default(value)` |
+| Prefault (v4) | `.prefault(value)` (pre-parse default) |
+| Exact Optional (v4) | `z.exactOptional(z.string())` |
 | Catch | `.catch(fallback)` |
 | Readonly | `.readonly()` |
 | Brand | `.brand<"BrandName">()` |
@@ -130,22 +132,28 @@ if (result.success) {
 | Method | Code |
 |--------|------|
 | Extend | `.extend({ field: z.string() })` |
+| Safe Extend | `.safeExtend({ field: z.string() })` |
 | Pick | `.pick({ name: true })` |
 | Omit | `.omit({ age: true })` |
-| Partial | `.partial()` |
+| Partial | `.partial()` (or `.partial({ age: true })`) |
 | Required | `.required()` |
-| Deep Partial | `.deepPartial()` |
-| Merge | `.merge(otherSchema)` |
+| Catchall | `.catchall(z.number())` |
 | Keyof | `.keyof()` |
+| Merge (deprecated) | `.merge(other)` — use `.extend(other.shape)` |
+
+**Note**: `.deepPartial()` was removed in v4 — build recursive partials manually.
 
 ## Validation
 
 | Method | Code |
 |--------|------|
-| Refine | `.refine((val) => condition, message)` |
-| Super Refine | `.superRefine((data, ctx) => { ... })` |
+| Refine | `.refine((val) => condition, { error: "msg" })` |
+| Super Refine | `.superRefine((data, ctx) => { ctx.issues.push(...) })` |
+| Check (v4) | `.check(z.minLength(3), z.startsWith("a"))` |
 | Transform | `.transform((val) => newVal)` |
 | Pipe | `.pipe(otherSchema)` |
+| Preprocess | `z.preprocess(fn, schema)` |
+| Custom | `z.custom<T>(fn, { error: "msg" })` |
 
 ## Parsing
 
@@ -238,10 +246,13 @@ DateCodec.encode(new Date());               // string
 ```typescript
 const jsonSchema = z.toJSONSchema(schema, {
   target: "openapi-3.0",
-  metadata: true,
   cycles: "ref",
-  reused: "defs",
+  reused: "inline",
+  // .meta() data included by default (globalRegistry)
 });
+
+// Experimental (4.3+): JSON Schema → Zod
+const schema = z.fromJSONSchema({ type: "string" });
 ```
 
 ## Metadata
@@ -284,6 +295,29 @@ z.cuid2()          // CUID2
 z.ulid()           // ULID
 z.base64()         // Base64
 z.hex()            // Hexadecimal
+z.guid()           // Permissive UUID/GUID
+z.httpUrl()        // http/https URL only
+z.e164()           // Phone (E.164)
+z.hash("sha256")   // Hash of algorithm-specific length
+z.uuidv4()         // Version-specific UUID (also z.uuidv7)
+```
+
+## Zod Mini (`zod/mini`)
+
+Functional, tree-shakable API (~1.9kb) for bundle-sensitive targets:
+
+```typescript
+import { z } from "zod/mini";
+
+// Checks attach via .check() with standalone check factories
+const Name = z.string().check(z.minLength(1), z.maxLength(100));
+const Email = z.pipe(z.string(), z.email());
+const User = z.object({ name: Name, email: Email });
+
+z.safeParse(User, { name: "a", email: "a@b.c" }); // functional parse
+// Functional wrappers live here: z.pick(schema, mask), z.omit, z.partial,
+// z.keyof, z.catchall(schema, z.string()), z.optional, z.union, ...
+// NOTE: z.pipe(schema, z.minLength(3)) crashes — bare checks go in .check(), not pipe
 ```
 
 ## Common Patterns

--- a/plugins/zod/skills/zod/references/troubleshooting.md
+++ b/plugins/zod/skills/zod/references/troubleshooting.md
@@ -2,7 +2,7 @@
 
 Solutions for common issues, performance optimization, and best practices.
 
-**Last Updated**: 2025-11-17
+**Last Updated**: 2026-08-20 (verified against zod@4.4.3)
 
 ---
 
@@ -37,16 +37,15 @@ Type 'string | undefined' is not assignable to type 'string'
 
 **Issue**: Complex schemas can increase bundle size significantly.
 
-**Solution 1**: Use lazy loading for large schemas:
+**Solution 1**: Use dynamic imports for large schemas (`z.lazy` is for circular
+references, not code splitting — it expects a schema, not a promise):
 
 ```typescript
-// Instead of importing directly
-import { HeavySchema } from './schemas/heavy';
-
-// Lazy load when needed
-const HeavySchema = z.lazy(() =>
-  import('./schemas/heavy').then(m => m.HeavySchema)
-);
+// Lazy load the schema module when needed
+async function validateHeavy(data: unknown) {
+  const { HeavySchema } = await import('./schemas/heavy');
+  return HeavySchema.safeParse(data);
+}
 ```
 
 **Solution 2**: Code splitting by route/page:
@@ -68,11 +67,11 @@ const TimestampSchema = z.object({
 // Use in multiple places
 const PostSchema = z.object({
   /* ... */
-}).merge(TimestampSchema);
+}).extend(TimestampSchema.shape);
 
 const CommentSchema = z.object({
   /* ... */
-}).merge(TimestampSchema);
+}).extend(TimestampSchema.shape);
 ```
 
 ---
@@ -163,9 +162,7 @@ const result = schema.parse(data, {
 import { t } from 'i18next';
 
 z.config({
-  customError: (issue) => ({
-    message: t(`validation.${issue.code}`, issue),
-  }),
+  customError: (issue) => t(`validation.${issue.code}`, issue),
 });
 ```
 
@@ -176,8 +173,8 @@ z.config({
   "validation": {
     "too_small": "Minimum length: {{minimum}}",
     "too_big": "Maximum length: {{maximum}}",
-    "invalid_type": "Expected {{expected}}, got {{received}}",
-    "invalid_string": "Invalid {{validation}}"
+    "invalid_type": "Expected {{expected}}",
+    "invalid_format": "Invalid {{format}}"
   }
 }
 ```
@@ -314,6 +311,24 @@ z.string().transform((val) => val.trim());
 
 ## Performance Tips
 
+### 0. Know Zod 4's Performance Profile
+
+Zod 4 uses JIT compilation: initial schema creation is slightly slower, but repeated
+parsing is dramatically faster (roughly 7-14x over v3 in the official benchmarks),
+with far fewer TypeScript type instantiations (~100x reduction). Consequences:
+
+- **Create schemas once** (module level) and reuse them — the JIT pays off on the second and later parses.
+- **Never build schemas inside hot loops or request handlers** — you pay the creation cost every time and lose the JIT benefit.
+- **For extreme bundle budgets**, switch to `zod/mini` (~1.9kb gzipped vs ~5kb core) — a functional API where checks attach via `.check(z.minLength(3))`.
+
+```typescript
+// Zod Mini for bundle-sensitive targets
+import { z } from "zod/mini";
+const Name = z.string().check(z.minLength(1), z.maxLength(100));
+const User = z.object({ name: Name });
+z.safeParse(User, { name: "a" });
+```
+
 ### 1. Use `.discriminatedUnion()` instead of `.union()`
 
 **Impact**: 5-10x faster for large unions
@@ -333,7 +348,11 @@ z.discriminatedUnion("type", [...]);
 **Impact**: Reduces initial bundle size by 50-80%
 
 ```typescript
-const HeavySchema = z.lazy(() => import('./schemas/heavy'));
+// Dynamic import the schema module on demand
+async function validateHeavy(data: unknown) {
+  const { HeavySchema } = await import('./schemas/heavy');
+  return HeavySchema.safeParse(data);
+}
 ```
 
 ---
@@ -536,7 +555,7 @@ const TimestampSchema = z.object({
 const PostSchema = z.object({
   title: z.string(),
   content: z.string(),
-}).merge(TimestampSchema);
+}).extend(TimestampSchema.shape);
 
 // ✗ Repetitive, error-prone
 const PostSchema = z.object({

--- a/plugins/zod/skills/zod/references/type-inference.md
+++ b/plugins/zod/skills/zod/references/type-inference.md
@@ -2,7 +2,7 @@
 
 Complete guide for TypeScript type inference, JSON Schema generation, and metadata system in Zod.
 
-**Last Updated**: 2025-11-17
+**Last Updated**: 2026-08-20 (verified against zod@4.4.3)
 
 ---
 
@@ -99,7 +99,7 @@ Generate JSON Schema from Zod schemas for OpenAPI, AI structured outputs, or doc
 
 ```typescript
 const UserSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   email: z.email(),
   age: z.number().int().positive(),
   role: z.enum(["admin", "user"]),
@@ -126,12 +126,26 @@ const jsonSchema = z.toJSONSchema(UserSchema);
 
 ```typescript
 z.toJSONSchema(schema, {
-  target: "openapi-3.0",           // Target version
-  metadata: true,                  // Include .meta() data
+  target: "openapi-3.0",           // Target version (also draft-2020-12/draft-07/draft-04)
+  metadata: myRegistry,            // Metadata registry (defaults to globalRegistry)
   cycles: "ref",                   // Handle recursive schemas
-  reused: "defs",                  // Extract repeated schemas
+  reused: "inline",                // Extract repeated schemas ("ref" | "inline")
   io: "input",                     // Use input types instead of output
-  unrepresentable: "any",          // Handle unsupported types
+  unrepresentable: "any",          // Handle unsupported types ("throw" | "any")
+});
+// NOTE: .meta() data from the global registry is included by default — there is
+// no `metadata: true` boolean option.
+```
+
+### From JSON Schema (Experimental)
+
+Round-trip in the other direction (4.3+):
+
+```typescript
+const schema = z.fromJSONSchema({
+  type: "object",
+  properties: { name: { type: "string" } },
+  required: ["name"],
 });
 ```
 
@@ -323,10 +337,8 @@ const UserSchema = z.object({
   }),
 });
 
-// Include metadata in JSON Schema output
-const jsonSchema = z.toJSONSchema(UserSchema, {
-  metadata: true, // ← Includes .meta() data
-});
+// .meta() data from the global registry is included in JSON Schema by default
+const jsonSchema = z.toJSONSchema(UserSchema);
 
 /*
 {
@@ -405,7 +417,7 @@ const ConditionalSchema = z.object({
     }
     return z.string().regex(/^\+?[1-9]\d{1,14}$/).safeParse(data.value).success;
   },
-  { message: "Invalid format for selected type" }
+  { error: "Invalid format for selected type" }
 );
 
 type ConditionalData = z.infer<typeof ConditionalSchema>;

--- a/plugins/zustand-state-management/.claude-plugin/plugin.json
+++ b/plugins/zustand-state-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zustand-state-management",
   "description": "Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loops.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "author": {
     "name": "Claude Skills Maintainers",
     "email": "maintainers@example.com"

--- a/plugins/zustand-state-management/.codex-plugin/plugin.json
+++ b/plugins/zustand-state-management/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zustand-state-management",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Zustand state management for React with TypeScript. Use for global state, Redux/Context API migration, localStorage persistence, slices pattern, devtools, Next.js SSR, or encountering hydration errors, TypeScript inference issues, persist middleware problems, infinite render loops.",
   "author": {
     "name": "Claude Skills Maintainers",


### PR DESCRIPTION
## Summary

Complete overhaul of the `zod` plugin skill, driven by a verified API probe against **zod@4.4.3** (strict typecheck + 22 runtime tests; artifacts in `.audit/zod-probe/`), plus a structural comparison against [pproenca/dot-skills](https://github.com/pproenca/dot-skills/tree/master/skills/.curated/zod) whose rule format we adopted.

### Fidelity fixes (documented APIs that were wrong or v3-stale)
- Install block: `bun add zod` ×3 → bun/npm/pnpm/yarn
- `z.string().uuid()` → `z.uuid()` (11+ sites); Quick Reference no longer lists deprecated string methods as current
- v3 `.merge()` → `.extend(other.shape)` in every example
- v3 `z.function().args().returns()` → v4 `{ input, output }` factory (`.implement()`/`.implementAsync()`)
- `.deepPartial()` documented as **removed** (doesn't exist in 4.4.3; manual recursive-partial recipe added)
- Single-arg `z.record(v)` → two-arg `z.record(k, v)` (required in v4)
- `z.toJSONSchema(…, { metadata: true })` → registry param (the boolean was a type error; `.meta()` data is included by default)
- Migration guide: format methods are **deprecated, not removed**; rollback pin → 3.25.76; v4 error-code renames; corrected §5/§6 examples
- Error docs: v3 codes → v4 (`invalid_format`, `invalid_value`, `unrecognized_keys`); `issue.received` → `expected`/`input`; `superRefine` `ctx.addIssue` → `ctx.issues.push`
- Codec docs: dropped `decodeSafe`/`encodeSafe` (never existed); real surface is `.decode/.encode/.decodeAsync/.encodeAsync` (composed-object decode **verified working**)
- Bundle claim: "2kb gzipped" → ~5kb core / ~1.9kb `zod/mini`

### New coverage (missing from both skills)
`zod/mini` (incl. the `.check()` pattern — piping bare checks **crashes at runtime**), `.check()` + check factories, `z.preprocess`, `z.custom`, `z.templateLiteral`, `catchall`, `z.xor`, `z.file`, `z.json` (value-level JSON validation), `z.stringbool`, `z.exactOptional`, `.safeExtend`, `z.fromJSONSchema`, import-path guide (`zod`/`zod/v4`/`zod/mini`/`zod/v4/core`), expanded format validators (`z.guid`, `z.httpUrl`, `z.e164`, `z.hash`, `z.hostname`, `z.mac`, `z.uuidv4/v7`).

### New `references/best-practices.md`
12-rule Incorrect/Correct/**When-NOT-to-use** rulebook with impact ratings — format ported from dot-skills, every example rewritten against verified v4 APIs (boundary validation, safeParse discipline, JSON.parse, unknown-not-any, module-level schemas + JIT, object-strictness decision table, optional/nullable/default, single-parse, hot-path schema caching, array batching/streaming, `z.input` for forms).

### Verification
- `references/common-patterns.ts`: strict `tsc --noEmit` clean against zod@4.4.3 + runtime smoke suite (codec composition through `.extend`, error formatting, lazy recursion)
- `./scripts/validate-json-schemas.sh`: 144/144 pass

### Lockstep
3.7.0 → 3.8.0 across all 144 plugins (marketplace `metadata.version` → `sync-plugins.sh` → root `package.json`).