### PR TITLE
fix(ci): harden GitHub Actions against 2025–2026 threat landscape

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,8 @@
 #
 # Syntax: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
+# Workflow edits require owner review (GhostAction-class injection control)
+/.github/workflows/ @secondsky
+
 # Default owner for the entire repository.
 * @secondsky

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       npm-minor:
@@ -14,6 +16,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       actions-minor:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,10 @@ permissions:
   actions: read
   security-events: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze
@@ -23,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,14 +8,21 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/validate-frontmatter.yml
+++ b/.github/workflows/validate-frontmatter.yml
@@ -9,16 +9,22 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate-frontmatter:
     name: Validate SKILL.md Frontmatter
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Make script executable
         run: chmod +x scripts/validate-frontmatter.sh
@@ -83,7 +89,9 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          echo "### Frontmatter Validation" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Validated \`SKILL.md\` files in \`plugins/\`" >> $GITHUB_STEP_SUMMARY
-          echo "Run \`./scripts/validate-frontmatter.sh\` locally to check before pushing." >> $GITHUB_STEP_SUMMARY
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ### Frontmatter Validation
+
+          Validated `SKILL.md` files in `plugins/`
+          Run `./scripts/validate-frontmatter.sh` locally to check before pushing.
+          EOF

--- a/.github/workflows/validate-json-schemas.yml
+++ b/.github/workflows/validate-json-schemas.yml
@@ -9,14 +9,21 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate-json-schemas:
     name: Validate JSON Schemas
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,73 @@
+# zizmor: static security analysis for GitHub Actions workflows.
+#
+# Why zizmor: it catches supply-chain patterns CodeQL does not — impostor
+# commits (a tag ref silently moved onto a malicious commit), typosquatted
+# actions, tag hijacking, and known-vulnerable action versions. This is the
+# tj-actions/changed-files class of attack (CVE-2025-30066), where a mutable
+# tag was retargeted to exfiltrate CI secrets. Failures here block the PR.
+#
+# Why the token: zizmor's online audits (tag/impostor-commit checks against
+# the GitHub API) silently degrade to offline mode when no token is available,
+# weakening exactly the checks this gate exists for. `github.token` is passed
+# explicitly to keep those audits genuinely enabled.
+#
+# Why the templates are scanned: the 12 workflows under
+# plugins/github-project-automation/skills/github-project-automation/templates/
+# are shipped to end users as content — they never run in this repo, but they
+# are the workflows this repo hands to others, so they are held to the same
+# audit as the live workflows.
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Monday 07:00 UTC — deliberately offset from CodeQL's 06:00 run
+    - cron: '0 7 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  zizmor-scan:
+    name: zizmor scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        # advanced-security: false — plain exit-code gate with no SARIF
+        # upload. The action's default (`true`) uploads results to the
+        # security tab, which needs permissions this workflow deliberately
+        # does not have. Blocking comes from the action's default behavior:
+        # it propagates zizmor's non-zero exit code on findings.
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          advanced-security: false
+          online-audits: true
+          token: ${{ github.token }}
+          inputs: >-
+            .github/workflows/
+            plugins/github-project-automation/skills/github-project-automation/templates/workflows/cd-production.yml
+            plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-basic.yml
+            plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-cloudflare-workers.yml
+            plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-matrix.yml
+            plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-node.yml
+            plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-python.yml
+            plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-react.yml
+            plugins/github-project-automation/skills/github-project-automation/templates/workflows/pr-checks.yml
+            plugins/github-project-automation/skills/github-project-automation/templates/workflows/release.yml
+            plugins/github-project-automation/skills/github-project-automation/templates/workflows/scheduled-maintenance.yml
+            plugins/github-project-automation/skills/github-project-automation/templates/workflows/security-codeql.yml
+            plugins/github-project-automation/skills/github-project-automation/templates/workflows/security-dependency-review.yml

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/cd-production.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/cd-production.yml
@@ -12,14 +12,25 @@ on:
     branches: [main, master]
   workflow_dispatch:  # Allow manual triggering
 
+# Least privilege: this workflow never needs write access to the repo.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
@@ -49,6 +60,7 @@ jobs:
     name: Deploy to Production
     needs: test
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     environment:
       name: production
       url: https://your-app.com
@@ -56,6 +68,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download build artifacts
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
@@ -79,8 +93,10 @@ jobs:
           # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Deployment summary
+        env:
+          COMMIT_SHA: ${{ github.sha }}
         run: |
           echo "✅ Deployment completed successfully!"
           echo "Environment: production"
-          echo "Commit: ${{ github.sha }}"
+          echo "Commit: $COMMIT_SHA"
           echo "URL: https://your-app.com"

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/cd-production.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/cd-production.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -39,7 +39,7 @@ jobs:
           NODE_ENV: production
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0
         with:
           name: production-build
           path: dist/
@@ -55,10 +55,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Download build artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
         with:
           name: production-build
           path: dist/

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-basic.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-basic.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -40,7 +40,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0
         with:
           name: build-output
           path: dist/

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-basic.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-basic.yml
@@ -13,13 +13,24 @@ on:
   pull_request:
     branches: [main, master]
 
+# Least privilege: CI only needs to read the repository.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-and-build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-cloudflare-workers.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-cloudflare-workers.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -51,10 +51,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-cloudflare-workers.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-cloudflare-workers.yml
@@ -13,14 +13,26 @@ on:
   pull_request:
     branches: [main, master]
 
+# Least privilege: deployment uses the CLOUDFLARE_API_TOKEN secret, not
+# repository write access.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
@@ -46,12 +58,15 @@ jobs:
   deploy:
     name: Deploy to Cloudflare
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     needs: test
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-matrix.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-matrix.yml
@@ -13,10 +13,19 @@ on:
   pull_request:
     branches: [main, master]
 
+# Least privilege: CI only needs to read the repository.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-matrix:
     name: Test on ${{ matrix.os }} with Node ${{ matrix.node-version }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false  # Continue testing all combinations
@@ -31,6 +40,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-matrix.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-matrix.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -52,6 +52,6 @@ jobs:
 
       - name: Upload coverage (Ubuntu only)
         if: matrix.os == 'ubuntu-24.04'
-        uses: codecov/codecov-action@5c47607acb93fed5485fdbf7232e8a31425f672a  # v5.0.2
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5.5.5
         with:
           flags: node-${{ matrix.node-version }}

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-node.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-node.yml
@@ -13,10 +13,19 @@ on:
   pull_request:
     branches: [main, master]
 
+# Least privilege: CI only needs to read the repository.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-matrix:
     name: Test on Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     strategy:
       matrix:
@@ -26,6 +35,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-node.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-node.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -43,7 +43,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@5c47607acb93fed5485fdbf7232e8a31425f672a  # v5.0.2
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5.5.5
         with:
           files: ./coverage/lcov.info
           flags: node-${{ matrix.node-version }}

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-python.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-python.yml
@@ -13,10 +13,19 @@ on:
   pull_request:
     branches: [main, master]
 
+# Least privilege: CI only needs to read the repository.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-matrix:
     name: Test on Python ${{ matrix.python-version }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     strategy:
       matrix:
@@ -26,6 +35,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-python.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-python.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -46,7 +46,7 @@ jobs:
         run: pytest --cov=. --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@5c47607acb93fed5485fdbf7232e8a31425f672a  # v5.0.2
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5.5.5
         with:
           files: ./coverage.xml
           flags: python-${{ matrix.python-version }}

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-react.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-react.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -58,7 +58,7 @@ jobs:
         run: npm test -- --coverage
 
       - name: Upload coverage
-        uses: codecov/codecov-action@5c47607acb93fed5485fdbf7232e8a31425f672a  # v5.0.2
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5.5.5
         with:
           files: ./coverage/lcov.info
 
@@ -68,10 +68,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -90,7 +90,7 @@ jobs:
           du -sh dist/
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0
         with:
           name: react-build
           path: dist/

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-react.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/ci-react.yml
@@ -13,14 +13,25 @@ on:
   pull_request:
     branches: [main, master]
 
+# Least privilege: CI only needs to read the repository.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   quality-checks:
     name: Type Check & Lint
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
@@ -40,10 +51,13 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
@@ -65,10 +79,13 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/pr-checks.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/pr-checks.yml
@@ -10,16 +10,27 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+# Least privilege: only the labels check talks to the API, and it only
+# needs read access; everything else just reads the repository.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pr-size:
     name: Check PR Size
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check PR size
         # Event-derived values are passed via env, never interpolated
@@ -53,12 +64,14 @@ jobs:
   commit-format:
     name: Check Commit Messages
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check commit messages
         # Event-derived values are passed via env, never interpolated
@@ -84,6 +97,7 @@ jobs:
   branch-naming:
     name: Check Branch Name
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
       - name: Check branch name
@@ -110,6 +124,11 @@ jobs:
   required-labels:
     name: Check Required Labels
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    # Read-only API access is enough to inspect PR labels.
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - name: Check for labels
@@ -135,10 +154,13 @@ jobs:
   conflict-check:
     name: Check for Merge Conflicts
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Check for conflicts
         # Event-derived values are passed via env, never interpolated

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/pr-checks.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/pr-checks.yml
@@ -22,14 +22,16 @@ jobs:
           fetch-depth: 0
 
       - name: Check PR size
+        # Event-derived values are passed via env, never interpolated
+        # directly into the script (prevents template injection).
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Get number of changed lines
-          BASE_SHA=${{ github.event.pull_request.base.sha }}
-          HEAD_SHA=${{ github.event.pull_request.head.sha }}
-
-          CHANGES=$(git diff --shortstat $BASE_SHA..$HEAD_SHA)
-          ADDED=$(echo $CHANGES | awk '{print $4}')
-          DELETED=$(echo $CHANGES | awk '{print $6}')
+          CHANGES=$(git diff --shortstat "$BASE_SHA..$HEAD_SHA")
+          ADDED=$(echo "$CHANGES" | awk '{print $4}')
+          DELETED=$(echo "$CHANGES" | awk '{print $6}')
           TOTAL=$((ADDED + DELETED))
 
           echo "Lines changed: $TOTAL"
@@ -37,11 +39,11 @@ jobs:
           echo "Deleted: $DELETED"
 
           # Warn if PR is large (>800 lines)
-          if [ $TOTAL -gt 800 ]; then
+          if [ "$TOTAL" -gt 800 ]; then
             echo "⚠️  Large PR detected ($TOTAL lines changed)"
             echo "Consider splitting into smaller PRs for easier review"
             exit 1
-          elif [ $TOTAL -gt 400 ]; then
+          elif [ "$TOTAL" -gt 400 ]; then
             echo "⚠️  Medium-sized PR ($TOTAL lines changed)"
             echo "This is acceptable but consider splitting if possible"
           else
@@ -59,13 +61,16 @@ jobs:
           fetch-depth: 0
 
       - name: Check commit messages
+        # Event-derived values are passed via env, never interpolated
+        # directly into the script (prevents template injection).
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Check if commits follow conventional commits format
-          BASE_SHA=${{ github.event.pull_request.base.sha }}
-          HEAD_SHA=${{ github.event.pull_request.head.sha }}
 
           echo "Checking commit messages..."
-          git log --format=%s $BASE_SHA..$HEAD_SHA | while read -r msg; do
+          git log --format=%s "$BASE_SHA..$HEAD_SHA" | while read -r msg; do
             if ! echo "$msg" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .+'; then
               echo "❌ Invalid commit message: $msg"
               echo "Must follow format: type(scope): description"
@@ -82,8 +87,13 @@ jobs:
 
     steps:
       - name: Check branch name
+        # SECURITY: github.head_ref is attacker-controlled on fork PRs.
+        # It is passed via env (never interpolated into the script) and
+        # always referenced quoted, so a branch name cannot inject shell
+        # commands into this workflow.
+        env:
+          BRANCH: ${{ github.head_ref }}
         run: |
-          BRANCH="${{ github.head_ref }}"
           echo "Branch name: $BRANCH"
 
           # Check if branch follows naming convention
@@ -103,9 +113,14 @@ jobs:
 
     steps:
       - name: Check for labels
+        # Event-derived values are passed via env, never interpolated
+        # directly into the script (prevents template injection).
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Get PR labels
-          LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | tr '\n' ',')
+          LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | tr '\n' ',')
           echo "PR labels: $LABELS"
 
           # Check if PR has at least one type label
@@ -116,8 +131,6 @@ jobs:
           else
             echo "✅ PR has required labels"
           fi
-        env:
-          GH_TOKEN: ${{ github.token }}
 
   conflict-check:
     name: Check for Merge Conflicts
@@ -128,8 +141,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Check for conflicts
+        # Event-derived values are passed via env, never interpolated
+        # directly into the script (prevents template injection).
+        env:
+          MERGEABLE: ${{ github.event.pull_request.mergeable }}
         run: |
-          if [ "${{ github.event.pull_request.mergeable }}" = "false" ]; then
+          if [ "$MERGEABLE" = "false" ]; then
             echo "❌ PR has merge conflicts"
             echo "Please resolve conflicts before merging"
             exit 1

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/pr-checks.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/pr-checks.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
 
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
 
@@ -138,7 +138,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Check for conflicts
         # Event-derived values are passed via env, never interpolated

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/release.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/release.yml
@@ -28,7 +28,10 @@ jobs:
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
         with:
           node-version: '20'
-          cache: 'npm'
+          # SECURITY: disable dependency caching in release/publish jobs —
+          # restored action caches are a cache-poisoning vector for a
+          # trusted publish path, so releases build from the registry.
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci
@@ -41,7 +44,7 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
       - name: Generate changelog
         id: changelog
@@ -51,32 +54,44 @@ jobs:
           if [ -z "$LAST_TAG" ]; then
             CHANGELOG=$(git log --pretty=format:"- %s (%h)" HEAD)
           else
-            CHANGELOG=$(git log --pretty=format:"- %s (%h)" $LAST_TAG..HEAD)
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" "$LAST_TAG..HEAD")
           fi
-          echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGELOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "CHANGELOG<<EOF"
+            echo "$CHANGELOG"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v2.0.8
-        with:
-          name: Release v${{ steps.version.outputs.VERSION }}
-          body: |
-            ## What's Changed
+        # SECURITY: uses the first-party `gh` CLI instead of a third-party
+        # release action, and receives every workflow expression via env —
+        # never interpolated directly into the script.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          CHANGELOG: ${{ steps.changelog.outputs.CHANGELOG }}
+          COMPARE_URL: ${{ github.server_url }}/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }}
+        run: |
+          {
+            echo "## What's Changed"
+            echo ""
+            echo "$CHANGELOG"
+            echo ""
+            echo "## Installation"
+            echo ""
+            echo '```bash'
+            echo "npm install your-package@${VERSION}"
+            echo '```'
+            echo ""
+            echo "**Full Changelog**: $COMPARE_URL"
+          } > release-notes.md
 
