### PR TITLE
docs: add absolute plain-language communication rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent Instructions
+
+## ⚠️ CRITICAL: Communication Rule — THE MOST IMPORTANT RULE
+
+**🚨 ABSOLUTE RULE: Always talk to the user in clear, easy, short, plain language. NEVER use jargon. This rule overrides everything else. 🚨**
+
+- Use plain, simple words that a non-expert understands right away
+- Keep answers short and to the point
+- Never use jargon or technical buzzwords — if a technical term is truly needed, explain it in one simple phrase
+- Lead with the outcome: say what happened, then give detail only if it helps
+
+## Full Project Context
+
+All repository policies, structure, and workflows live in [CLAUDE.md](CLAUDE.md) — read it before making changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,18 @@
 
 ---
 
+## ⚠️ CRITICAL: Communication Rule — THE MOST IMPORTANT RULE
+
+**🚨 ABSOLUTE RULE: Always talk to the user in clear, easy, short, plain language. NEVER use jargon. This rule is more important than any other rule in this file. 🚨**
+
+When communicating with the user:
+- Use plain, simple words that a non-expert understands right away
+- Keep answers short and to the point
+- Never use jargon or technical buzzwords — if a technical term is truly needed, explain it in one simple phrase
+- Lead with the outcome: say what happened, then give detail only if it helps
+
+---
+
 ## ⚠️ CRITICAL: Repository Policy - NEVER TOUCH JEZWEB REPO
 
 **🚨 ABSOLUTE RULE: The `jezweb/claude-skills` repository must NEVER be modified under ANY circumstances! 🚨**


### PR DESCRIPTION
## What changed

- **CLAUDE.md**: added a new rule at the very top — always talk to the user in clear, easy, short, plain language, never jargon. Marked as the most important rule, placed above all others.
- **AGENTS.md**: created at repo root with the same rule (plus a one-line pointer to CLAUDE.md for full project context) so every coding agent reads it, not just Claude.

Docs-only change — no code, no workflows touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project guidance for clear, concise, plain-language communication.
  * Documented repository policies, structure, and workflow expectations.
  * Added instructions to explain technical terms simply and present outcomes before details.
  * Included guidance for reviewing project documentation before making changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->