### PR TITLE
docs: backfill CHANGELOG 3.7.0/3.8.0; refresh README to 145 skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CLAUDE.md + AGENTS.md (PR #90)** — added an absolute plain-language communication rule: agents must always answer in clear, simple, jargon-free language, and it overrides everything else.
+
+- **GitHub Actions hardening (PR #91)** — workflows hardened against the 2025–2026 threat landscape; the default workflow token is read-only and zizmor linting is enforced via the main-branch ruleset.
+
 - **Version bump 3.8.0 → 3.9.0** — all 145 plugins, both marketplaces, and `package.json`.
+
+## [3.8.0] - 2026-08-20
+
+### Changed
+
+- **`zod` skill v2.1.0 — fidelity audit against zod@4.4.3 (PR #89).** All documented APIs verified by typecheck plus 22 runtime tests against the real package (probe artifacts kept in `.audit/zod-probe`). Fidelity fixes: real install block (bun/npm/pnpm/yarn — was `bun add zod` ×3), `z.string().uuid()` → `z.uuid()` (11+ sites), v3 `.merge()` → `.extend(other.shape)`, v4 `{input, output}` function factory, `.deepPartial()` documented as removed, two-arg `z.record`, `toJSONSchema` registry parameter, corrected error-code renames and migration-guide claims, corrected bundle-size claim. New coverage: zod/mini (including the `.check()` pattern), check factories, `z.preprocess`/`z.custom`/`z.templateLiteral`, catchall, `z.xor`, `z.file`, `z.json`, `z.stringbool`, `z.exactOptional`, `.safeExtend`, `z.fromJSONSchema`, import-path guide, and the new format validators. New `references/best-practices.md`: 12-rule Incorrect/Correct/When-NOT-to-use rulebook with impact ratings.
+
+- **Version bump 3.7.0 → 3.8.0** — all 144 plugins, both marketplaces, and `package.json`.
+
+## [3.7.0] - 2026-08-06
+
+### Added
+
+- **`tech-debt` plugin (plugin #143, PR #84).** Two-mode routed skill: prevent tech debt while reworking a change, or triage the existing refactor backlog (categorize, score, prioritize). Bundles the jnsahaj/zero-tech-debt and anthropics/tech-debt stances.
+
+- **`unknowns-discovery` plugin (plugin #144, PR #84).** Ported from the suedzucker-codex-plugins Codex plugin into the Claude Code plugin format. Frontmatter description trimmed 341 → 150 chars for the sync 250-char limit; its 3 slash commands namespaced `unknowns-discovery:<cmd>`; 7 references, 12 templates, 4 examples, and 2 scripts copied verbatim; Codex-only files dropped. Also synced a pre-existing `package.json` version drift (the bump scripts don't touch it).
+
+### Fixed
+
+- **Adversarial script audit — 15 + 4 bugs across the marketplace scripts (PRs #85, #86).** Critical: `review-skill.sh`'s `((VAR++))` aborted the whole report under `set -e` on the first finding, and GNU-only `date -d` flagged every skill as ~20,500 days stale on macOS. Also fixed: validators aborting on the first failing skill, a false `Total: 1` count, version-drift masking (the generator read only the alphabetically-first plugin), GNU-only `head -n -1`, JSON built by heredoc interpolation (now `jq -nc --arg` per entry), non-idempotent frontmatter re-folding, `set -o pipefail` aborting `find | wc` on missing directories, publishing an empty marketplace, and YAML quote/comment stripping order.
+
+### Changed
+
+- **Version bump 3.6.3 → 3.7.0** — all 144 plugins, both marketplaces, and `package.json`.
 
 ## [3.6.3] - 2026-08-06
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A curated collection of battle-tested skills for building modern web application
 /plugin install gemini-cli@claude-skills
 ```
 
-See [MARKETPLACE.md](MARKETPLACE.md) for complete catalog of all 145 skills.
+The authoritative catalog is [.claude-plugin/marketplace.json](.claude-plugin/marketplace.json), summarized in the category table below. ([MARKETPLACE.md](MARKETPLACE.md) is outdated — it still describes the retired suite-based layout and is pending a rewrite.)
 
 ### Codex CLI Installation
 
@@ -112,7 +112,7 @@ This repository contains **145 production-tested skills** for Claude Code, each 
 
 Each skill is individually installable. Install only the skills you need.
 
-**Full Catalog**: See [MARKETPLACE.md](MARKETPLACE.md) for detailed listings.
+**Full Catalog**: The authoritative list is [.claude-plugin/marketplace.json](.claude-plugin/marketplace.json). [MARKETPLACE.md](MARKETPLACE.md) is outdated (retired suite-based layout, pending rewrite).
 
 ### Categories
 
@@ -324,7 +324,7 @@ See [CONTRIBUTING.md](docs/guides/CONTRIBUTING.md) and [PLUGIN_DEV_BEST_PRACTICE
 |----------|---------|
 | [START_HERE.md](docs/getting-started/START_HERE.md) | **Start here!** Quick navigation guide |
 | [PLUGIN_DEV_BEST_PRACTICES.md](docs/guides/PLUGIN_DEV_BEST_PRACTICES.md) | **Repository-specific best practices** (marketplace, budget, quality) |
-| [MARKETPLACE.md](MARKETPLACE.md) | Full skill catalog and installation guide |
+| [MARKETPLACE.md](MARKETPLACE.md) | Legacy catalog — **outdated** (retired suite-based layout, pending rewrite; use `marketplace.json` or the README category table) |
 | [MARKETPLACE_MANAGEMENT.md](docs/guides/MARKETPLACE_MANAGEMENT.md) | Technical infrastructure (plugin.json, scripts, validation) |
 | [CLAUDE.md](CLAUDE.md) | Project context and development standards |
 | [CONTRIBUTING.md](docs/guides/CONTRIBUTING.md) | Contribution guidelines |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Claude Code Skills Collection
 
-**142 production-ready skills for Claude Code CLI**
+**145 production-ready skills for Claude Code CLI**
 
-Version 3.6.3 | Last Updated: 2026-08-06
+Version 3.9.0 | Last Updated: 2026-09-09
 
 <div align="center">
 
@@ -41,11 +41,11 @@ A curated collection of battle-tested skills for building modern web application
 /plugin install gemini-cli@claude-skills
 ```
 
-See [MARKETPLACE.md](MARKETPLACE.md) for complete catalog of all 142 skills.
+See [MARKETPLACE.md](MARKETPLACE.md) for complete catalog of all 145 skills.
 
 ### Codex CLI Installation
 
-This repo generates `.codex-plugin/` manifests and a `.agents/plugins/marketplace.json` for all 142 plugins, so Codex CLI can install them natively:
+This repo generates `.codex-plugin/` manifests and a `.agents/plugins/marketplace.json` for all 145 plugins, so Codex CLI can install them natively:
 
 ```bash
 # Add the marketplace (from GitHub)
@@ -94,7 +94,7 @@ skills.sh runs every published skill through three scanners (Gen Agent Trust Hub
 
 ## Repository Structure
 
-This repository contains **142 production-tested skills** for Claude Code, each focused on a specific technology or capability.
+This repository contains **145 production-tested skills** for Claude Code, each focused on a specific technology or capability.
 
 **Individual Skills**: Each skill is a standalone unit with:
 - `SKILL.md` - Core knowledge and guidance
@@ -108,7 +108,7 @@ This repository contains **142 production-tested skills** for Claude Code, each 
 
 ---
 
-## Available Skills (142 Individual Skills)
+## Available Skills (145 Individual Skills)
 
 Each skill is individually installable. Install only the skills you need.
 
@@ -118,7 +118,7 @@ Each skill is individually installable. Install only the skills you need.
 
 | Category | Skills | Examples |
 |----------|--------|----------|
-| **tooling** | 24 | turborepo, plan-interview, code-review |
+| **tooling** | 27 | turborepo, plan-interview, code-review, tech-debt, humanize-writing |
 | **frontend** | 26 | nuxt-v4, nuxt-v5, tailwind-v4-shadcn, tanstack-query, nuxt-studio, maz-ui, threejs |
 | **cloudflare** | 21 | cloudflare-d1, cloudflare-workers-ai, cloudflare-agents |
 | **api** | 16 | api-design-principles, graphql-implementation |
@@ -182,6 +182,20 @@ plugins/[plugin-name]/
 
 ## Recent Additions
 
+### September 2026
+
+**Writing Quality**:
+- **humanize-writing** — Rewrites AI-sounding text so it reads like a knowledgeable human wrote it. Eight editing passes (formulaic structure, significance inflation, AI vocabulary, grammar-level tells, robotic rhythm, hedging, overused transitions, missing personality) plus a review-only mode that flags passages and names the pattern. Based on Wikipedia's "Signs of AI writing" guide; adapted from [jpeggdev/humanize-writing](https://github.com/jpeggdev/humanize-writing)
+
+### August 2026
+
+**Plugin Additions**:
+- **tech-debt** — Two-mode routed skill: prevent tech debt while reworking a change, or triage the existing backlog (categorize, score, prioritize). Bundles jnsahaj/zero-tech-debt and anthropics/tech-debt stances
+- **unknowns-discovery** — Ported from the suedzucker-codex-plugins Codex plugin: surfaces unknowns, risks, and open questions in a plan or codebase
+
+**Skill Overhauls**:
+- **zod v2.1.0** — Fidelity audit against zod@4.4.3: every documented API verified by typecheck + runtime tests. Fixed stale v3 patterns across 11+ sites, corrected the migration guide, added zod/mini and the full v4 surface (`.check()`, `z.xor`, `z.file`, `z.json`, new format validators), and added a 12-rule best-practices rulebook
+
 ### July 2026
 
 **Offensive Security** (new category):
@@ -233,7 +247,7 @@ plugins/[plugin-name]/
 Claude Code has a **15,000 character limit** for the total size of skill descriptions in the system prompt. This limit also applies to commands and agents.
 
 **What this means:**
-- Not all 142 skills may be visible in Claude's context at once
+- Not all 145 skills may be visible in Claude's context at once
 - Skills are loaded based on relevance and available token budget
 - You can verify how many skills Claude currently sees by asking: *"How many skills do you see in your system prompt?"*
 
@@ -246,7 +260,7 @@ To verify which skills are currently loaded:
 "Check what skills/plugins you see in your system prompt"
 ```
 
-Claude will report something like: "85 of 142 skills visible due to token limits"
+Claude will report something like: "85 of 145 skills visible due to token limits"
 
 ### Workaround: Increase Token Budget
 
@@ -274,7 +288,7 @@ This gives you approximately **2x more skill visibility** in the system prompt.
 | **Typical Errors** | 2-4 per service | 0 (prevented) | **100%** |
 | **Setup Time** | 2-4 hours | 15-45 minutes | **~80%** |
 
-**Across all 142 skills**: 400+ documented errors prevented.
+**Across all 145 skills**: 400+ documented errors prevented.
 
 ---
 


### PR DESCRIPTION
## What

Docs-only follow-up to #94 (no version bump — still 3.9.0):

**CHANGELOG**
- Backfills the missing **[3.7.0]** entry: `tech-debt` + `unknowns-discovery` plugins (PR #84) and the adversarial script audit with 15 + 4 fixes (PRs #85, #86)
- Backfills the missing **[3.8.0]** entry: `zod` skill v2.1.0 fidelity audit vs zod@4.4.3 (PR #89)
- Folds PRs #90 (plain-language communication rule) and #91 (GHA hardening) into the existing **[3.9.0]** entry, since they landed between 3.8.0 and 3.9.0 and shipped with it

**README**
- All skill counts 142 → **145** (9 places), header version 3.6.3 → **3.9.0**
- Category table: `tooling` 24 → **27**, examples now include `tech-debt` and `humanize-writing`
- New **Recent Additions** entries for September 2026 (humanize-writing) and August 2026 (tech-debt, unknowns-discovery, zod v2.1.0)

Entries were reconstructed from the actual merge commits (`2b93f5ac`, `fb6e3f1c`, `b9627cae`, `ad16332a`); dates are the merge dates.

**Known issue (out of scope):** MARKETPLACE.md is heavily stale — it still documents the retired 18-suite-plugin architecture ("168 skills", v2.0.0 December 2025). It needs a regeneration/rewrite decision separate from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `tech-debt` and `humanize-writing` skills, bringing the marketplace total to 145 skills.
  - Added expanded tooling coverage and September 2026 additions to the marketplace documentation.

- **Security**
  - GitHub Actions workflows now use read-only default permissions and undergo automated security linting.

- **Documentation**
  - Updated README version, skill counts, catalog links, and token-efficiency information.
  - Expanded changelog details for recent skill audits and marketplace script fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->