-            ${{ steps.changelog.outputs.CHANGELOG }}
-
-            ## Installation
-
-            ```bash
-            npm install your-package@${{ steps.version.outputs.VERSION }}
-            ```
-
-            **Full Changelog**: ${{ github.server_url }}/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }}
-          files: |
-            dist/**/*
-          draft: false
-          prerelease: false
+          shopt -s globstar nullglob
+          files=(dist/**/*)
+          gh release create "v${VERSION}" \
+            --title "Release v${VERSION}" \
+            --notes-file release-notes.md \
+            "${files[@]}"
 
   publish-npm:
     name: Publish to npm
@@ -92,6 +107,9 @@ jobs:
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
         with:
           node-version: '20'
+          # SECURITY: disable dependency caching in release/publish jobs
+          # (cache-poisoning hardening — see above).
+          package-manager-cache: false
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
@@ -101,7 +119,10 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish
+        # SECURITY NOTE: a long-lived NPM_TOKEN is the portable default for
+        # a public template. Prefer npm trusted publishing (OIDC, npm >= 11.5)
+        # in your own repo when your npm registry configuration supports it.
+        run: npm publish  # zizmor: ignore[use-trusted-publishing]
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/release.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0  # Fetch all history for changelog
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '20'
           # SECURITY: disable dependency caching in release/publish jobs —
@@ -101,10 +101,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '20'
           # SECURITY: disable dependency caching in release/publish jobs
@@ -135,10 +135,10 @@ jobs:
   #
   #   steps:
   #     - name: Checkout code
-  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+  #       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
   #
   #     - name: Setup Python
-  #       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+  #       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
   #       with:
   #         python-version: '3.12'
   #

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/release.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/release.yml
@@ -11,18 +11,34 @@ on:
     tags:
       - 'v*'  # Trigger on version tags (v1.0.0, v2.1.3, etc.)
 
+# Least privilege: read-only by default; the one job that publishes a
+# GitHub Release opts into contents: write explicitly below.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    # contents: write is required to create the GitHub Release itself;
+    # nothing else in this job needs elevated access.
     permissions:
-      contents: write  # Required to create releases
+      contents: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0  # Fetch all history for changelog
+          # This job never pushes git objects: the release is created through
+          # the API with GH_TOKEN, so persisted checkout credentials are not
+          # needed and are disabled as a hardening measure.
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
@@ -87,7 +103,17 @@ jobs:
           } > release-notes.md
 
           shopt -s globstar nullglob
-          files=(dist/**/*)
+          # gh release create only accepts regular files as assets; globstar
+          # otherwise expands to subdirectories too (e.g. dist/esm/) and the
+          # release step would hard-fail on them.
+          files=()
+          for f in dist/**/*; do
+            [ -f "$f" ] && files+=("$f")
+          done
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::No files found under dist/ to attach to the release"
+            exit 1
+          fi
           gh release create "v${VERSION}" \
             --title "Release v${VERSION}" \
             --notes-file release-notes.md \
@@ -97,11 +123,15 @@ jobs:
     name: Publish to npm
     needs: create-release
     runs-on: ubuntu-24.04
-    if: startsWith(github.ref, 'refs/tags/v')
+    timeout-minutes: 15
+    permissions:
+      contents: read  # npm publish authenticates with the NPM_TOKEN secret
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/scheduled-maintenance.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/scheduled-maintenance.yml
@@ -49,15 +49,15 @@ jobs:
         run: |
           echo "Cleaning caches older than 7 days..."
           gh cache list --limit 100 | while read -r line; do
-            CACHE_ID=$(echo $line | awk '{print $1}')
-            CACHE_AGE=$(echo $line | awk '{print $NF}')
+            CACHE_ID=$(echo "$line" | awk '{print $1}')
+            CACHE_AGE=$(echo "$line" | awk '{print $NF}')
 
             # Delete if older than 7 days
             if [[ "$CACHE_AGE" == *"days ago"* ]]; then
-              DAYS=$(echo $CACHE_AGE | awk '{print $1}')
-              if [ $DAYS -gt 7 ]; then
+              DAYS=$(echo "$CACHE_AGE" | awk '{print $1}')
+              if [ "$DAYS" -gt 7 ]; then
                 echo "Deleting cache $CACHE_ID (${DAYS} days old)"
-                gh cache delete $CACHE_ID || true
+                gh cache delete "$CACHE_ID" || true
               fi
             fi
           done

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/scheduled-maintenance.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/scheduled-maintenance.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '20'
 
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Clean old caches
         run: |

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/scheduled-maintenance.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/scheduled-maintenance.yml
@@ -12,14 +12,27 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:  # Allow manual triggering
 
+# Least privilege: read-only by default; only the cache-cleanup job opts
+# into actions: write, which the cache management API requires.
+permissions:
+  contents: read
+
+# Scheduled maintenance should never kill an in-progress maintenance run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   dependency-audit:
     name: Security Audit
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
@@ -40,10 +53,17 @@ jobs:
   cache-cleanup:
     name: Clean Old Caches
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    # actions: write is required by the cache management API (gh cache delete).
+    permissions:
+      contents: read
+      actions: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Clean old caches
         run: |
@@ -67,6 +87,7 @@ jobs:
   health-check:
     name: Health Check
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
       - name: Check production endpoint
@@ -86,7 +107,7 @@ jobs:
           DURATION=$((END - START))
           echo "Build took ${DURATION} seconds"
 
-          if [ $DURATION -gt 300 ]; then
+          if [ "$DURATION" -gt 300 ]; then
             echo "⚠️  Build is slow (>${DURATION}s)"
           fi
 
@@ -94,6 +115,7 @@ jobs:
     name: Generate Report
     needs: [dependency-audit, cache-cleanup, health-check]
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     if: always()
 
     steps:

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/security-codeql.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/security-codeql.yml
@@ -16,14 +16,22 @@ on:
     # Run weekly on Sundays at 00:00 UTC
     - cron: '0 0 * * 0'
 
+# Least privilege: read access for source checkout plus write access only
+# for uploading SARIF results to the security tab.
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze Code
     runs-on: ubuntu-24.04
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -34,6 +42,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/security-codeql.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/security-codeql.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ea9e4e37992a54ee68a9622e985e60c8e8f12d9f  # v3.27.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         with:
           languages: ${{ matrix.language }}
           # Optionally specify additional queries
@@ -50,12 +50,12 @@ jobs:
       #     dotnet build          # For C#
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ea9e4e37992a54ee68a9622e985e60c8e8f12d9f  # v3.27.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         with:
           category: "/language:${{ matrix.language }}"
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@ea9e4e37992a54ee68a9622e985e60c8e8f12d9f  # v3.27.4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         if: always()
         with:
           sarif_file: ../results

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/security-dependency-review.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/security-dependency-review.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c  # v4.3.4
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
         with:
           # Fail on: critical, high
           # Warn on: medium, low

--- a/plugins/github-project-automation/skills/github-project-automation/templates/workflows/security-dependency-review.yml
+++ b/plugins/github-project-automation/skills/github-project-automation/templates/workflows/security-dependency-review.yml
@@ -11,18 +11,27 @@ on:
   pull_request:
     branches: [main, master]
 
+# pull-requests: write is required only to post the review summary comment
+# (comment-summary-in-pr); the review itself needs read access alone.
 permissions:
   contents: read
   pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   dependency-review:
     name: Review Dependencies
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0


### PR DESCRIPTION
## Why: the 2025–2026 GitHub Actions threat landscape

Research pass over 2025 incidents + the Jan–Aug 2026 state of play (full notes in `.audit/gha-security-2025-2026/`, local). The dominant attack classes and what this PR does about each:

| Threat (year) | What happened | Defense in this PR |
|---|---|---|
| tj-actions/changed-files — CVE-2025-30066 + reviewdog — CVE-2025-30154 (2025-03) | All version tags retro-rewritten to one malicious commit; runner memory dumped to logs; ~23k repos | SHA pinning everywhere (already done) **kept fresh** via Dependabot + new zizmor gate |
| s1ngularity / Nx (2025-08) | `pull_request_target` + PR-title injection on a repo whose **default token was read/write** | Repo default GITHUB_TOKEN flipped to **read-only, no PR approval** (see below); zero `pull_request_target` in this repo and templates |
| GhostAction (2025-09) | Malicious workflows injected into 817 repos; 3,325 secrets stolen | Least-privilege explicit `permissions:` on every workflow incl. all shipped templates; CODEOWNERS guard for `.github/workflows/` |
| Shai-Hulud v1/v2 (2025-09/11) | npm worm; freshly-published versions weaponized; Actions secrets exfiltrated | Dependabot **cooldown (7 days)** on npm + github-actions ecosystems |
| TeamPCP wave: Trivy, Checkmarx — CVE-2026-33634, actions-cool (2026-03/05) | Impostor commits: every tag moved to attacker commit; runner-process memory scraping defeats log masking | Blocking **zizmor CI gate** (impostor-commit/typosquat/archived audits, online mode); documented follow-up for egress filtering |
| Known-vulnerable pin: codeql-action v3.27.4 — GHSA-vqf5-2xx6-9wfm | PAT written to debug artifacts | Replaced with v4.37.6 pin in 3 shipped templates |

## Baseline → result (measured, red → green)

| Scan (zizmor 1.29.0 / actionlint 1.7.12) | Baseline | After |
|---|---|---|
| Live `.github/workflows/` (zizmor) | 4 low (`artipacked`) | **exit 0** |
| Live workflows (actionlint) | 5 nits (SC2086/SC2129) | **exit 0** |
| Shipped templates, 12 files (zizmor) | **6 high / 47 medium / 2 informational** | **exit 0** (1 documented `zizmor: ignore`) |
| Shipped templates (actionlint) | 14 findings incl. real `github.head_ref` injection (`pr-checks.yml:85`) | **exit 0** |
| `.github/dependabot.yml` (zizmor) | 2 medium (`dependabot-cooldown`) | **exit 0** |
| Repo default GITHUB_TOKEN | **`write` + could approve PR reviews** (the s1ngularity root cause) | **`read` + approval disabled** — ⚠️ applied via API alongside this PR, not in the diff |

## What changed (19 files, 6 commits)

1. **`bf35de33` — live workflows**: `persist-credentials: false` on all checkouts, `timeout-minutes: 15` (CodeQL keeps 30), concurrency groups (`cancel-in-progress` on PRs only), shellcheck-clean step summary.
2. **`76efd9ee` — new zizmor gate** (`.github/workflows/zizmor.yml`): `zizmorcore/zizmor-action@3dc1ecc9… # v0.6.2`, `permissions: contents: read` only (`advanced-security: false` skips the SARIF upload path), online audits enabled via token input, blocking exit-code gate, scans live workflows **and** the 12 shipped templates, weekly Monday 07:00 UTC.
3. **`4bc2ebd0` — Dependabot cooldown** (`default-days: 7`, both ecosystems) + explicit `/​.github/workflows/ @secondsky` CODEOWNERS guard.
4. **`4f63c7d6`, `8db01186`, `a45521b6` — 12 shipped templates** (`plugins/github-project-automation/.../templates/workflows/`): all `uses:` SHA-pinned with version comments; vulnerable codeql-action v3.27.4 → v4.37.6; `github.head_ref` injection → env-var indirection; explicit least-privilege `permissions:` per template; timeouts; concurrency; `persist-credentials: false` (no template git-pushes — release uses `gh release create` over the API); `pull_request_target` eliminated; one documented `zizmor: ignore[use-trusted-publishing]` on `npm publish` (trusted publishing would break non-OIDC registries for template users).

## Verified

- 9 distinct action pins independently verified tag↔SHA against upstream (`git ls-remote` + GitHub API).
- zizmor (online + offline) and actionlint: exit 0 over all 17 workflow YAMLs; `validate-frontmatter.sh` 185/185; `npm ci` + `validate-json-schemas.sh` pass.
- Final whole-branch adversarial review (independent subagent): **ready to merge**, no Critical/Important findings.

## Follow-ups (not blocking)

- [x] ~~Add `zizmor-scan` to ruleset 11240677's required checks~~ — **done via API**: `zizmor scan` is now a required status check on main (verified active; CodeRabbit Major finding resolved).
- [x] ~~Verify repo Settings → Actions → Workflow permissions read-only~~ — **done via API**: default GITHUB_TOKEN now `read`, PR approval disabled.
- [ ] Template polish (pre-existing, non-security): align setup-node pin with live workflows (templates on v5.0.0, live on v7.0.0 — both valid); drop the redundant manual `upload-sarif` step in `security-codeql.yml` (v4 `analyze` auto-uploads); remove or redesign the `conflict-check` job in `pr-checks.yml` (GitHub never triggers `pull_request` workflows on conflicted PRs, so it can't do its job — CodeRabbit Minor).
- [ ] Consider egress monitoring (StepSecurity Harden-Runner, or GitHub's native egress firewall when GA) as the backstop against runner-memory secret scraping.

No lockstep version bump (CI + shipped template content only; same precedent as the CodeQL remediation PRs).
